### PR TITLE
feat(applicant): implement the password editing page

### DIFF
--- a/frontend/src/api/applicants.js
+++ b/frontend/src/api/applicants.js
@@ -18,3 +18,14 @@ export const fetchLogin = ({ name, email, birthday, password }) =>
 
 export const fetchPasswordFind = ({ name, email, birthday }) =>
   axios.post("/api/applicants/reset-password", { name, email, birthday })
+
+export const fetchPasswordEdit = ({ token, beforePassword, newPassword }) =>
+  axios.post(
+    "/api/applicants/edit-password",
+    { beforePassword, newPassword },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )

--- a/frontend/src/api/applicants.js
+++ b/frontend/src/api/applicants.js
@@ -19,10 +19,10 @@ export const fetchLogin = ({ name, email, birthday, password }) =>
 export const fetchPasswordFind = ({ name, email, birthday }) =>
   axios.post("/api/applicants/reset-password", { name, email, birthday })
 
-export const fetchPasswordEdit = ({ token, beforePassword, newPassword }) =>
+export const fetchPasswordEdit = ({ token, password, newPassword }) =>
   axios.post(
     "/api/applicants/edit-password",
-    { beforePassword, newPassword },
+    { password, newPassword },
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/frontend/src/components/form/Form.vue
+++ b/frontend/src/components/form/Form.vue
@@ -16,6 +16,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 512px;
   max-width: 512px;
   padding: 20px;
   margin: 15px;
@@ -26,6 +27,7 @@
 
 @media screen and (max-width: 512px) {
   .form {
+    min-width: 100%;
     margin: 0;
   }
 }

--- a/frontend/src/components/form/Form.vue
+++ b/frontend/src/components/form/Form.vue
@@ -15,8 +15,7 @@
 .form {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  min-width: 512px;
+  width: 512px;
   max-width: 512px;
   padding: 20px;
   margin: 15px;
@@ -27,7 +26,7 @@
 
 @media screen and (max-width: 512px) {
   .form {
-    min-width: 100%;
+    width: 100vw;
     margin: 0;
   }
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,6 +6,7 @@ import ApplicationRegister from "@/views/ApplicationRegister"
 import Login from "@/views/Login"
 import PasswordFind from "@/views/PasswordFind"
 import PasswordFindResult from "@/views/PasswordFindResult"
+import PasswordEdit from "@/views/PasswordEdit"
 import MyApplications from "@/views/MyApplications"
 import store from "@/store"
 
@@ -64,6 +65,11 @@ const routes = [
   {
     path: "/find",
     component: PasswordFind,
+  },
+  {
+    path: "/edit",
+    component: PasswordEdit,
+    beforeEnter: requireAuth,
   },
   {
     path: "/find/result",

--- a/frontend/src/store/token.js
+++ b/frontend/src/store/token.js
@@ -26,6 +26,10 @@ export const token = {
 
       commit("setToken", token)
     },
+
+    resetToken({ commit }) {
+      commit("setToken", "")
+    },
   },
 
   getters: {

--- a/frontend/src/views/ApplicationRegister.vue
+++ b/frontend/src/views/ApplicationRegister.vue
@@ -7,37 +7,6 @@
         <p class="autosave-indicator" v-if="isEditing">
           임시 저장되었습니다. ({{ modifiedDateTime }})
         </p>
-        <TextField
-          :value="$store.state.applicantInfo.name"
-          name="name"
-          type="text"
-          label="이름"
-          readonly
-        />
-        <ValidationObserver v-if="isEditing">
-          <ValidationProvider name="password" rules="password|required" v-slot="{ errors }">
-            <TextField
-              v-model="password"
-              name="password"
-              type="password"
-              label="비밀번호"
-              placeholder="비밀번호를 입력해 주세요"
-              required
-            />
-            <p class="rule-field">{{ errors[0] }}</p>
-          </ValidationProvider>
-          <ValidationProvider rules="password|rePassword:@password|required" v-slot="{ errors }">
-            <TextField
-              v-model="rePassword"
-              name="re-password"
-              type="password"
-              label="비밀번호 확인"
-              placeholder="비밀번호를 다시 한 번 입력해 주세요"
-              required
-            />
-            <p class="rule-field">{{ errors[0] }}</p>
-          </ValidationProvider>
-        </ValidationObserver>
         <ValidationProvider
           v-for="(item, index) in recruitmentItems"
           v-bind:key="item.id"
@@ -112,8 +81,6 @@ export default {
   },
   data: () => ({
     factCheck: false,
-    password: "",
-    rePassword: "",
     referenceUrl: "",
     recruitmentItems: [],
     modifiedDateTime: null,
@@ -181,8 +148,6 @@ export default {
     reset() {
       if (confirm("정말 초기화하시겠습니까?")) {
         this.factCheck = false
-        this.password = ""
-        this.rePassword = ""
         this.recruitmentItems = this.recruitmentItems.map(recruitmentItem => ({
           ...recruitmentItem,
           contents: "",
@@ -198,7 +163,6 @@ export default {
           contents: item.contents,
           recruitmentItemId: item.id,
         })),
-        password: this.password,
         isSubmitted,
       }
       return ApplicationFormsApi.updateForm({

--- a/frontend/src/views/MyApplications.vue
+++ b/frontend/src/views/MyApplications.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="my-application-forms">
     <Box>
-      <h1>내 지원서</h1>
+      <div class="head">
+        <h1>내 지원서</h1>
+        <router-link class="edit-password" to="/edit">비밀번호 변경</router-link>
+      </div>
       <ApplicationFormItem
         class="application-forms"
         v-for="recruitment in appliedRecruitments"
@@ -10,9 +13,6 @@
         :submitted="recruitment.submitted"
       />
     </Box>
-    <template>
-      <router-link class="edit-password" to="/edit">비밀번호 변경</router-link>
-    </template>
   </div>
 </template>
 
@@ -68,11 +68,16 @@ export default {
   background: #ced6e0;
 }
 
+.head {
+  display: flex;
+  justify-content: space-between;
+}
+
 .edit-password {
   text-decoration: none;
   text-align: right;
   font-weight: 500;
   color: #2c3e50;
-  margin-right: 5px;
+  margin: 35px 5px;
 }
 </style>

--- a/frontend/src/views/MyApplications.vue
+++ b/frontend/src/views/MyApplications.vue
@@ -10,6 +10,9 @@
         :submitted="recruitment.submitted"
       />
     </Box>
+    <template>
+      <router-link class="edit-password" to="/edit">비밀번호 변경</router-link>
+    </template>
   </div>
 </template>
 
@@ -63,5 +66,13 @@ export default {
   flex-direction: column;
   align-items: center;
   background: #ced6e0;
+}
+
+.edit-password {
+  text-decoration: none;
+  text-align: right;
+  font-weight: 500;
+  color: #2c3e50;
+  margin-right: 5px;
 }
 </style>

--- a/frontend/src/views/PasswordEdit.vue
+++ b/frontend/src/views/PasswordEdit.vue
@@ -69,7 +69,7 @@ export default {
       try {
         await Api.fetchPasswordEdit({
           token: this.$store.getters["token"],
-          beforePassword: this.beforePassword,
+          password: this.beforePassword,
           newPassword: this.password,
         })
         alert("비밀번호가 변경되었습니다. 다시 로그인해주세요.")

--- a/frontend/src/views/PasswordEdit.vue
+++ b/frontend/src/views/PasswordEdit.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="password-edit">
+    <ValidationObserver v-slot="{ handleSubmit, passed }">
+      <Form @submit.prevent="handleSubmit(submit)">
+        <h1>비밀번호 변경</h1>
+        <ValidationProvider name="before-password" rules="password|required" v-slot="{ errors }">
+          <TextField
+            v-model="beforePassword"
+            name="before-password"
+            type="password"
+            label="기존 비밀번호"
+            placeholder="기존 비밀번호를 입력해 주세요"
+            required
+          />
+          <p class="rule-field">{{ errors[0] }}</p>
+        </ValidationProvider>
+        <ValidationProvider name="password" rules="password|required" v-slot="{ errors }">
+          <TextField
+            v-model="password"
+            name="password"
+            type="password"
+            label="새 비밀번호"
+            placeholder="비밀번호를 입력해 주세요"
+            required
+          />
+          <p class="rule-field">{{ errors[0] }}</p>
+        </ValidationProvider>
+        <ValidationProvider rules="password|rePassword:@password|required" v-slot="{ errors }">
+          <TextField
+            v-model="rePassword"
+            name="re-password"
+            type="password"
+            label="비밀번호 확인"
+            placeholder="비밀번호를 다시 한 번 입력해 주세요"
+            required
+          />
+          <p class="rule-field">{{ errors[0] }}</p>
+        </ValidationProvider>
+        <template v-slot:actions>
+          <Button type="button" @click="back" cancel value="이전" />
+          <Button type="submit" :disabled="!passed" value="확인" />
+        </template>
+      </Form>
+    </ValidationObserver>
+  </div>
+</template>
+
+<script>
+import { Button, Form, TextField } from "@/components/form"
+import * as Api from "@/api"
+
+export default {
+  name: "PasswordEdit",
+  components: {
+    Form,
+    Button,
+    TextField,
+  },
+  data: () => ({
+    beforePassword: "",
+    password: "",
+    rePassword: "",
+  }),
+  methods: {
+    back() {
+      this.$router.go(-1)
+    },
+    async submit() {
+      try {
+        await Api.fetchPasswordEdit({
+          token: this.$store.getters["token"],
+          beforePassword: this.beforePassword,
+          newPassword: this.password,
+        })
+        alert("비밀번호가 변경되었습니다. 다시 로그인해주세요.")
+        this.$store.dispatch("resetToken")
+        this.$router.push("/login")
+      } catch (e) {
+        alert(e.response.data.message)
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.password-edit {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.rule-field {
+  margin-left: 8px;
+  font-size: 12px;
+  color: #ff0000;
+}
+</style>

--- a/src/main/kotlin/apply/application/ApplicantDtos.kt
+++ b/src/main/kotlin/apply/application/ApplicantDtos.kt
@@ -108,3 +108,11 @@ data class ResetPasswordRequest(
     @field:NotNull
     val birthday: LocalDate
 )
+
+data class EditPasswordRequest(
+    @field:NotNull
+    val beforePassword: Password,
+
+    @field:NotNull
+    val newPassword: Password
+)

--- a/src/main/kotlin/apply/application/ApplicantDtos.kt
+++ b/src/main/kotlin/apply/application/ApplicantDtos.kt
@@ -111,7 +111,7 @@ data class ResetPasswordRequest(
 
 data class EditPasswordRequest(
     @field:NotNull
-    val beforePassword: Password,
+    val password: Password,
 
     @field:NotNull
     val newPassword: Password

--- a/src/main/kotlin/apply/application/ApplicantService.kt
+++ b/src/main/kotlin/apply/application/ApplicantService.kt
@@ -8,7 +8,6 @@ import apply.domain.applicant.exception.ApplicantValidateException
 import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.cheater.CheaterRepository
 import apply.security.JwtTokenProvider
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import support.createLocalDate
@@ -53,12 +52,6 @@ class ApplicantService(
         return jwtTokenProvider.createToken(applicant.email)
     }
 
-    fun changePassword(applicantId: Long, newPassword: String) {
-        applicantRepository.findByIdOrNull(applicantId)
-            ?.run { password = Password(newPassword) }
-            ?: throw IllegalArgumentException("존재하지 않는 사용자입니다.")
-    }
-
     fun generateTokenByLogin(applicantVerifyInformation: ApplicantVerifyInformation): String {
         return when (
             applicantRepository.existsByNameAndEmailAndBirthdayAndPassword(
@@ -81,6 +74,14 @@ class ApplicantService(
         )?.run {
             passwordGenerator.generate().also { password = Password(it) }
         } ?: throw ApplicantValidateException()
+    }
+
+    fun editPassword(applicant: Applicant, request: EditPasswordRequest) {
+        if (applicant.isSamePassword(request.beforePassword)) {
+            applicant.password = request.newPassword
+        } else {
+            throw ApplicantValidateException()
+        }
     }
 
     @PostConstruct

--- a/src/main/kotlin/apply/application/ApplicantService.kt
+++ b/src/main/kotlin/apply/application/ApplicantService.kt
@@ -77,11 +77,11 @@ class ApplicantService(
     }
 
     fun editPassword(applicant: Applicant, request: EditPasswordRequest) {
-        if (applicant.isSamePassword(request.beforePassword)) {
-            applicant.password = request.newPassword
-        } else {
-            throw ApplicantValidateException()
-        }
+        applicant.takeIf { it.isSamePassword(request.beforePassword) }
+            ?.run {
+                applicant.password = request.newPassword
+                applicantRepository.save(applicant)
+            } ?: throw ApplicantValidateException()
     }
 
     @PostConstruct

--- a/src/main/kotlin/apply/application/ApplicantService.kt
+++ b/src/main/kotlin/apply/application/ApplicantService.kt
@@ -77,7 +77,7 @@ class ApplicantService(
     }
 
     fun editPassword(applicant: Applicant, request: EditPasswordRequest) {
-        applicant.takeIf { it.isSamePassword(request.beforePassword) }
+        applicant.takeIf { it.isSamePassword(request.password) }
             ?.run {
                 applicant.password = request.newPassword
                 applicantRepository.save(applicant)

--- a/src/main/kotlin/apply/application/ApplicationFormDtos.kt
+++ b/src/main/kotlin/apply/application/ApplicationFormDtos.kt
@@ -20,20 +20,11 @@ data class UpdateApplicationFormRequest(
 
     val isSubmitted: Boolean = false,
 
-    val answers: List<AnswerRequest> = emptyList(),
-
-    val password: String
+    val answers: List<AnswerRequest> = emptyList()
 ) {
     constructor(
-        recruitmentId: Long,
-        referenceUrl: String,
-        isSubmitted: Boolean,
-        answers: List<AnswerRequest>
-    ) : this(recruitmentId, referenceUrl, isSubmitted, answers, "")
-
-    constructor(
         recruitmentId: Long
-    ) : this(recruitmentId, "", false, emptyList(), "")
+    ) : this(recruitmentId, "", false, emptyList())
 }
 
 data class AnswerRequest(

--- a/src/main/kotlin/apply/application/ApplicationFormDtos.kt
+++ b/src/main/kotlin/apply/application/ApplicationFormDtos.kt
@@ -16,16 +16,12 @@ data class UpdateApplicationFormRequest(
     val recruitmentId: Long,
 
     @field:Size(min = 0, max = 255)
-    val referenceUrl: String,
+    val referenceUrl: String = "",
 
     val isSubmitted: Boolean = false,
 
     val answers: List<AnswerRequest> = emptyList()
-) {
-    constructor(
-        recruitmentId: Long
-    ) : this(recruitmentId, "", false, emptyList())
-}
+)
 
 data class AnswerRequest(
     @field:Size(min = 1)

--- a/src/main/kotlin/apply/application/ApplicationFormService.kt
+++ b/src/main/kotlin/apply/application/ApplicationFormService.kt
@@ -15,8 +15,7 @@ import javax.transaction.Transactional
 @Service
 class ApplicationFormService(
     private val applicationFormRepository: ApplicationFormRepository,
-    private val recruitmentRepository: RecruitmentRepository,
-    private val applicantService: ApplicantService
+    private val recruitmentRepository: RecruitmentRepository
 ) {
 
     fun findAllByRecruitmentId(recruitmentId: Long): List<ApplicationForm> =
@@ -50,9 +49,6 @@ class ApplicationFormService(
             }.toMutableList()
         )
         applicationForm.update(request.referenceUrl, answers)
-        if (request.password.isNotBlank()) {
-            applicantService.changePassword(applicantId, request.password)
-        }
         if (request.isSubmitted) {
             applicationForm.submit()
         }

--- a/src/main/kotlin/apply/domain/applicant/Applicant.kt
+++ b/src/main/kotlin/apply/domain/applicant/Applicant.kt
@@ -45,6 +45,10 @@ class Applicant(
         }
     }
 
+    fun isSamePassword(password: Password): Boolean {
+        return this.password == password
+    }
+
     private fun getInformation() = ApplicantInformation(
         name = name,
         email = email,

--- a/src/main/kotlin/apply/ui/api/ApplicantRestController.kt
+++ b/src/main/kotlin/apply/ui/api/ApplicantRestController.kt
@@ -3,8 +3,11 @@ package apply.ui.api
 import apply.application.ApplicantInformation
 import apply.application.ApplicantService
 import apply.application.ApplicantVerifyInformation
+import apply.application.EditPasswordRequest
 import apply.application.MailService
 import apply.application.ResetPasswordRequest
+import apply.domain.applicant.Applicant
+import apply.security.LoginApplicant
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -34,6 +37,16 @@ class ApplicantRestController(
     fun resetPassword(@RequestBody @Valid resetPasswordRequest: ResetPasswordRequest): ResponseEntity<Unit> {
         val newPassword = applicantService.resetPassword(resetPasswordRequest)
         mailService.sendPasswordResetMail(resetPasswordRequest, newPassword)
+
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/edit-password")
+    fun editPassword(
+        @RequestBody @Valid editPasswordRequest: EditPasswordRequest,
+        @LoginApplicant applicant: Applicant
+    ): ResponseEntity<Unit> {
+        applicantService.editPassword(applicant, editPasswordRequest)
 
         return ResponseEntity.noContent().build()
     }

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -96,11 +96,11 @@ internal class ApplicantServiceTest {
         validApplicantPasswordFindRequest.copy(birthday = createLocalDate(1995, 4, 4))
 
     private val validEditPasswordRequest = EditPasswordRequest(
-        beforePassword = Password("password"),
+        password = Password("password"),
         newPassword = Password("NEW_PASSWORD")
     )
 
-    private val inValidEditPasswordRequest = validEditPasswordRequest.copy(beforePassword = Password("wrongPassword"))
+    private val inValidEditPasswordRequest = validEditPasswordRequest.copy(password = Password("wrongPassword"))
 
     private val applicant = validApplicantRequest.toEntity(APPLICANT_ID)
 

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -224,6 +224,8 @@ internal class ApplicantServiceTest {
 
     @Test
     fun `지원자의 비밀번호를 수정한다`() {
+        given(applicantRepository.save(applicant)).willReturn(applicant)
+
         assertDoesNotThrow { applicantService.editPassword(applicant, validEditPasswordRequest) }
     }
 

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anySet
@@ -93,6 +94,13 @@ internal class ApplicantServiceTest {
 
     private val inValidApplicantPasswordFindRequest =
         validApplicantPasswordFindRequest.copy(birthday = createLocalDate(1995, 4, 4))
+
+    private val validEditPasswordRequest = EditPasswordRequest(
+        beforePassword = Password("password"),
+        newPassword = Password("NEW_PASSWORD")
+    )
+
+    private val inValidEditPasswordRequest = validEditPasswordRequest.copy(beforePassword = Password("wrongPassword"))
 
     private val applicant = validApplicantRequest.toEntity(APPLICANT_ID)
 
@@ -210,6 +218,18 @@ internal class ApplicantServiceTest {
     @Test
     fun `비밀번호를 초기화를 위한 검증 데이터가 올바르지 않을시 예외가 발생한다`() {
         assertThatThrownBy { applicantService.resetPassword(inValidApplicantPasswordFindRequest) }
+            .isInstanceOf(ApplicantValidateException::class.java)
+            .hasMessage("요청 정보가 기존 지원자 정보와 일치하지 않습니다")
+    }
+
+    @Test
+    fun `지원자의 비밀번호를 수정한다`() {
+        assertDoesNotThrow { applicantService.editPassword(applicant, validEditPasswordRequest) }
+    }
+
+    @Test
+    fun `비밀번호 수정시 기존 비밀번호를 다르게 입력했을경우 예외가 발생한다`() {
+        assertThatThrownBy { applicantService.editPassword(applicant, inValidEditPasswordRequest) }
             .isInstanceOf(ApplicantValidateException::class.java)
             .hasMessage("요청 정보가 기존 지원자 정보와 일치하지 않습니다")
     }

--- a/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
@@ -12,7 +12,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -52,7 +51,7 @@ class ApplicationFormServiceTest {
     @BeforeEach
     internal fun setUp() {
         this.applicationFormService =
-            ApplicationFormService(applicationFormRepository, recruimentRepository, applicantService)
+            ApplicationFormService(applicationFormRepository, recruimentRepository)
 
         applicationForm1 = createApplicationForm()
 
@@ -106,8 +105,7 @@ class ApplicationFormServiceTest {
             recruitmentId = applicationForm1.recruitmentId,
             referenceUrl = applicationForm1.referenceUrl,
             isSubmitted = false,
-            answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) },
-            password = "12345678"
+            answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) }
         )
 
         recruitment = Recruitment(
@@ -221,18 +219,6 @@ class ApplicationFormServiceTest {
         every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
 
         assertDoesNotThrow { applicationFormService.update(1L, updateApplicationFormRequest) }
-    }
-
-    @Test
-    fun `비밀번호가 있는 경우 비밀번호를 수정한다`() {
-        every { applicantService.changePassword(any(), any()) } returns mockk()
-        every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
-        every { recruimentRepository.findByIdOrNull(any()) } returns recruitment
-        every { applicationFormRepository.findByRecruitmentIdAndApplicantId(any(), any()) } returns applicationForm1
-
-        applicationFormService.update(1L, updateApplicationFormRequestWithPassword)
-
-        verify { applicantService.changePassword(1L, updateApplicationFormRequestWithPassword.password) }
     }
 
     @Test

--- a/src/test/kotlin/apply/domain/applicant/ApplicantTest.kt
+++ b/src/test/kotlin/apply/domain/applicant/ApplicantTest.kt
@@ -2,10 +2,13 @@ package apply.domain.applicant
 
 import apply.application.ApplicantInformation
 import apply.domain.applicant.exception.ApplicantValidateException
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import support.createLocalDate
 
 internal class ApplicantTest {
@@ -37,5 +40,13 @@ internal class ApplicantTest {
         assertThatThrownBy { applicant.validate(invalidApplicantInformation) }
             .isInstanceOf(ApplicantValidateException::class.java)
             .hasMessage("요청 정보가 기존 지원자 정보와 일치하지 않습니다")
+    }
+
+    @ParameterizedTest
+    @CsvSource("password,true", "wrongPassword,false")
+    fun `지원자의 기존 비밀번호와 다른 비밀번호와의 일치 여부를 확인한다`(password: String, expected: Boolean) {
+        val samePassword = Password(password)
+
+        assertThat(applicant.isSamePassword(samePassword)).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/apply/ui/api/ApplicantRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/ApplicantRestControllerTest.kt
@@ -108,11 +108,11 @@ internal class ApplicantRestControllerTest(
         applicantPasswordFindRequest.copy(birthday = createLocalDate(1995, 4, 4))
 
     private val validEditPasswordRequest = EditPasswordRequest(
-        beforePassword = Password("password"),
+        password = Password("password"),
         newPassword = Password("NEW_PASSWORD")
     )
 
-    private val inValidEditPasswordRequest = validEditPasswordRequest.copy(beforePassword = Password("wrongPassword"))
+    private val inValidEditPasswordRequest = validEditPasswordRequest.copy(password = Password("wrongPassword"))
 
     @BeforeEach
     internal fun setUp(webApplicationContext: WebApplicationContext) {


### PR DESCRIPTION
Resolves #162 

- 지원서 수정, 작성시 이름과 비밀번호, 비밀번호 확인란을 지운다.
- 비밀번호를 수정할 수 있는 페이지를 따로 만든다.
---
이슈1 : 모바일로 전환하여 보면 이렇습니다.(비밀번호 수정 페이지만 해당)

![image](https://user-images.githubusercontent.com/7259103/95949693-34ad7700-0e2e-11eb-991b-e64b30b8d84e.png)

이슈2 : #163 과 새로생긴 비밀번호 수정 버튼 위치 충돌 예상

![image](https://user-images.githubusercontent.com/7259103/95949966-b43b4600-0e2e-11eb-9c2c-bf832a7c2319.png)