### PR TITLE
feat(apply): implement recruitment list tab based on the recruitment status

### DIFF
--- a/frontend/src/components/RecruitItem.vue
+++ b/frontend/src/components/RecruitItem.vue
@@ -13,8 +13,8 @@
         <Button
           class="enroll-button button"
           @click="onClickAdmission(recruitment.id)"
-          :disabled="!this.isRecruiting()"
-          :value="buttonLabel()"
+          :disabled="!this.isRecruiting"
+          :value="buttonLabel"
         >
         </Button>
       </div>
@@ -34,7 +34,7 @@ export default {
       required: true,
     },
   },
-  methods: {
+  computed: {
     isRecruiting() {
       return this.recruitment.recruitmentStatus === "RECRUITING"
     },
@@ -57,6 +57,8 @@ export default {
         }
       }
     },
+  },
+  methods: {
     onClickAdmission(id) {
       this.$router.push({
         path: `/application/${id}`,
@@ -138,5 +140,4 @@ export default {
 .button-wrapper {
   margin-right: 12px;
 }
-
 </style>

--- a/frontend/src/components/RecruitItem.vue
+++ b/frontend/src/components/RecruitItem.vue
@@ -10,20 +10,24 @@
         </div>
       </div>
       <div class="button-wrapper">
-        <button
+        <Button
           class="enroll-button button"
           @click="onClickAdmission(recruitment.id)"
           :disabled="!this.isRecruiting()"
+          :value="buttonLabel()"
         >
-          {{ buttonLabel() }}
-        </button>
+        </Button>
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import Button from "@/components/form/Button"
 export default {
+  components: {
+    Button,
+  },
   props: {
     recruitment: {
       type: Object,
@@ -135,21 +139,4 @@ export default {
   margin-right: 12px;
 }
 
-.button {
-  cursor: pointer;
-  outline: none;
-  border: 0;
-  background: #0078ff;
-  color: #fff;
-  border-radius: 3px;
-  padding: 10px;
-  min-width: 80px;
-  min-height: 28px;
-  margin: 5px;
-}
-
-.button:disabled {
-  cursor: default;
-  background: #ccc;
-}
 </style>

--- a/frontend/src/components/RecruitItem.vue
+++ b/frontend/src/components/RecruitItem.vue
@@ -13,11 +13,8 @@
         <button
           class="enroll-button button"
           @click="onClickAdmission(recruitment.id)"
-          v-if="this.isRecruiting()"
+          :disabled="!this.isRecruiting()"
         >
-          {{ buttonLabel() }}
-        </button>
-        <button class="enroll-button button" disabled v-if="!this.isRecruiting()">
           {{ buttonLabel() }}
         </button>
       </div>

--- a/frontend/src/components/RecruitItem.vue
+++ b/frontend/src/components/RecruitItem.vue
@@ -10,8 +10,18 @@
         </div>
       </div>
       <div class="button-wrapper">
-        <button class="enroll-button" @click="onClickAdmission(recruitment.id)">
-          지원하기
+        <button
+          class="enroll-button button-recruiting"
+          @click="onClickAdmission(recruitment.id)"
+          v-if="this.isRecruiting()"
+        >
+          {{ buttonLabel() }}
+        </button>
+        <button
+            class="enroll-button button-disabled"
+            v-if="!this.isRecruiting()"
+        >
+          {{ buttonLabel() }}
         </button>
       </div>
     </div>
@@ -27,6 +37,28 @@ export default {
     },
   },
   methods: {
+    isRecruiting() {
+      return this.recruitment.recruitmentStatus === "RECRUITING"
+    },
+    buttonLabel() {
+      switch (this.recruitment.recruitmentStatus) {
+        case "RECRUITING": {
+          return "지원하기"
+        }
+        case "RECRUITABLE": {
+          return "모집 예정"
+        }
+        case "UNRECRUITABLE": {
+          return "일시 중지"
+        }
+        case "ENDED": {
+          return "모집 종료"
+        }
+        default: {
+          throw "올바르지 않은 지원 타입입니다"
+        }
+      }
+    },
     onClickAdmission(id) {
       this.$router.push({
         path: `/application/${id}`,
@@ -102,6 +134,21 @@ export default {
   height: 40px;
   margin: 10px;
   vertical-align: middle;
+}
+
+.button-disabled {
+  background-color: #eeeeee;
+}
+
+.button-disabled:active {
+  background-color: #eeeeee !important;
+}
+
+.button-recruiting {
   background-color: #3498db;
+}
+
+.button-recruiting:active {
+  background-color: #0078ff !important;
 }
 </style>

--- a/frontend/src/components/RecruitItem.vue
+++ b/frontend/src/components/RecruitItem.vue
@@ -11,16 +11,13 @@
       </div>
       <div class="button-wrapper">
         <button
-          class="enroll-button button-recruiting"
+          class="enroll-button button"
           @click="onClickAdmission(recruitment.id)"
           v-if="this.isRecruiting()"
         >
           {{ buttonLabel() }}
         </button>
-        <button
-            class="enroll-button button-disabled"
-            v-if="!this.isRecruiting()"
-        >
+        <button class="enroll-button button" disabled v-if="!this.isRecruiting()">
           {{ buttonLabel() }}
         </button>
       </div>
@@ -98,10 +95,11 @@ export default {
 .card {
   width: 100%;
   height: 70px;
-  background-color: #dcdcdc;
-  border-radius: 5px;
+  background-color: #ffffff;
+  border-radius: 3px;
   display: inline-block;
   margin: 5px 0 5px 0;
+  box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);
 }
 
 .recruit-title {
@@ -136,19 +134,25 @@ export default {
   vertical-align: middle;
 }
 
-.button-disabled {
-  background-color: #eeeeee;
+.button-wrapper {
+  margin-right: 12px;
 }
 
-.button-disabled:active {
-  background-color: #eeeeee !important;
+.button {
+  cursor: pointer;
+  outline: none;
+  border: 0;
+  background: #0078ff;
+  color: #fff;
+  border-radius: 3px;
+  padding: 10px;
+  min-width: 80px;
+  min-height: 28px;
+  margin: 5px;
 }
 
-.button-recruiting {
-  background-color: #3498db;
-}
-
-.button-recruiting:active {
-  background-color: #0078ff !important;
+.button:disabled {
+  cursor: default;
+  background: #ccc;
 }
 </style>

--- a/frontend/src/views/Recruits.vue
+++ b/frontend/src/views/Recruits.vue
@@ -1,21 +1,23 @@
 <template>
-  <div id="wrapper">
-    <div id="tab-wrapper">
-      <h2
-        v-for="tab in tabList"
-        :key="tab.name"
-        class="list-tab filter"
-        :class="{ active: tab.name === $route.query.status }"
-        :id="tab.name"
-        @click="setFilter(tab.name)"
-      >
-        {{ tab.label }}
-      </h2>
-      <h2 class="list-tab" id="mypage">내 지원서</h2>
-    </div>
-    <div id="component">
-      <div v-for="recruitment in activeList" :key="recruitment.id">
-        <recruit-item :recruitment="recruitment" />
+  <div id="recruits">
+    <div id="recruits-box">
+      <div id="tab-wrapper">
+        <h2
+          v-for="tab in tabList"
+          :key="tab.name"
+          class="list-tab filter"
+          :class="{ active: tab.name === $route.query.status }"
+          :id="tab.name"
+          @click="setFilter(tab.name)"
+        >
+          {{ tab.label }}
+        </h2>
+        <h2 class="list-tab" id="mypage">내 지원서</h2>
+      </div>
+      <div id="component">
+        <div v-for="recruitment in activeList" :key="recruitment.id">
+          <recruit-item :recruitment="recruitment" />
+        </div>
       </div>
     </div>
   </div>
@@ -141,10 +143,29 @@ export default {
 
 <style scoped>
 @media (min-width: 800px) {
-  #wrapper {
+  #recruits-box {
     width: 800px;
     margin: 0 auto;
   }
+}
+
+#recruits {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #ced6e0;
+  height: 100%;
+}
+
+#recruits-box {
+  align-items: center;
+  width: 100%;
+  max-width: 800px;
+  padding: 20px;
+  margin: 15px;
+  border-radius: 3px;
+  background: #f1f2f6;
+  box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);
 }
 
 #tab-wrapper {

--- a/frontend/src/views/Recruits.vue
+++ b/frontend/src/views/Recruits.vue
@@ -8,7 +8,7 @@
           class="list-tab filter"
           :class="{ active: tab.name === $route.query.status }"
           :id="tab.name"
-          @click="setFilter(tab.name)"
+          @click="setStatus(tab.name)"
         >
           {{ tab.label }}
         </h2>
@@ -102,17 +102,19 @@ export default {
     this.setList(this.$route.query.status)
   },
   methods: {
-    setFilter(filter) {
-      this.$router.replace({
-        path: "/recruits/?status=" + filter,
-      })
-      this.setList(filter)
+    setStatus(status) {
+      if (status !== this.$route.query.status) {
+        this.$router.replace({
+          path: "/recruits/?status=" + status,
+        })
+        this.setList(status)
+      }
     },
     async setList(filter) {
       try {
         this.activeList = await this.getRecruits(filter)
       } catch (e) {
-        await this.setFilter("all")
+        await this.setStatus("all")
       }
     },
     // TODO: 이 부분을 실제 API 콜로 대체하기

--- a/frontend/src/views/Recruits.vue
+++ b/frontend/src/views/Recruits.vue
@@ -153,7 +153,7 @@ export default {
 
 #recruits-box {
   align-items: center;
-  width: 100%;
+  width: 800px;
   max-width: 800px;
   padding: 20px;
   margin: 15px;
@@ -162,9 +162,9 @@ export default {
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);
 }
 
-@media (min-width: 800px) {
+@media (max-width: 800px) {
   #recruits-box {
-    width: 800px;
+    width: 100%;
     margin: 0 auto;
   }
 }

--- a/frontend/src/views/Recruits.vue
+++ b/frontend/src/views/Recruits.vue
@@ -34,11 +34,19 @@ export default {
           label: "전체",
         },
         {
+          name: "recruitable",
+          label: "모집 예정",
+        },
+        {
           name: "recruiting",
           label: "모집 중",
         },
         {
-          name: "completed",
+          name: "unrecruitable",
+          label: "일시 중지",
+        },
+        {
+          name: "ended",
           label: "모집 종료",
         },
       ],
@@ -49,19 +57,19 @@ export default {
           title: "웹 백엔드 3기",
           startTime: new Date("2020-10-24T15:00:00"),
           endTime: new Date("2020-11-09T23:59:00"),
-          recruitmentStatus: "RECRUITABLE",
+          recruitmentStatus: "RECRUITING",
         },
         {
           id: 5,
           title: "웹 프론트엔드 3기",
           startTime: new Date("2020-10-24T15:00:00"),
           endTime: new Date("2020-11-09T23:59:00"),
-          recruitmentStatus: "RECRUITABLE",
+          recruitmentStatus: "RECRUITING",
         },
         {
           id: 4,
           title: "모바일(iOS) 3기",
-          startTime: new Date("2020-10-24T15:00:00"),
+          startTime: new Date("2020-10-27T15:00:00"),
           endTime: new Date("2020-11-09T23:59:00"),
           recruitmentStatus: "RECRUITABLE",
         },
@@ -70,7 +78,7 @@ export default {
           title: "모바일(Android) 3기",
           startTime: new Date("2020-10-24T15:00:00"),
           endTime: new Date("2020-11-09T23:59:00"),
-          recruitmentStatus: "RECRUITABLE",
+          recruitmentStatus: "UNRECRUITABLE",
         },
         {
           id: 2,
@@ -112,10 +120,16 @@ export default {
     // TODO: 이 부분을 실제 API 콜로 대체하기
     getRecruits(filter) {
       switch (filter) {
-        case "recruiting": {
+        case "recruitable": {
           return this.allList.filter(el => el.recruitmentStatus === "RECRUITABLE")
         }
-        case "completed": {
+        case "recruiting": {
+          return this.allList.filter(el => el.recruitmentStatus === "RECRUITING")
+        }
+        case "unrecruitable": {
+          return this.allList.filter(el => el.recruitmentStatus === "UNRECRUITABLE")
+        }
+        case "ended": {
           return this.allList.filter(el => el.recruitmentStatus === "ENDED")
         }
         case "all": {

--- a/frontend/src/views/Recruits.vue
+++ b/frontend/src/views/Recruits.vue
@@ -42,10 +42,6 @@ export default {
           label: "모집 중",
         },
         {
-          name: "unrecruitable",
-          label: "일시 중지",
-        },
-        {
           name: "ended",
           label: "모집 종료",
         },
@@ -124,10 +120,9 @@ export default {
           return this.allList.filter(el => el.recruitmentStatus === "RECRUITABLE")
         }
         case "recruiting": {
-          return this.allList.filter(el => el.recruitmentStatus === "RECRUITING")
-        }
-        case "unrecruitable": {
-          return this.allList.filter(el => el.recruitmentStatus === "UNRECRUITABLE")
+          return this.allList.filter(
+            el => el.recruitmentStatus === "RECRUITING" || el.recruitmentStatus === "UNRECRUITABLE",
+          )
         }
         case "ended": {
           return this.allList.filter(el => el.recruitmentStatus === "ENDED")

--- a/frontend/src/views/Recruits.vue
+++ b/frontend/src/views/Recruits.vue
@@ -142,19 +142,13 @@ export default {
 </script>
 
 <style scoped>
-@media (min-width: 800px) {
-  #recruits-box {
-    width: 800px;
-    margin: 0 auto;
-  }
-}
-
 #recruits {
   display: flex;
   flex-direction: column;
   align-items: center;
   background: #ced6e0;
   height: 100%;
+  user-select: none;
 }
 
 #recruits-box {
@@ -168,12 +162,26 @@ export default {
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);
 }
 
+@media (min-width: 800px) {
+  #recruits-box {
+    width: 800px;
+    margin: 0 auto;
+  }
+}
+
 #tab-wrapper {
   display: flex;
 }
 
 .list-tab {
   padding: 0 20px 0 20px;
+}
+
+@media (max-width: 500px) {
+  .list-tab {
+    font-size: smaller;
+    padding: 0 10px 0 10px;
+  }
 }
 
 .filter {
@@ -184,10 +192,10 @@ export default {
   color: #000000 !important;
 }
 
-@media (max-width: 500px) {
-  .list-tab {
-    font-size: smaller;
-    padding: 0 10px 0 10px;
-  }
+#tab-wrapper > h2 {
+  cursor: pointer;
+}
+.enroll-button button {
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
#79 번 PR의 커밋 로그 문제로 새로 브랜치를 파고 체리픽해서 다시 올립니다.


Resolves: #31
Resolves: #64

기존의 'recruitable'이었던 '모집 중' 상태가 'recruiting'으로 바뀌고
모집 예정을 'recruitable', 모집 일시 중지를 'unrecruitable'로 하였습니다.

모집 일시 중지 상태는 모집 중과 같은 탭에서 표시됩니다.

UI 디자인을 지원자 등록, 모집 폼 등과 어울리도록 수정했습니다.
<img width="938" alt="스크린샷 2020-09-16 오후 12 00 57" src="https://user-images.githubusercontent.com/13493184/93348357-12492d80-f871-11ea-9c0f-9a95ca8ffd8e.png">