### PR TITLE
feat(apply): add a password reset email template

### DIFF
--- a/src/main/kotlin/apply/application/ApplicantService.kt
+++ b/src/main/kotlin/apply/application/ApplicantService.kt
@@ -10,7 +10,6 @@ import apply.domain.applicant.exception.ApplicantValidateException
 import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.cheater.CheaterRepository
 import apply.security.JwtTokenProvider
-import apply.utils.RandomPasswordGenerator
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -24,7 +23,7 @@ class ApplicantService(
     private val applicantRepository: ApplicantRepository,
     private val cheaterRepository: CheaterRepository,
     private val jwtTokenProvider: JwtTokenProvider,
-    private val randomPasswordGenerator: RandomPasswordGenerator
+    private val passwordGenerator: PasswordGenerator
 ) {
     fun findAllByRecruitmentId(recruitmentId: Long): List<ApplicantResponse> {
         val applicationForms = applicationFormRepository.findByRecruitmentId(recruitmentId)
@@ -73,13 +72,13 @@ class ApplicantService(
         }
     }
 
-    fun resetPassword(resetPasswordRequest: ResetPasswordRequest): String {
+    fun resetPassword(request: ResetPasswordRequest): String {
         return applicantRepository.findByNameAndEmailAndBirthday(
-            resetPasswordRequest.name,
-            resetPasswordRequest.email,
-            resetPasswordRequest.birthday
+            request.name,
+            request.email,
+            request.birthday
         )?.run {
-            password = randomPasswordGenerator.generate()
+            password = passwordGenerator.generate()
             password
         } ?: throw ApplicantValidateException()
     }

--- a/src/main/kotlin/apply/application/ApplicationProperties.kt
+++ b/src/main/kotlin/apply/application/ApplicationProperties.kt
@@ -5,6 +5,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConfigurationProperties("application")
-class CustomApplicationProperties {
+class ApplicationProperties {
     lateinit var url: String
 }

--- a/src/main/kotlin/apply/application/CustomApplicationProperties.kt
+++ b/src/main/kotlin/apply/application/CustomApplicationProperties.kt
@@ -1,0 +1,10 @@
+package apply.application
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties("application")
+class CustomApplicationProperties {
+    lateinit var url: String
+}

--- a/src/main/kotlin/apply/application/MailService.kt
+++ b/src/main/kotlin/apply/application/MailService.kt
@@ -1,6 +1,7 @@
 package apply.application
 
 import apply.domain.applicant.ResetPasswordRequest
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.mail.MailProperties
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
@@ -15,12 +16,15 @@ class MailService(
     private val mailProperties: MailProperties,
     private val templateEngine: ISpringTemplateEngine
 ) {
+    @Value("\${spring.frontend.url}")
+    lateinit var url: String
+
     @Async
     fun sendPasswordResetMail(request: ResetPasswordRequest, newPassword: String) {
         val context = Context()
         context.setVariable("name", request.name)
         context.setVariable("password", newPassword)
-        context.setVariable("url", "http://localhost:8081")
+        context.setVariable("url", url)
 
         val message = mailSender.createMimeMessage()
         val messageHelper = MimeMessageHelper(message, "UTF-8")

--- a/src/main/kotlin/apply/application/MailService.kt
+++ b/src/main/kotlin/apply/application/MailService.kt
@@ -13,7 +13,7 @@ import org.thymeleaf.spring5.ISpringTemplateEngine
 class MailService(
     private val mailSender: JavaMailSender,
     private val mailProperties: MailProperties,
-    private val customApplicationProperties: CustomApplicationProperties,
+    private val applicationProperties: ApplicationProperties,
     private val templateEngine: ISpringTemplateEngine
 ) {
     @Async
@@ -21,7 +21,7 @@ class MailService(
         val context = Context().apply {
             setVariable("name", request.name)
             setVariable("password", newPassword)
-            setVariable("url", customApplicationProperties.url)
+            setVariable("url", applicationProperties.url)
         }
 
         val message = mailSender.createMimeMessage()

--- a/src/main/kotlin/apply/application/MailService.kt
+++ b/src/main/kotlin/apply/application/MailService.kt
@@ -2,23 +2,32 @@ package apply.application
 
 import apply.domain.applicant.ResetPasswordRequest
 import org.springframework.boot.autoconfigure.mail.MailProperties
-import org.springframework.mail.MailSender
-import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring5.ISpringTemplateEngine
 
 @Service
 class MailService(
-    private val mailSender: MailSender,
-    private val mailProperties: MailProperties
+    private val mailSender: JavaMailSender,
+    private val mailProperties: MailProperties,
+    private val templateEngine: ISpringTemplateEngine
 ) {
     @Async
-    fun sendPasswordResetMail(resetPasswordRequest: ResetPasswordRequest, newPassword: String) {
-        val message = SimpleMailMessage()
-        message.setFrom(mailProperties.username)
-        message.setTo(resetPasswordRequest.email)
-        message.setSubject("${resetPasswordRequest.name}님, 임시 비밀번호를 발송해 드립니다.")
-        message.setText(newPassword)
+    fun sendPasswordResetMail(request: ResetPasswordRequest, newPassword: String) {
+        val context = Context()
+        context.setVariable("name", request.name)
+        context.setVariable("password", newPassword)
+        context.setVariable("url", "http://localhost:8081")
+
+        val message = mailSender.createMimeMessage()
+        val messageHelper = MimeMessageHelper(message, "UTF-8")
+        messageHelper.setFrom(mailProperties.username)
+        messageHelper.setTo(request.email)
+        messageHelper.setSubject("${request.name}님, 임시 비밀번호를 발송해 드립니다.")
+        messageHelper.setText(templateEngine.process("mail/password-reset", context), true)
 
         mailSender.send(message)
     }

--- a/src/main/kotlin/apply/application/MailService.kt
+++ b/src/main/kotlin/apply/application/MailService.kt
@@ -25,11 +25,12 @@ class MailService(
         }
 
         val message = mailSender.createMimeMessage()
-        val messageHelper = MimeMessageHelper(message)
-        messageHelper.setFrom(mailProperties.username)
-        messageHelper.setTo(request.email)
-        messageHelper.setSubject("${request.name}님, 임시 비밀번호를 발송해 드립니다.")
-        messageHelper.setText(templateEngine.process("mail/password-reset", context), true)
+        MimeMessageHelper(message).apply {
+            setFrom(mailProperties.username)
+            setTo(request.email)
+            setSubject("${request.name}님, 임시 비밀번호를 발송해 드립니다.")
+            setText(templateEngine.process("mail/password-reset", context), true)
+        }
 
         mailSender.send(message)
     }

--- a/src/main/kotlin/apply/application/MailService.kt
+++ b/src/main/kotlin/apply/application/MailService.kt
@@ -1,7 +1,6 @@
 package apply.application
 
 import apply.domain.applicant.ResetPasswordRequest
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.mail.MailProperties
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
@@ -14,20 +13,19 @@ import org.thymeleaf.spring5.ISpringTemplateEngine
 class MailService(
     private val mailSender: JavaMailSender,
     private val mailProperties: MailProperties,
+    private val customApplicationProperties: CustomApplicationProperties,
     private val templateEngine: ISpringTemplateEngine
 ) {
-    @Value("\${spring.frontend.url}")
-    lateinit var url: String
-
     @Async
     fun sendPasswordResetMail(request: ResetPasswordRequest, newPassword: String) {
-        val context = Context()
-        context.setVariable("name", request.name)
-        context.setVariable("password", newPassword)
-        context.setVariable("url", url)
+        val context = Context().apply {
+            setVariable("name", request.name)
+            setVariable("password", newPassword)
+            setVariable("url", customApplicationProperties.url)
+        }
 
         val message = mailSender.createMimeMessage()
-        val messageHelper = MimeMessageHelper(message, "UTF-8")
+        val messageHelper = MimeMessageHelper(message)
         messageHelper.setFrom(mailProperties.username)
         messageHelper.setTo(request.email)
         messageHelper.setSubject("${request.name}님, 임시 비밀번호를 발송해 드립니다.")

--- a/src/main/kotlin/apply/application/PasswordGenerator.kt
+++ b/src/main/kotlin/apply/application/PasswordGenerator.kt
@@ -1,0 +1,5 @@
+package apply.application
+
+interface PasswordGenerator {
+    fun generate(): String
+}

--- a/src/main/kotlin/apply/application/UUIDBasedPasswordGenerator.kt
+++ b/src/main/kotlin/apply/application/UUIDBasedPasswordGenerator.kt
@@ -1,10 +1,10 @@
-package apply.utils
+package apply.application
 
 import org.springframework.stereotype.Component
 import java.util.UUID
 
 @Component
-class UUIDBasedPasswordGenerator : RandomPasswordGenerator {
+class UUIDBasedPasswordGenerator : PasswordGenerator {
     override fun generate(): String {
         return UUID.randomUUID().toString().substring(0, 18)
     }

--- a/src/main/kotlin/apply/domain/applicant/ApplicantRepository.kt
+++ b/src/main/kotlin/apply/domain/applicant/ApplicantRepository.kt
@@ -8,12 +8,6 @@ interface ApplicantRepository : JpaRepository<Applicant, Long> {
 
     fun findByEmail(email: String): Applicant?
 
-    fun existsByNameAndEmailAndBirthday(
-        name: String,
-        email: String,
-        birthDay: LocalDate
-    ): Boolean
-
     fun findByNameAndEmailAndBirthday(
         name: String,
         email: String,

--- a/src/main/kotlin/apply/ui/api/ApplicantRestController.kt
+++ b/src/main/kotlin/apply/ui/api/ApplicantRestController.kt
@@ -3,8 +3,8 @@ package apply.ui.api
 import apply.application.ApplicantService
 import apply.application.MailService
 import apply.domain.applicant.ApplicantInformation
-import apply.domain.applicant.ResetPasswordRequest
 import apply.domain.applicant.ApplicantVerifyInformation
+import apply.domain.applicant.ResetPasswordRequest
 import apply.domain.applicant.exception.ApplicantValidateException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/apply/ui/api/ApplicationFormRestController.kt
+++ b/src/main/kotlin/apply/ui/api/ApplicationFormRestController.kt
@@ -1,7 +1,7 @@
 package apply.ui.api
 
-import apply.application.SaveApplicationFormRequest
 import apply.application.ApplicationFormService
+import apply.application.SaveApplicationFormRequest
 import apply.application.UpdateApplicationFormRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/apply/utils/RandomPasswordGenerator.kt
+++ b/src/main/kotlin/apply/utils/RandomPasswordGenerator.kt
@@ -1,5 +1,0 @@
-package apply.utils
-
-interface RandomPasswordGenerator {
-    fun generate(): String
-}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.mail.password=PASSWORD
 spring.mail.port=587
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+spring.frontend.url=http://localhost:8081

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,5 +11,6 @@ spring.mail.password=PASSWORD
 spring.mail.port=587
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.mime.charset=UTF-8
 
-spring.frontend.url=http://localhost:8081
+application.url=http://localhost:8081

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Title</title>
+  </head>
+  <body>
+    <strong th:text="${name}"></strong>님, 임시 비밀번호를 발송해 드립니다.<br /><br />
+    <div th:text="${password}"></div>
+    <a th:href="${url}+'/recruits'" target="_blank">
+      <button type="button">내 지원서 보기</button>
+    </a>
+  </body>
+</html>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -6,17 +6,13 @@
     style="width: 200px"
     alt="logo"
   />
-  <h3>
-    <span th:text="${name}">홍길동</span>님, 임시 비밀번호를 발송해 드립니다.
-  </h3>
+  <h3><span th:text="${name}"></span>님, 임시 비밀번호를 발송해 드립니다.</h3>
   <div>
     <br />
     <div
       style="background-color: lightgray;padding: 25px;text-align: center;margin-bottom: 20px"
       th:text="${password}"
-    >
-      1q2w3e4r!-12345qb-q
-    </div>
+    ></div>
     <div style="text-align: center">
       <a th:href="${url}+'/recruits'" target="_blank">
         <button

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -5,10 +5,32 @@
     <title>Title</title>
   </head>
   <body>
-    <strong th:text="${name}"></strong>님, 임시 비밀번호를 발송해 드립니다.<br /><br />
-    <div th:text="${password}"></div>
-    <a th:href="${url}+'/recruits'" target="_blank">
-      <button type="button">내 지원서 보기</button>
-    </a>
+    <div
+      style="width: 100%;max-width: 512px;padding: 20px;margin: 15px;border-radius: 3px;background: #f1f2f6;box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);"
+    >
+      <h3>
+        <span th:text="${name}">홍길동</span>님, 임시 비밀번호를 발송해
+        드립니다.
+      </h3>
+      <div
+      >
+        <br />
+        <div
+          class="password-field"
+          style="background-color: lightgray;padding: 25px;text-align: center;margin-bottom: 20px"
+          th:text="${password}"
+        >
+          1q2w3e4r!-12345qb-q
+        </div>
+        <a th:href="${url}+'/recruits'" target="_blank">
+          <button
+            style="cursor: pointer;outline: none;border: 0;background: #0078ff;color: #fff;border-radius: 3px;padding: 10px;min-width:
+80px; min-height: 28px; margin: 5px;"
+          >
+            내 지원서 보기
+          </button>
+        </a>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -8,6 +8,7 @@
     <div
       style="width: 100%;max-width: 512px;padding: 20px;margin: 15px;border-radius: 3px;background: #f1f2f6;box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);"
     >
+      <img src="https://woowacourse.github.io/img/logo_full_dark.26e30197.png" style="width: 200px" alt="logo">
       <h3>
         <span th:text="${name}">홍길동</span>님, 임시 비밀번호를 발송해
         드립니다.

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -12,8 +12,7 @@
         <span th:text="${name}">홍길동</span>님, 임시 비밀번호를 발송해
         드립니다.
       </h3>
-      <div
-      >
+      <div>
         <br />
         <div
           class="password-field"
@@ -22,14 +21,16 @@
         >
           1q2w3e4r!-12345qb-q
         </div>
-        <a th:href="${url}+'/recruits'" target="_blank">
-          <button
-            style="cursor: pointer;outline: none;border: 0;background: #0078ff;color: #fff;border-radius: 3px;padding: 10px;min-width:
+        <div style="text-align: center">
+          <a th:href="${url}+'/recruits'" target="_blank">
+            <button
+              style="cursor: pointer;outline: none;border: 0;background: #0078ff;color: #fff;border-radius: 3px;padding: 10px;min-width:
 80px; min-height: 28px; margin: 5px;"
-          >
-            내 지원서 보기
-          </button>
-        </a>
+            >
+              내 지원서 보기
+            </button>
+          </a>
+        </div>
       </div>
     </div>
   </body>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -1,38 +1,31 @@
-<!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Title</title>
-  </head>
-  <body>
+<div
+  style="width: 100%;max-width: 512px;padding: 20px;margin: 15px;border-radius: 3px;background: #f1f2f6;box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);"
+>
+  <img
+    src="https://woowacourse.github.io/img/logo_full_dark.26e30197.png"
+    style="width: 200px"
+    alt="logo"
+  />
+  <h3>
+    <span th:text="${name}">홍길동</span>님, 임시 비밀번호를 발송해 드립니다.
+  </h3>
+  <div>
+    <br />
     <div
-      style="width: 100%;max-width: 512px;padding: 20px;margin: 15px;border-radius: 3px;background: #f1f2f6;box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);"
+      style="background-color: lightgray;padding: 25px;text-align: center;margin-bottom: 20px"
+      th:text="${password}"
     >
-      <img src="https://woowacourse.github.io/img/logo_full_dark.26e30197.png" style="width: 200px" alt="logo">
-      <h3>
-        <span th:text="${name}">홍길동</span>님, 임시 비밀번호를 발송해
-        드립니다.
-      </h3>
-      <div>
-        <br />
-        <div
-          class="password-field"
-          style="background-color: lightgray;padding: 25px;text-align: center;margin-bottom: 20px"
-          th:text="${password}"
-        >
-          1q2w3e4r!-12345qb-q
-        </div>
-        <div style="text-align: center">
-          <a th:href="${url}+'/recruits'" target="_blank">
-            <button
-              style="cursor: pointer;outline: none;border: 0;background: #0078ff;color: #fff;border-radius: 3px;padding: 10px;min-width:
-80px; min-height: 28px; margin: 5px;"
-            >
-              내 지원서 보기
-            </button>
-          </a>
-        </div>
-      </div>
+      1q2w3e4r!-12345qb-q
     </div>
-  </body>
-</html>
+    <div style="text-align: center">
+      <a th:href="${url}+'/recruits'" target="_blank">
+        <button
+          style="cursor: pointer;outline: none;border: 0;background: #0078ff;color: #fff;border-radius: 3px;padding: 10px;min-width:
+80px; min-height: 28px; margin: 5px;"
+        >
+          내 지원서 보기
+        </button>
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -13,7 +13,6 @@ import apply.domain.cheater.CheaterRepository
 import apply.domain.recruitmentitem.Answer
 import apply.domain.recruitmentitem.Answers
 import apply.security.JwtTokenProvider
-import apply.utils.RandomPasswordGenerator
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -48,7 +47,7 @@ internal class ApplicantServiceTest {
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
     @Mock
-    private lateinit var passwordGenerator: RandomPasswordGenerator
+    private lateinit var passwordGenerator: PasswordGenerator
 
     private lateinit var applicantService: ApplicantService
 


### PR DESCRIPTION
Resolves #119 

html 파일입니다.
MailSender -> JavaMailSender (메일전송시 html지원해줌)

css는 부득이하게 inline입니다
flex-column는 gmail-html에서 지원하지 않았습니다.

![image](https://user-images.githubusercontent.com/7259103/95173788-1f17cc00-07f4-11eb-8dd2-19f1b1199bd7.png)
