### PR TITLE
feat(evaluation): implement evaluation target and load function

### DIFF
--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -39,7 +39,7 @@ class EvaluationTargetService(
         }
     }
 
-    private fun saveEvaluationTargetOfFirst(evaluation: Evaluation): MutableList<EvaluationTarget> {
+    private fun saveEvaluationTargetOfFirst(evaluation: Evaluation): List<EvaluationTarget> {
         val evaluationTargets: List<EvaluationTarget> = createEvaluationTargetsFromFirst(evaluation)
 
         return evaluationTargetRepository.saveAll(evaluationTargets)
@@ -56,7 +56,7 @@ class EvaluationTargetService(
 
     private fun isNotCheater(applicantId: Long) = !cheaterRepository.existsByApplicantId(applicantId)
 
-    private fun saveEvaluationTarget(evaluation: Evaluation): MutableList<EvaluationTarget> {
+    private fun saveEvaluationTarget(evaluation: Evaluation): List<EvaluationTarget> {
         val evaluationTargets = createEvaluationTargetsFrom(evaluation)
 
         return evaluationTargetRepository.saveAll(evaluationTargets)

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -27,14 +27,14 @@ class EvaluationTargetService(
     fun load(evaluationId: Long) {
         val evaluation = evaluationRepository.findByIdOrNull(evaluationId) ?: throw IllegalArgumentException()
         val cheaterApplicantIds = cheaterRepository.findAll().map { it.applicantId }
-
-        val updatingEvaluationTargets =
-            createUpdatingEvaluationTargets(evaluation).filterNot { cheaterApplicantIds.contains(it.applicantId) }
-
-        val updatingApplicantIds = updatingEvaluationTargets.map { it.applicantId }.toSet()
-
-        val currentApplicantIds =
-            evaluationTargetRepository.findByEvaluationId(evaluationId).map { it.applicantId }.toSet()
+        val updatingApplicantIds = createUpdatingEvaluationTargets(evaluation)
+            .filterNot { cheaterApplicantIds.contains(it.applicantId) }
+            .map { it.applicantId }
+            .toSet()
+        val currentApplicantIds = evaluationTargetRepository
+            .findByEvaluationId(evaluationId)
+            .map { it.applicantId }
+            .toSet()
 
         evaluationTargetRepository.deleteByEvaluationIdAndApplicantIdIn(
             evaluationId,
@@ -42,7 +42,6 @@ class EvaluationTargetService(
         )
 
         val newApplicantIds = updatingApplicantIds - currentApplicantIds
-
         save(newApplicantIds, evaluation)
     }
 

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -40,8 +40,10 @@ class EvaluationTargetService(
 
             evaluationTargetRepository.deleteByApplicantIdIn(currentApplicantIds - updatingApplicantIds)
 
-            if ((updatingApplicantIds - currentApplicantIds).isNotEmpty()) {
-                save(updatingApplicantIds, currentApplicantIds, evaluation)
+            val newlyAddedApplicantIds = updatingApplicantIds - currentApplicantIds
+
+            if (newlyAddedApplicantIds.isNotEmpty()) {
+                save(newlyAddedApplicantIds, evaluation)
             }
         } else {
             evaluationTargetRepository.saveAll(updatingEvaluationTargets)
@@ -70,10 +72,8 @@ class EvaluationTargetService(
             .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.id) }
     }
 
-    private fun save(updatingApplicantIds: Set<Long>, currentApplicantIds: Set<Long>, evaluation: Evaluation) {
-        val addingApplicantIds = updatingApplicantIds - currentApplicantIds
-
-        val additionalEvaluationTargets = applicantRepository.findAllById(addingApplicantIds)
+    private fun save(newlyAddedApplicantIds: Set<Long>, evaluation: Evaluation) {
+        val additionalEvaluationTargets = applicantRepository.findAllById(newlyAddedApplicantIds)
             .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.id) }
 
         evaluationTargetRepository.saveAll(additionalEvaluationTargets)

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -28,10 +28,10 @@ class EvaluationTargetService(
         val evaluation = evaluationRepository.findByIdOrNull(evaluationId) ?: throw IllegalArgumentException()
         val cachedCheaterApplicantIds = cheaterRepository.findAll().map { it.applicantId }
 
-        return when {
-            !evaluation.hasBeforeEvaluation() -> updateEvaluationTargetOfFirst(evaluation, cachedCheaterApplicantIds)
-            evaluation.hasBeforeEvaluation() -> updateEvaluationTarget(evaluation, cachedCheaterApplicantIds)
-            else -> throw IllegalStateException("평가 대상자를 갱신할 수 없습니다.")
+        if (evaluation.hasBeforeEvaluation()) {
+            updateEvaluationTarget(evaluation, cachedCheaterApplicantIds)
+        } else {
+            updateEvaluationTargetOfFirst(evaluation, cachedCheaterApplicantIds)
         }
     }
 

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -22,7 +22,7 @@ class EvaluationTargetService(
     private val cheaterRepository: CheaterRepository
 ) {
     fun findByEvaluationId(evaluationId: Long): List<EvaluationTarget> =
-        evaluationTargetRepository.findByEvaluationId(evaluationId)
+        evaluationTargetRepository.findAllByEvaluationId(evaluationId)
 
     fun load(evaluationId: Long) {
         val evaluation = evaluationRepository.findByIdOrNull(evaluationId) ?: throw IllegalArgumentException()
@@ -31,8 +31,7 @@ class EvaluationTargetService(
             .filterNot { cheaterApplicantIds.contains(it.applicantId) }
             .map { it.applicantId }
             .toSet()
-        val currentApplicantIds = evaluationTargetRepository
-            .findByEvaluationId(evaluationId)
+        val currentApplicantIds = evaluationTargetRepository.findAllByEvaluationId(evaluationId)
             .map { it.applicantId }
             .toSet()
 
@@ -54,7 +53,7 @@ class EvaluationTargetService(
     }
 
     private fun createEvaluationTargets(evaluation: Evaluation): List<EvaluationTarget> {
-        return evaluationTargetRepository.findByEvaluationId(evaluation.beforeEvaluationId)
+        return evaluationTargetRepository.findAllByEvaluationId(evaluation.beforeEvaluationId)
             .filter { it.isPassed }
             .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.applicantId) }
     }

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -5,7 +5,7 @@ import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.cheater.CheaterRepository
 import apply.domain.evaluation.Evaluation
 import apply.domain.evaluation.EvaluationRepository
-import apply.domain.evaluationtarget.EvaluationStatus
+import apply.domain.evaluationtarget.EvaluationStatus.PASS
 import apply.domain.evaluationtarget.EvaluationTarget
 import apply.domain.evaluationtarget.EvaluationTargetRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -64,7 +64,7 @@ class EvaluationTargetService(
 
     private fun createEvaluationTargetsFrom(evaluation: Evaluation): List<EvaluationTarget> {
         return evaluationTargetRepository.findByEvaluationId(evaluation.beforeEvaluationId)
-            .filter { EvaluationStatus.PASS.equals(it.evaluationStatus) }
+            .filter { it.isSameStatusWith(PASS) }
             .filter { isNotCheater(it.applicantId) }
             .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.applicantId) }
     }

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -1,0 +1,137 @@
+package apply.application
+
+import apply.domain.applicant.ApplicantRepository
+import apply.domain.applicationform.ApplicationFormRepository
+import apply.domain.cheater.CheaterRepository
+import apply.domain.evaluation.Evaluation
+import apply.domain.evaluation.EvaluationRepository
+import apply.domain.evaluationtarget.EvaluationStatus
+import apply.domain.evaluationtarget.EvaluationTarget
+import apply.domain.evaluationtarget.EvaluationTargetRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import javax.annotation.PostConstruct
+import javax.transaction.Transactional
+
+@Transactional
+@Service
+class EvaluationTargetService(
+    private val evaluationTargetRepository: EvaluationTargetRepository,
+    private val evaluationRepository: EvaluationRepository,
+    private val applicationFormRepository: ApplicationFormRepository,
+    private val applicantRepository: ApplicantRepository,
+    private val cheaterRepository: CheaterRepository
+) {
+    fun findByEvaluationId(evaluationId: Long): List<EvaluationTarget> =
+        evaluationTargetRepository.findByEvaluationId(evaluationId)
+
+    fun load(evaluationId: Long): List<EvaluationTarget> {
+        val evaluation: Evaluation =
+            evaluationRepository.findByIdOrNull(evaluationId) ?: throw IllegalArgumentException()
+        val isSavedBefore: Boolean = evaluationTargetRepository.existsByEvaluationId(evaluationId)
+
+        return when {
+            !evaluation.hasBeforeEvaluation() && !isSavedBefore -> saveEvaluationTargetOfFirst(evaluation)
+            evaluation.hasBeforeEvaluation() && !isSavedBefore -> saveEvaluationTarget(evaluation)
+            !evaluation.hasBeforeEvaluation() && isSavedBefore -> updateEvaluationTargetOfFirst(evaluation)
+            evaluation.hasBeforeEvaluation() && isSavedBefore -> updateEvaluationTarget(evaluation)
+            else -> throw IllegalStateException("평가 대상자 리스트를 불러올 수 없습니다.")
+        }
+    }
+
+    private fun saveEvaluationTargetOfFirst(evaluation: Evaluation): MutableList<EvaluationTarget> {
+        val evaluationTargets: List<EvaluationTarget> = createEvaluationTargetsFromFirst(evaluation)
+
+        return evaluationTargetRepository.saveAll(evaluationTargets)
+    }
+
+    private fun createEvaluationTargetsFromFirst(evaluation: Evaluation): List<EvaluationTarget> {
+        val applicantIds: List<Long> =
+            applicationFormRepository.findByRecruitmentId(evaluation.recruitmentId).map { it.applicantId }
+
+        return applicantRepository.findAllById(applicantIds)
+            .filter { isNotCheater(it.id) }
+            .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.id) }
+    }
+
+    private fun isNotCheater(applicantId: Long) = !cheaterRepository.existsByApplicantId(applicantId)
+
+    private fun saveEvaluationTarget(evaluation: Evaluation): MutableList<EvaluationTarget> {
+        val evaluationTargets = createEvaluationTargetsFrom(evaluation)
+
+        return evaluationTargetRepository.saveAll(evaluationTargets)
+    }
+
+    private fun createEvaluationTargetsFrom(evaluation: Evaluation): List<EvaluationTarget> {
+        return evaluationTargetRepository.findByEvaluationId(evaluation.beforeEvaluationId)
+            .filter { EvaluationStatus.PASS.equals(it.evaluationStatus) }
+            .filter { isNotCheater(it.applicantId) }
+            .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.applicantId) }
+    }
+
+    private fun updateEvaluationTargetOfFirst(evaluation: Evaluation): List<EvaluationTarget> {
+        val persistApplicantIds: Set<Long> =
+            evaluationTargetRepository.findByEvaluationId(evaluation.id).map { it.applicantId }.toSet()
+
+        val newApplicantIds: Set<Long> = createEvaluationTargetsFromFirst(evaluation).map { it.applicantId }.toSet()
+
+        update(persistApplicantIds, newApplicantIds, evaluation)
+
+        return evaluationTargetRepository.findByEvaluationId(evaluation.id)
+    }
+
+    private fun update(
+        persistApplicantIds: Set<Long>,
+        newApplicantIds: Set<Long>,
+        evaluation: Evaluation
+    ) {
+        val deletingApplicantIds = persistApplicantIds subtract newApplicantIds
+
+        evaluationTargetRepository.deleteByEvaluationIdAndApplicantIdIn(evaluation.id, deletingApplicantIds)
+
+        val addingApplicantIds = newApplicantIds subtract persistApplicantIds
+
+        val additionalEvaluationTargets: List<EvaluationTarget> =
+            applicantRepository.findAllById(addingApplicantIds)
+                .filter { isNotCheater(it.id) }
+                .map { EvaluationTarget(evaluationId = evaluation.id, applicantId = it.id) }
+
+        evaluationTargetRepository.saveAll(additionalEvaluationTargets)
+    }
+
+    private fun updateEvaluationTarget(evaluation: Evaluation): List<EvaluationTarget> {
+        val persistApplicantIds =
+            evaluationTargetRepository.findByEvaluationId(evaluation.id).map { it.applicantId }.toSet()
+
+        val newApplicantIds = createEvaluationTargetsFrom(evaluation).map { it.applicantId }.toSet()
+
+        update(persistApplicantIds, newApplicantIds, evaluation)
+
+        return evaluationTargetRepository.findByEvaluationId(evaluation.id)
+    }
+
+    @PostConstruct
+    private fun populateDummy() {
+        if (evaluationTargetRepository.count() != 0L) {
+            return
+        }
+        val evaluationTargets = listOf(
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 1L,
+                applicantId = 1L
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 1L,
+                applicantId = 2L
+            ),
+            EvaluationTarget(
+                evaluationId = 2L,
+                administratorId = 1L,
+                applicantId = 3L
+            )
+        )
+        evaluationTargetRepository.saveAll(evaluationTargets)
+    }
+}

--- a/src/main/kotlin/apply/domain/evaluation/Evaluation.kt
+++ b/src/main/kotlin/apply/domain/evaluation/Evaluation.kt
@@ -23,6 +23,8 @@ class Evaluation(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L
 ) {
+    fun hasBeforeEvaluation(): Boolean = beforeEvaluationId != 0L
+
     fun hasSameBeforeEvaluationWith(beforeEvaluationId: Long): Boolean = this.beforeEvaluationId == beforeEvaluationId
 
     fun resetBeforeEvaluation() {

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswer.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswer.kt
@@ -1,0 +1,18 @@
+package apply.domain.evaluationtarget
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class EvaluationAnswer(
+    @Column(nullable = false)
+    private var score: Int = 0,
+
+    @Column(nullable = false)
+    private val EvaluationItemId: Long
+) {
+    fun update(score: Int) {
+        require(score >= 0)
+        this.score = score
+    }
+}

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswer.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswer.kt
@@ -9,7 +9,7 @@ class EvaluationAnswer(
     private var score: Int = 0,
 
     @Column(nullable = false)
-    private val EvaluationItemId: Long
+    private val evaluationItemId: Long
 ) {
     fun update(score: Int) {
         require(score >= 0)

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswers.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswers.kt
@@ -1,0 +1,15 @@
+package apply.domain.evaluationtarget
+
+import javax.persistence.ElementCollection
+import javax.persistence.Embeddable
+import javax.persistence.FetchType
+
+@Embeddable
+class EvaluationAnswers(
+    @ElementCollection(fetch = FetchType.EAGER)
+    private val evaluationAnswers: MutableList<EvaluationAnswer> = mutableListOf()
+) {
+    fun add(evaluationAnswer: EvaluationAnswer) {
+        evaluationAnswers.add(evaluationAnswer)
+    }
+}

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationStatus.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationStatus.kt
@@ -1,0 +1,8 @@
+package apply.domain.evaluationtarget
+
+enum class EvaluationStatus(val title: String) {
+    WAITING("평가 전"),
+    PENDING("보류"),
+    PASS("합격"),
+    FAIL("탈락")
+}

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
@@ -35,4 +35,6 @@ class EvaluationTarget(
         administratorId = 0L,
         applicantId = applicantId
     )
+
+    fun isSameStatusWith(evaluationStatus: EvaluationStatus) = this.evaluationStatus == evaluationStatus
 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
@@ -1,0 +1,38 @@
+package apply.domain.evaluationtarget
+
+import javax.persistence.Column
+import javax.persistence.Embedded
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+
+@Entity
+class EvaluationTarget(
+    @Column(nullable = false)
+    val evaluationId: Long = 0L,
+
+    // TODO 추후 채점자 개념이 들어가면 수정 필요
+    val administratorId: Long,
+
+    @Column(nullable = false)
+    val applicantId: Long,
+
+    @Column(nullable = false)
+    val evaluationStatus: EvaluationStatus = EvaluationStatus.WAITING,
+
+    @Embedded
+    val evaluationAnswers: EvaluationAnswers = EvaluationAnswers(),
+
+    val note: String = "",
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) {
+    constructor(evaluationId: Long, applicantId: Long) : this(
+        evaluationId = evaluationId,
+        administratorId = 0L,
+        applicantId = applicantId
+    )
+}

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
@@ -36,5 +36,6 @@ class EvaluationTarget(
         applicantId = applicantId
     )
 
-    fun isSameStatusWith(evaluationStatus: EvaluationStatus) = this.evaluationStatus == evaluationStatus
+    val isPassed: Boolean
+        get() = this.evaluationStatus == EvaluationStatus.PASS
 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
@@ -13,7 +13,7 @@ class EvaluationTarget(
     val evaluationId: Long = 0L,
 
     // TODO 추후 채점자 개념이 들어가면 수정 필요
-    val administratorId: Long,
+    val administratorId: Long?,
 
     @Column(nullable = false)
     val applicantId: Long,

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -3,7 +3,7 @@ package apply.domain.evaluationtarget
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
-    fun findByEvaluationId(evaluationId: Long): List<EvaluationTarget>
+    fun findAllByEvaluationId(evaluationId: Long): List<EvaluationTarget>
 
     fun existsByEvaluationId(evaluationId: Long): Boolean
 

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -6,4 +6,8 @@ interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
     fun findByEvaluationId(evaluationId: Long): List<EvaluationTarget>
 
     fun existsByEvaluationId(evaluationId: Long): Boolean
+
+    fun deleteByApplicantIdIn(applicantIds: Collection<Long>)
+
+    fun deleteByEvaluationIdAndApplicantIdIn(evaluationId: Long, applicantIds: Collection<Long>)
 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -1,0 +1,9 @@
+package apply.domain.evaluationtarget
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
+    fun findByEvaluationId(evaluationId: Long): List<EvaluationTarget>
+
+    fun existsByEvaluationId(evaluationId: Long): Boolean
+}

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -221,7 +221,7 @@ class EvaluationTargetServiceTest(
     }
 
     @Test
-    fun `이전 평가가 없고 저장 된 평가 대상자가 있을 경우 갱신하여 불러온다`() {
+    fun `이전 평가가 없고 저장 된 평가 대상자가 있을 경우 갱신하여 불러온다, 새로 등록된 지원자를 평가 대상자에 추가한다`() {
         // given
         val savedEvaluationTargets = listOf(
             EvaluationTarget(
@@ -387,7 +387,7 @@ class EvaluationTargetServiceTest(
     }
 
     @Test
-    fun `이전 평가가 있고 저장 된 평가 대상자가 있을 경우 갱신하고 불러온다`() {
+    fun `이전 평가가 있고 저장 된 평가 대상자가 있을 경우 갱신하고 불러온다, 이전 평가의 평가 대상자의 평가가 FAIL로 바뀌면 제거한다`() {
         // given
         val savedEvaluationTargets = listOf(
             EvaluationTarget(

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -61,93 +61,34 @@ class EvaluationTargetServiceTest(
     @Test
     fun `이전 평가가 없고 저장 된 평가 대상자가 없을 경우 저장하고 불러온다`() {
         // given
-        val firstEvaluation = Evaluation(
+        val firstEvaluation = createEvaluation(
             id = 1L,
-            title = "평가1",
-            description = "평가1에 대한 설명",
             recruitmentId = 1L,
             beforeEvaluationId = 0L
         )
 
         val applicationForms = listOf(
-            ApplicationForm(
+            createApplicationForm(
                 id = 1L,
-                referenceUrl = "",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 1L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("고객에게 가치를 전달하고 싶습니다.", 1L),
-                        Answer("도전, 끈기", 2L)
-                    )
-                )
+                applicantId = 1L
             ),
-            ApplicationForm(
+            createApplicationForm(
                 id = 2L,
-                referenceUrl = "https://www.google.com",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 2L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("스타트업을 하고 싶습니다.", 1L),
-                        Answer("책임감", 2L)
-                    )
-                )
+                applicantId = 2L
             ),
-            ApplicationForm(
+            createApplicationForm(
                 id = 3L,
-                referenceUrl = "https://www.google.com",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 3L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("양자 컴퓨터를 배우고 싶습니다.", 1L),
-                        Answer("노력", 2L)
-                    )
-                )
+                applicantId = 3L
             )
         )
 
         val applicants = listOf(
-            Applicant(
-                id = 1L,
-                name = "홍길동1",
-                email = "a@email.com",
-                phoneNumber = "010-0000-0000",
-                gender = Gender.MALE,
-                birthday = createLocalDate(2020, 4, 17),
-                password = "password"
-            ),
-            Applicant(
-                id = 2L,
-                name = "홍길동2",
-                email = "b@email.com",
-                phoneNumber = "010-0000-0000",
-                gender = Gender.FEMALE,
-                birthday = createLocalDate(2020, 5, 5),
-                password = "password"
-            ),
-            Applicant(
-                id = 3L,
-                name = "홍길동3",
-                email = "c@email.com",
-                phoneNumber = "010-0000-0000",
-                gender = Gender.MALE,
-                birthday = createLocalDate(2020, 1, 1),
-                password = "password"
-            )
+            createApplicant(1L),
+            createApplicant(2L),
+            createApplicant(3L)
         )
 
         // when
@@ -197,10 +138,8 @@ class EvaluationTargetServiceTest(
         evaluationTargetRepository.saveAll(savedEvaluationTargets)
 
         // when
-        val secondEvaluation = Evaluation(
+        val secondEvaluation = createEvaluation(
             id = 2L,
-            title = "평가2",
-            description = "평가2에 대한 설명",
             recruitmentId = 1L,
             beforeEvaluationId = 1L
         )
@@ -247,119 +186,41 @@ class EvaluationTargetServiceTest(
         evaluationTargetRepository.saveAll(savedEvaluationTargets)
 
         // when
-        val firstEvaluation = Evaluation(
+        val firstEvaluation = createEvaluation(
             id = 1L,
-            title = "평가1",
-            description = "평가1에 대한 설명",
             recruitmentId = 1L,
             beforeEvaluationId = 0L
         )
 
         val allApplicationForms = listOf(
-            ApplicationForm(
+            createApplicationForm(
                 id = 1L,
-                referenceUrl = "",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 1L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("고객에게 가치를 전달하고 싶습니다.", 1L),
-                        Answer("도전, 끈기", 2L)
-                    )
-                )
+                applicantId = 1L
             ),
-            ApplicationForm(
+            createApplicationForm(
                 id = 2L,
-                referenceUrl = "https://www.google.com",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 2L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("스타트업을 하고 싶습니다.", 1L),
-                        Answer("책임감", 2L)
-                    )
-                )
+                applicantId = 2L
             ),
-            ApplicationForm(
+            createApplicationForm(
                 id = 3L,
-                referenceUrl = "https://www.google.com",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 3L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("양자 컴퓨터를 배우고 싶습니다.", 1L),
-                        Answer("노력", 2L)
-                    )
-                )
+                applicantId = 3L
             ),
-            ApplicationForm(
+            createApplicationForm(
                 id = 4L,
-                referenceUrl = "",
-                submitted = true,
-                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
-                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
-                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
                 recruitmentId = 1L,
-                applicantId = 4L,
-                answers = Answers(
-                    mutableListOf(
-                        Answer("협업하는 개발자가 되고 싶습니다.", 1L),
-                        Answer("협업", 2L)
-                    )
-                )
+                applicantId = 4L
             )
         )
 
-        val addingApplicant = Applicant(
-            id = 4L,
-            name = "홍길동4",
-            email = "d@email.com",
-            phoneNumber = "010-0000-0000",
-            gender = Gender.MALE,
-            birthday = createLocalDate(2020, 11, 11),
-            password = "password"
-        )
+        val addingApplicant = createApplicant(id = 4L)
 
         val allApplicants = listOf(
-            Applicant(
-                id = 1L,
-                name = "홍길동1",
-                email = "a@email.com",
-                phoneNumber = "010-0000-0000",
-                gender = Gender.MALE,
-                birthday = createLocalDate(2020, 4, 17),
-                password = "password"
-            ),
-            Applicant(
-                id = 2L,
-                name = "홍길동2",
-                email = "b@email.com",
-                phoneNumber = "010-0000-0000",
-                gender = Gender.FEMALE,
-                birthday = createLocalDate(2020, 5, 5),
-                password = "password"
-            ),
-            Applicant(
-                id = 3L,
-                name = "홍길동3",
-                email = "c@email.com",
-                phoneNumber = "010-0000-0000",
-                gender = Gender.MALE,
-                birthday = createLocalDate(2020, 1, 1),
-                password = "password"
-            ),
+            createApplicant(1L),
+            createApplicant(2L),
+            createApplicant(3L),
             addingApplicant
         )
 
@@ -442,23 +303,13 @@ class EvaluationTargetServiceTest(
         evaluationTargetRepository.saveAll(loadingEvaluationTargetsFromBeforeEvaluation)
 
         // when
-        val secondEvaluation = Evaluation(
+        val secondEvaluation = createEvaluation(
             id = 2L,
-            title = "평가2",
-            description = "평가2에 대한 설명",
             recruitmentId = 1L,
             beforeEvaluationId = 1L
         )
 
-        val addingApplicant = Applicant(
-            id = 4L,
-            name = "홍길동4",
-            email = "d@email.com",
-            phoneNumber = "010-0000-0000",
-            gender = Gender.MALE,
-            birthday = createLocalDate(2020, 11, 11),
-            password = "password"
-        )
+        val addingApplicant = createApplicant(4L)
 
         every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
         every { applicantRepository.findAllById(setOf(4L)) } returns listOf(addingApplicant)
@@ -476,6 +327,47 @@ class EvaluationTargetServiceTest(
             { assertThat(actual[0].evaluationStatus).isEqualTo(EvaluationStatus.PASS) },
             { assertThat(actual[1].applicantId).isEqualTo(4L) },
             { assertThat(actual[1].evaluationStatus).isEqualTo(EvaluationStatus.WAITING) }
+        )
+    }
+
+    private fun createEvaluation(id: Long, recruitmentId: Long = 1L, beforeEvaluationId: Long): Evaluation {
+        return Evaluation(
+            id = id,
+            title = "평가$id",
+            description = "평가${id}에 대한 설명",
+            recruitmentId = recruitmentId,
+            beforeEvaluationId = beforeEvaluationId
+        )
+    }
+
+    private fun createApplicationForm(id: Long, recruitmentId: Long = 1L, applicantId: Long): ApplicationForm {
+        return ApplicationForm(
+            id = id,
+            referenceUrl = "",
+            submitted = true,
+            createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+            modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+            submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+            recruitmentId = recruitmentId,
+            applicantId = applicantId,
+            answers = Answers(
+                mutableListOf(
+                    Answer("${id}의 1번 답", 1L),
+                    Answer("${id}의 2번 답", 2L)
+                )
+            )
+        )
+    }
+
+    private fun createApplicant(id: Long): Applicant {
+        return Applicant(
+            id = id,
+            name = "홍길동$id",
+            email = "$id@email.com",
+            phoneNumber = "010-0000-0000",
+            gender = Gender.MALE,
+            birthday = createLocalDate(2020, 4, 17),
+            password = "password"
         )
     }
 }

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -1,0 +1,481 @@
+package apply.application
+
+import apply.domain.applicant.Applicant
+import apply.domain.applicant.ApplicantRepository
+import apply.domain.applicant.Gender
+import apply.domain.applicationform.ApplicationForm
+import apply.domain.applicationform.ApplicationFormRepository
+import apply.domain.cheater.CheaterRepository
+import apply.domain.evaluation.Evaluation
+import apply.domain.evaluation.EvaluationRepository
+import apply.domain.evaluationtarget.EvaluationStatus
+import apply.domain.evaluationtarget.EvaluationTarget
+import apply.domain.evaluationtarget.EvaluationTargetRepository
+import apply.domain.recruitmentitem.Answer
+import apply.domain.recruitmentitem.Answers
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.TestConstructor
+import support.createLocalDate
+import support.createLocalDateTime
+
+@ExtendWith(MockKExtension::class)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
+class EvaluationTargetServiceTest(
+    private val evaluationTargetRepository: EvaluationTargetRepository
+) {
+    @MockK
+    private lateinit var evaluationRepository: EvaluationRepository
+
+    @MockK
+    private lateinit var applicationFormRepository: ApplicationFormRepository
+
+    @MockK
+    private lateinit var applicantRepository: ApplicantRepository
+
+    @MockK
+    private lateinit var cheaterRepository: CheaterRepository
+
+    private lateinit var evaluationTargetService: EvaluationTargetService
+
+    @BeforeEach
+    fun setUp() {
+        evaluationTargetService = EvaluationTargetService(
+            evaluationTargetRepository,
+            evaluationRepository,
+            applicationFormRepository,
+            applicantRepository,
+            cheaterRepository
+        )
+    }
+
+    @Test
+    fun `이전 평가가 없고 저장 된 평가 대상자가 없을 경우 저장하고 불러온다`() {
+        // given
+        val firstEvaluation = Evaluation(
+            id = 1L,
+            title = "평가1",
+            description = "평가1에 대한 설명",
+            recruitmentId = 1L,
+            beforeEvaluationId = 0L
+        )
+
+        val applicationForms = listOf(
+            ApplicationForm(
+                id = 1L,
+                referenceUrl = "",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 1L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("고객에게 가치를 전달하고 싶습니다.", 1L),
+                        Answer("도전, 끈기", 2L)
+                    )
+                )
+            ),
+            ApplicationForm(
+                id = 2L,
+                referenceUrl = "https://www.google.com",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 2L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("스타트업을 하고 싶습니다.", 1L),
+                        Answer("책임감", 2L)
+                    )
+                )
+            ),
+            ApplicationForm(
+                id = 3L,
+                referenceUrl = "https://www.google.com",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 3L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("양자 컴퓨터를 배우고 싶습니다.", 1L),
+                        Answer("노력", 2L)
+                    )
+                )
+            )
+        )
+
+        val applicants = listOf(
+            Applicant(
+                id = 1L,
+                name = "홍길동1",
+                email = "a@email.com",
+                phoneNumber = "010-0000-0000",
+                gender = Gender.MALE,
+                birthday = createLocalDate(2020, 4, 17),
+                password = "password"
+            ),
+            Applicant(
+                id = 2L,
+                name = "홍길동2",
+                email = "b@email.com",
+                phoneNumber = "010-0000-0000",
+                gender = Gender.FEMALE,
+                birthday = createLocalDate(2020, 5, 5),
+                password = "password"
+            ),
+            Applicant(
+                id = 3L,
+                name = "홍길동3",
+                email = "c@email.com",
+                phoneNumber = "010-0000-0000",
+                gender = Gender.MALE,
+                birthday = createLocalDate(2020, 1, 1),
+                password = "password"
+            )
+        )
+
+        // when
+        every { evaluationRepository.findByIdOrNull(any()) } returns firstEvaluation
+        every { applicationFormRepository.findByRecruitmentId(any()) } returns applicationForms
+        every { applicantRepository.findAllById(any()) } returns applicants
+        every { cheaterRepository.existsByApplicantId(1L) } returns false
+        every { cheaterRepository.existsByApplicantId(2L) } returns false
+        every { cheaterRepository.existsByApplicantId(3L) } returns true
+
+        val actual: List<EvaluationTarget> = evaluationTargetService.load(firstEvaluation.id)
+
+        // then
+        assertAll(
+            { assertThat(actual).hasSize(2) },
+            { assertThat(actual[0].applicantId).isEqualTo(1L) },
+            { assertThat(actual[0].evaluationStatus).isEqualTo(EvaluationStatus.WAITING) },
+            { assertThat(actual[1].applicantId).isEqualTo(2L) },
+            { assertThat(actual[1].evaluationStatus).isEqualTo(EvaluationStatus.WAITING) }
+        )
+    }
+
+    @Test
+    fun `이전 평가가 있고 저장 된 평가 대상자가 없을 경우 저장하고 불러온다`() {
+        // given
+        val savedEvaluationTargets = listOf(
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 1L,
+                evaluationStatus = EvaluationStatus.WAITING
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 2L,
+                evaluationStatus = EvaluationStatus.PASS
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 3L,
+                evaluationStatus = EvaluationStatus.PASS
+            )
+        )
+
+        evaluationTargetRepository.saveAll(savedEvaluationTargets)
+
+        // when
+        val secondEvaluation = Evaluation(
+            id = 2L,
+            title = "평가2",
+            description = "평가2에 대한 설명",
+            recruitmentId = 1L,
+            beforeEvaluationId = 1L
+        )
+
+        every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
+        every { cheaterRepository.existsByApplicantId(1L) } returns false
+        every { cheaterRepository.existsByApplicantId(2L) } returns false
+        every { cheaterRepository.existsByApplicantId(3L) } returns true
+
+        val actual: List<EvaluationTarget> = evaluationTargetService.load(secondEvaluation.id)
+
+        // then
+        assertAll(
+            { assertThat(actual).hasSize(1) },
+            { assertThat(actual[0].applicantId).isEqualTo(2L) },
+            { assertThat(actual[0].evaluationStatus).isEqualTo(EvaluationStatus.WAITING) }
+        )
+    }
+
+    @Test
+    fun `이전 평가가 없고 저장 된 평가 대상자가 있을 경우 갱신하여 불러온다`() {
+        // given
+        val savedEvaluationTargets = listOf(
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 1L,
+                evaluationStatus = EvaluationStatus.FAIL
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 2L,
+                evaluationStatus = EvaluationStatus.PASS
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 3L,
+                evaluationStatus = EvaluationStatus.PASS
+            )
+        )
+
+        evaluationTargetRepository.saveAll(savedEvaluationTargets)
+
+        // when
+        val firstEvaluation = Evaluation(
+            id = 1L,
+            title = "평가1",
+            description = "평가1에 대한 설명",
+            recruitmentId = 1L,
+            beforeEvaluationId = 0L
+        )
+
+        val allApplicationForms = listOf(
+            ApplicationForm(
+                id = 1L,
+                referenceUrl = "",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 1L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("고객에게 가치를 전달하고 싶습니다.", 1L),
+                        Answer("도전, 끈기", 2L)
+                    )
+                )
+            ),
+            ApplicationForm(
+                id = 2L,
+                referenceUrl = "https://www.google.com",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 2L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("스타트업을 하고 싶습니다.", 1L),
+                        Answer("책임감", 2L)
+                    )
+                )
+            ),
+            ApplicationForm(
+                id = 3L,
+                referenceUrl = "https://www.google.com",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 3L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("양자 컴퓨터를 배우고 싶습니다.", 1L),
+                        Answer("노력", 2L)
+                    )
+                )
+            ),
+            ApplicationForm(
+                id = 4L,
+                referenceUrl = "",
+                submitted = true,
+                createdDateTime = createLocalDateTime(2019, 10, 25, 10),
+                modifiedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                submittedDateTime = createLocalDateTime(2019, 11, 5, 10),
+                recruitmentId = 1L,
+                applicantId = 4L,
+                answers = Answers(
+                    mutableListOf(
+                        Answer("협업하는 개발자가 되고 싶습니다.", 1L),
+                        Answer("협업", 2L)
+                    )
+                )
+            )
+        )
+
+        val addingApplicant = Applicant(
+            id = 4L,
+            name = "홍길동4",
+            email = "d@email.com",
+            phoneNumber = "010-0000-0000",
+            gender = Gender.MALE,
+            birthday = createLocalDate(2020, 11, 11),
+            password = "password"
+        )
+
+        val allApplicants = listOf(
+            Applicant(
+                id = 1L,
+                name = "홍길동1",
+                email = "a@email.com",
+                phoneNumber = "010-0000-0000",
+                gender = Gender.MALE,
+                birthday = createLocalDate(2020, 4, 17),
+                password = "password"
+            ),
+            Applicant(
+                id = 2L,
+                name = "홍길동2",
+                email = "b@email.com",
+                phoneNumber = "010-0000-0000",
+                gender = Gender.FEMALE,
+                birthday = createLocalDate(2020, 5, 5),
+                password = "password"
+            ),
+            Applicant(
+                id = 3L,
+                name = "홍길동3",
+                email = "c@email.com",
+                phoneNumber = "010-0000-0000",
+                gender = Gender.MALE,
+                birthday = createLocalDate(2020, 1, 1),
+                password = "password"
+            ),
+            addingApplicant
+        )
+
+        every { evaluationRepository.findByIdOrNull(any()) } returns firstEvaluation
+        every { applicationFormRepository.findByRecruitmentId(any()) } returns allApplicationForms
+        every { applicantRepository.findAllById(listOf(1L, 2L, 3L, 4L)) } returns allApplicants
+        every { applicantRepository.findAllById(setOf(4L)) } returns listOf(addingApplicant)
+        every { cheaterRepository.existsByApplicantId(1L) } returns false
+        every { cheaterRepository.existsByApplicantId(2L) } returns false
+        every { cheaterRepository.existsByApplicantId(3L) } returns true
+        every { cheaterRepository.existsByApplicantId(4L) } returns false
+
+        val actual: List<EvaluationTarget> = evaluationTargetService.load(firstEvaluation.id)
+
+        // then
+        assertAll(
+            { assertThat(actual).hasSize(3) },
+            { assertThat(actual[0].applicantId).isEqualTo(1L) },
+            { assertThat(actual[0].evaluationStatus).isEqualTo(EvaluationStatus.FAIL) },
+            { assertThat(actual[1].applicantId).isEqualTo(2L) },
+            { assertThat(actual[1].evaluationStatus).isEqualTo(EvaluationStatus.PASS) },
+            { assertThat(actual[2].applicantId).isEqualTo(4L) },
+            { assertThat(actual[2].evaluationStatus).isEqualTo(EvaluationStatus.WAITING) }
+        )
+    }
+
+    @Test
+    fun `이전 평가가 있고 저장 된 평가 대상자가 있을 경우 갱신하고 불러온다`() {
+        // given
+        val savedEvaluationTargets = listOf(
+            EvaluationTarget(
+                evaluationId = 2L,
+                administratorId = 0L,
+                applicantId = 1L,
+                evaluationStatus = EvaluationStatus.WAITING
+            ),
+            EvaluationTarget(
+                evaluationId = 2L,
+                administratorId = 0L,
+                applicantId = 2L,
+                evaluationStatus = EvaluationStatus.PASS
+            ),
+            EvaluationTarget(
+                evaluationId = 2L,
+                administratorId = 0L,
+                applicantId = 3L,
+                evaluationStatus = EvaluationStatus.PASS
+            )
+        )
+
+        evaluationTargetRepository.saveAll(savedEvaluationTargets)
+
+        val loadingEvaluationTargetsFromBeforeEvaluation = listOf(
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 1L,
+                evaluationStatus = EvaluationStatus.FAIL
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 2L,
+                evaluationStatus = EvaluationStatus.PASS
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 3L,
+                evaluationStatus = EvaluationStatus.PASS
+            ),
+            EvaluationTarget(
+                evaluationId = 1L,
+                administratorId = 0L,
+                applicantId = 4L,
+                evaluationStatus = EvaluationStatus.PASS
+            )
+        )
+
+        evaluationTargetRepository.saveAll(loadingEvaluationTargetsFromBeforeEvaluation)
+
+        // when
+        val secondEvaluation = Evaluation(
+            id = 2L,
+            title = "평가2",
+            description = "평가2에 대한 설명",
+            recruitmentId = 1L,
+            beforeEvaluationId = 1L
+        )
+
+        val addingApplicant = Applicant(
+            id = 4L,
+            name = "홍길동4",
+            email = "d@email.com",
+            phoneNumber = "010-0000-0000",
+            gender = Gender.MALE,
+            birthday = createLocalDate(2020, 11, 11),
+            password = "password"
+        )
+
+        every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
+        every { applicantRepository.findAllById(setOf(4L)) } returns listOf(addingApplicant)
+        every { cheaterRepository.existsByApplicantId(1L) } returns false
+        every { cheaterRepository.existsByApplicantId(2L) } returns false
+        every { cheaterRepository.existsByApplicantId(3L) } returns true
+        every { cheaterRepository.existsByApplicantId(4L) } returns false
+
+        val actual: List<EvaluationTarget> = evaluationTargetService.load(secondEvaluation.id)
+
+        // then
+        assertAll(
+            { assertThat(actual).hasSize(2) },
+            { assertThat(actual[0].applicantId).isEqualTo(2L) },
+            { assertThat(actual[0].evaluationStatus).isEqualTo(EvaluationStatus.PASS) },
+            { assertThat(actual[1].applicantId).isEqualTo(4L) },
+            { assertThat(actual[1].evaluationStatus).isEqualTo(EvaluationStatus.WAITING) }
+        )
+    }
+}

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -101,7 +101,7 @@ class EvaluationTargetServiceTest(
         every { applicantRepository.findAllById(listOf(1L, 2L, 3L)) } returns newApplicants
         every { applicantRepository.findAllById(setOf(1L, 2L)) } returns additionalApplicants
 
-        evaluationTargetService.update(firstEvaluation.id)
+        evaluationTargetService.load(firstEvaluation.id)
 
         val actual = evaluationTargetRepository.findByEvaluationId(firstEvaluation.id)
 
@@ -154,7 +154,7 @@ class EvaluationTargetServiceTest(
         every { cheaterRepository.findAll() } returns listOf(Cheater(3L))
         every { applicantRepository.findAllById(any()) } returns addingApplicants
 
-        evaluationTargetService.update(secondEvaluation.id)
+        evaluationTargetService.load(secondEvaluation.id)
 
         val actual = evaluationTargetRepository.findByEvaluationId(secondEvaluation.id)
 
@@ -237,7 +237,7 @@ class EvaluationTargetServiceTest(
         every { applicantRepository.findAllById(listOf(1L, 2L, 3L, 4L)) } returns allApplicants
         every { applicantRepository.findAllById(setOf(4L)) } returns listOf(addingApplicant)
 
-        evaluationTargetService.update(firstEvaluation.id)
+        evaluationTargetService.load(firstEvaluation.id)
 
         val actual = evaluationTargetRepository.findByEvaluationId(firstEvaluation.id)
 
@@ -321,7 +321,7 @@ class EvaluationTargetServiceTest(
         every { cheaterRepository.findAll() } returns listOf(Cheater(3L))
         every { applicantRepository.findAllById(setOf(4L)) } returns listOf(addingApplicant)
 
-        evaluationTargetService.update(secondEvaluation.id)
+        evaluationTargetService.load(secondEvaluation.id)
 
         val actual = evaluationTargetRepository.findByEvaluationId(secondEvaluation.id)
 

--- a/src/test/kotlin/apply/domain/evaluationitem/EvaluationItemRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationitem/EvaluationItemRepositoryTest.kt
@@ -20,7 +20,7 @@ internal class EvaluationItemRepositoryTest(
 
     @Test
     fun `평가의 id로 평가 항목들을 Position의 오름차순으로 조회한다`() {
-        val evauationItems = listOf(
+        val evaluationItems = listOf(
             EvaluationItem(
                 title = "평가 항목 제목",
                 description = "평가 항목 설명",
@@ -51,10 +51,10 @@ internal class EvaluationItemRepositoryTest(
             )
         )
 
-        evaluationItemRepository.saveAll(evauationItems)
+        evaluationItemRepository.saveAll(evaluationItems)
         val results = evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
 
-        val expected = listOf(evauationItems[3], evauationItems[1], evauationItems[0], evauationItems[2])
+        val expected = listOf(evaluationItems[3], evaluationItems[1], evaluationItems[0], evaluationItems[2])
         assertAll(
             { assertThat(results).usingElementComparatorIgnoringFields("id").isEqualTo(expected) },
             { assertThat(results).usingElementComparatorOnFields("id").isNotNull() }

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -1,0 +1,59 @@
+package apply.domain.evaluationtarget
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.TestConstructor
+import java.util.stream.Stream
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
+class EvaluationTargetRepositoryTest(
+    private val evaluationTargetRepository: EvaluationTargetRepository
+) {
+    companion object {
+        private const val EVALUATION_ID = 1L
+
+        @JvmStatic
+        fun provideExistsByEvaluationIdTestArguments(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(1L, true),
+                Arguments.of(2L, false)
+            )
+    }
+
+    private val evaluationTargets: List<EvaluationTarget> = listOf(
+        EvaluationTarget(
+            EVALUATION_ID,
+            1L
+        ),
+        EvaluationTarget(
+            EVALUATION_ID,
+            2L
+        )
+    )
+
+    @BeforeEach
+    internal fun setUp() {
+        evaluationTargetRepository.saveAll(evaluationTargets)
+    }
+
+    @Test
+    fun `평가의 id로 평가 대상자를 찾는다`() {
+        val results = evaluationTargetRepository.findByEvaluationId(EVALUATION_ID)
+
+        assertThat(results).usingElementComparatorOnFields("applicantId").isEqualTo(evaluationTargets)
+    }
+
+    @MethodSource("provideExistsByEvaluationIdTestArguments")
+    @ParameterizedTest
+    fun `평가의 id를 가지고 있는 평가 대상자의 존재 여부를 확인한다`(evaluationId: Long, expected: Boolean) {
+        val actual = evaluationTargetRepository.existsByEvaluationId(evaluationId)
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -4,11 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.TestConstructor
-import java.util.stream.Stream
 
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @DataJpaTest
@@ -17,13 +15,6 @@ class EvaluationTargetRepositoryTest(
 ) {
     companion object {
         private const val EVALUATION_ID = 1L
-
-        @JvmStatic
-        fun provideExistsByEvaluationIdTestArguments(): Stream<Arguments> =
-            Stream.of(
-                Arguments.of(1L, true),
-                Arguments.of(2L, false)
-            )
     }
 
     private val evaluationTargets: List<EvaluationTarget> = listOf(
@@ -49,7 +40,7 @@ class EvaluationTargetRepositoryTest(
         assertThat(results).usingElementComparatorOnFields("applicantId").isEqualTo(evaluationTargets)
     }
 
-    @MethodSource("provideExistsByEvaluationIdTestArguments")
+    @CsvSource(value = ["1,true", "2,false"])
     @ParameterizedTest
     fun `평가의 id를 가지고 있는 평가 대상자의 존재 여부를 확인한다`(evaluationId: Long, expected: Boolean) {
         val actual = evaluationTargetRepository.existsByEvaluationId(evaluationId)

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -20,11 +20,11 @@ class EvaluationTargetRepositoryTest(
     private val evaluationTargets: List<EvaluationTarget> = listOf(
         EvaluationTarget(
             EVALUATION_ID,
-            1L
+            applicantId = 1L
         ),
         EvaluationTarget(
             EVALUATION_ID,
-            2L
+            applicantId = 2L
         )
     )
 
@@ -59,8 +59,8 @@ class EvaluationTargetRepositoryTest(
     fun `지정한 평가에 해당되고 지원자의 id들에 해당되는 평가 대상자를 제거한다`() {
         evaluationTargetRepository.save(
             EvaluationTarget(
-                2L,
-                1L
+                evaluationId = 2L,
+                applicantId = 1L
             )
         )
 

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -35,7 +35,7 @@ class EvaluationTargetRepositoryTest(
 
     @Test
     fun `평가의 id로 평가 대상자를 찾는다`() {
-        val results = evaluationTargetRepository.findByEvaluationId(EVALUATION_ID)
+        val results = evaluationTargetRepository.findAllByEvaluationId(EVALUATION_ID)
 
         assertThat(results).usingElementComparatorOnFields("applicantId").isEqualTo(evaluationTargets)
     }

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -56,4 +56,25 @@ class EvaluationTargetRepositoryTest(
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `지원자의 id들에 해당되는 평가 대상자를 제거한다`() {
+        evaluationTargetRepository.deleteByApplicantIdIn(setOf(1L, 2L))
+
+        assertThat(evaluationTargetRepository.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `지정한 평가에 해당되고 지원자의 id들에 해당되는 평가 대상자를 제거한다`() {
+        evaluationTargetRepository.save(
+            EvaluationTarget(
+                2L,
+                1L
+            )
+        )
+
+        evaluationTargetRepository.deleteByEvaluationIdAndApplicantIdIn(1L, setOf(1L, 2L))
+
+        assertThat(evaluationTargetRepository.count()).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
제이슨의 빛과 같은 리뷰 반영 01:26, 9/30

이렇게 코드가 바뀔 수 있군요. 리팩토링 재미있네요. 도와주신 제이슨 고마워요!
저는 처음에 생각했던 틀을 못 벗어났던 것 같습니다 😂

늦은 시간이라 머리가 맑지 않기에 내일 일어나서 추가적으로 손보도록 하겠습니다.

다들 굳나잇~

---

모든 리뷰 반영 21:30, 9/29

범의 조언에 힘입어 두가지 분기로 나눠봤습니다. 코멘트 땡큐!

그리고 기존 load 메서드는 저장하고 갱신하고 조회하여 반환까지 하는 무거운 메서드였습니다.
이를 한 메서드에서 최대한 하나의 일을 할 수 있도록 update라는 메서드로 수정했습니다. (save보다는 update가 낫다고 판단했습니다)
이제 불러오기 버튼이 눌리면 update를 실행한 후 findByEvaluationId 메서드를 호출해서 불러오는 방식을 취해야합니다.

실제 갱신 로직은 deleteAndSave라는 메서드에서 진행됩니다. 


---

resolve: #89 

복잡하고 중요도 높은 로직이고 저 혼자 구현했기에 상세한 리뷰 부탁드립니다..!!
허점이 있을게 분명해요🙃

구현은 아침에도 보여드렸듯 4가지 분기로 처리됩니다. 

알려드릴 사항이 있습니다.

1. 테스트 코드의 픽스쳐를 정리하지 못했습니다. 
`https://github.com/woowacourse/jwp-refactoring/pull/2#discussion_r491043437`를 보고나니 setUp으로 분리하기 힘든 여지가 많이 보여서 문맥에 맞추기 위해 각 메서드에 놔뒀습니다.
추후 메서드나 fixture 파일로 분리할 여지가 있습니다.
가독성을 위한 아이디어가 있다면 부탁드립니다~!

2.
평가 대상자 갱신(update) 시 삭제를 진행합니다(EvaluationTargetRepository의 메서드 사용) 
이때 전략에 대해 이야기 나눠보고 싶습니다.

~~~java
interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
... 중략 ...

    fun deleteByApplicantIdIn(applicantIds: Collection<Long>)

    fun deleteByEvaluationIdAndApplicantIdIn(evaluationId: Long, applicantIds: Collection<Long>)
}
~~~
현재는 두 삭제 메서드 중 deleteByEvaluationIdAndApplicantIdIn 메서드를 사용하여 삭제를 진행합니다.

즉 EvaluationId를 이용하여 해당되는 평가에서만 평가 대상자를 제거합니다. 

예를 들자면 평가 1, 2, 3이 있습니다.
이미 평가 2은 평가 대상자를 불러와서 평가 1로부터 정보를 가져와 평가 대상자를 DB에 저장한 상태입니다.

또한 평가 3은 평가 대상자를 불러와서 평가 2로부터 정보를 가져와 평가 대상자를 DB에 저장한 상태입니다.

평가 대상자 A는 평가 1, 2 모두 PASS했고 부정행위자가 아니기에 평가 3의 평가 대상자에 포함되어 있습니다. (WAIT 상태)

이 상황에서 기존 1 평가에서 PASS를 받은 평가 대상자의 평가를 FAIL로 바꾸고 평가 2를 다시 불러온다면, 
**현재 상황에서는 평가 2에서는 평가 대상자 A가 삭제되지만 평가 3에서는 삭제되지 않습니다.**

반면 deleteByApplicantIdIn 메서드를 사용한다면 평가 3에서도 평가 대상자A가 삭제될 것입니다. 

이 부분에 대한 정책을 생각해보면 좋을 것 같습니다.

3. 요구사항 상 자주 눌리지 않는 버튼으로 알고 있고, DB 성능에 대해 많이 고려하지 않고 구현을 진행하기로 해서 레포지토리를 요리조리 활용했습니다. 
최적화할 수 있는 여지가 있다면 피드백 부탁드립니다 😎

감사해요~!