### PR TITLE
fix(selection): modify the application so that it can be viewed when a recruitment item is added

### DIFF
--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -2,10 +2,10 @@ package apply.ui.admin.selections
 
 import apply.application.ApplicantResponse
 import apply.application.ApplicantService
-import apply.application.ExcelService
 import apply.application.EvaluationService
 import apply.application.EvaluationTargetResponse
 import apply.application.EvaluationTargetService
+import apply.application.ExcelService
 import apply.application.RecruitmentItemService
 import apply.application.RecruitmentService
 import apply.domain.applicationform.ApplicationForm
@@ -207,7 +207,7 @@ class SelectionView(
             .toMap()
         val items = recruitmentItemService.findByRecruitmentIdOrderByPosition(recruitmentId)
             .map {
-                createItem(it.title, createAnswer(answers.getValue(it.id)))
+                createItem(it.title, createAnswer(answers.getOrDefault(it.id, "")))
             }.toTypedArray()
         return addIfExist(items, applicationForm.referenceUrl)
     }


### PR DESCRIPTION
resolves #182 

프런트에서 관리자 화면을 출력하는 방식으로 수정했습니다.

백엔드에서 처리하는게 좋을까요?
백엔드에서 하면 지원서의 응답(`ApplicantForm#answers`)들과 모집항목(`RecruitmentItem`)들을 비교해서 현재 모집항목들에 맞게 만들어서 줄 것 같아요
공수가 클 거 같진 않은데, 항상 지원서 응답을 현재 모집항목과 싱크를 맞춰서 주는게 맞는지 고민이네요

