### PR TITLE
refactor(apply): migrate root component to react

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,36 @@
+* {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Apple SD Gothic Neo", Roboto, "Helvetica Neue", Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #ced6e0;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.main-view {
+  flex: 1 0 auto;
+}
+
+button {
+  background-color: #ffffff;
+  border-radius: 10px;
+  font-size: 16px;
+  border: 0;
+  outline: 0;
+}
+
+button:active {
+  background-color: #cccccc;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,64 @@
-function App() {
-  return <div>hi</div>;
-}
+import React from "react";
+import { BrowserRouter, Switch, Route } from "react-router-dom";
+import axios from "axios";
+import PrivateRoute from "./components/PrivateRoute/PrivateRoute";
+import MainHeader from "./components/MainHeader/MainHeader";
+import MainFooter from "./components/MainFooter/MainFooter";
+import Recruits from "./pages/Recruits";
+import ApplicantRegister from "./pages/ApplicantRegister";
+import ApplicationRegister from "./pages/ApplicationRegister";
+import Login from "./pages/Login";
+import PasswordFind from "./pages/PasswordFind";
+import PasswordEdit from "./pages/PasswordEdit";
+import PasswordFindResult from "./pages/PasswordFindResult";
+import useTokenContext from "./hooks/useTokenContext";
+import "./App.css";
+
+axios.defaults.baseURL = "http://localhost:8080";
+
+const App = () => {
+  const { token } = useTokenContext();
+
+  return (
+    <>
+      <BrowserRouter>
+        <MainHeader />
+        <div className="main-view">
+          <Switch>
+            <Route path={["/", "/recruits"]} exact>
+              <Recruits />
+            </Route>
+            <Route path="/applicants/new" exact>
+              <ApplicantRegister />
+            </Route>
+            <Route path="/application-forms/new" exact>
+              <ApplicationRegister />
+            </Route>
+            <Route path="/login" exact>
+              <Login />
+            </Route>
+            <Route path="/find" exact>
+              <PasswordFind />
+            </Route>
+            <Route path="/find/result" exact>
+              <PasswordFindResult />
+            </Route>
+            <PrivateRoute
+              path="/application-forms/edit"
+              isAuthenticated={token !== ""}
+              exact
+            >
+              <ApplicationRegister />
+            </PrivateRoute>
+            <PrivateRoute path="/edit" isAuthenticated={token !== ""} exact>
+              <PasswordEdit />
+            </PrivateRoute>
+          </Switch>
+        </div>
+        <MainFooter />
+      </BrowserRouter>
+    </>
+  );
+};
 
 export default App;

--- a/frontend/src/components/MainFooter/MainFooter.js
+++ b/frontend/src/components/MainFooter/MainFooter.js
@@ -15,6 +15,7 @@ const MainFooter = () => {
             <img
               className={styles.logo}
               src="/assets/logo/logo_full_white.png"
+              alt="우아한테크코스 로고"
             />
           </a>
         </div>

--- a/frontend/src/components/MainHeader/MainHeader.js
+++ b/frontend/src/components/MainHeader/MainHeader.js
@@ -12,6 +12,7 @@ const MainHeader = () => {
             <img
               className={styles.logo}
               src="/assets/logo/logo_full_dark.png"
+              alt="우아한테크코스 로고"
             />
           </Link>
           <h3 className={styles.title}>

--- a/frontend/src/components/PrivateRoute/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute/PrivateRoute.js
@@ -1,0 +1,13 @@
+import { Redirect, Route } from "react-router-dom";
+
+const PrivateRoute = ({ isAuthenticated, children, ...props }) => {
+  if (!isAuthenticated) alert("로그인이 필요합니다.");
+
+  return (
+    <Route {...props}>
+      {isAuthenticated ? children : <Redirect to="/login" />}
+    </Route>
+  );
+};
+
+export default PrivateRoute;

--- a/frontend/src/hooks/useRecruitmentContext.js
+++ b/frontend/src/hooks/useRecruitmentContext.js
@@ -1,0 +1,14 @@
+import { useContext, createContext } from "react";
+
+export const RecruitmentContext = createContext();
+
+const useRecruitmentContext = () => {
+  const recruitmentContext = useContext(RecruitmentContext);
+
+  if (!recruitmentContext)
+    throw Error("recruitmentContext가 존재하지 않습니다");
+
+  return recruitmentContext;
+};
+
+export default useRecruitmentContext;

--- a/frontend/src/hooks/useTokenContext.js
+++ b/frontend/src/hooks/useTokenContext.js
@@ -1,0 +1,13 @@
+import { useContext, createContext } from "react";
+
+export const TokenContext = createContext();
+
+const useTokenContext = () => {
+  const tokenContext = useContext(TokenContext);
+
+  if (!tokenContext) throw Error("TokenContext가 존재하지 않습니다");
+
+  return tokenContext;
+};
+
+export default useTokenContext;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,10 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import TokenProvider from "./provider/TokenProvider";
+import RecruitmentProvider from "./provider/RecruitmentProvider";
 import App from "./App";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <TokenProvider>
+      <RecruitmentProvider>
+        <App />
+      </RecruitmentProvider>
+    </TokenProvider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/frontend/src/pages/ApplicantRegister.js
+++ b/frontend/src/pages/ApplicantRegister.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ApplicantRegister = () => {
+  return <div>ApplicantRegister</div>;
+};
+
+export default ApplicantRegister;

--- a/frontend/src/pages/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ApplicationRegister = () => {
+  return <div>ApplicationRegister</div>;
+};
+
+export default ApplicationRegister;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Login = () => {
+  return <div>Login</div>;
+};
+
+export default Login;

--- a/frontend/src/pages/PasswordEdit.js
+++ b/frontend/src/pages/PasswordEdit.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const PasswordEdit = () => {
+  return <div>PasswordEdit</div>;
+};
+
+export default PasswordEdit;

--- a/frontend/src/pages/PasswordFind.js
+++ b/frontend/src/pages/PasswordFind.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const PasswordFind = () => {
+  return <div>PasswordFind</div>;
+};
+
+export default PasswordFind;

--- a/frontend/src/pages/PasswordFindResult.js
+++ b/frontend/src/pages/PasswordFindResult.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const PasswordFindResult = () => {
+  return <div>PasswordFindResult</div>;
+};
+
+export default PasswordFindResult;

--- a/frontend/src/pages/Recruits.js
+++ b/frontend/src/pages/Recruits.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Recruits = () => {
+  return <div>recruits</div>;
+};
+
+export default Recruits;

--- a/frontend/src/provider/RecruitmentProvider.js
+++ b/frontend/src/provider/RecruitmentProvider.js
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from "react";
+import { RecruitmentContext } from "../hooks/useRecruitmentContext";
+import * as Api from "../api";
+
+const RecruitmentProvider = ({ children }) => {
+  const [recruitments, setRecruitments] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data: recruitments } = await Api.fetchRecruitments();
+
+      setRecruitments(recruitments.sort((a, b) => b.id - a.id));
+    };
+
+    fetchData();
+  }, []);
+
+  const fetchMyApplicationForms = async (payload) => {
+    const { data: myApplicationForms } = await Api.fetchMyApplicationForms(
+      payload
+    );
+
+    return myApplicationForms;
+  };
+
+  return (
+    <RecruitmentContext.Provider
+      value={{ recruitments, fetchMyApplicationForms }}
+    >
+      {children}
+    </RecruitmentContext.Provider>
+  );
+};
+
+export default RecruitmentProvider;

--- a/frontend/src/provider/TokenProvider.js
+++ b/frontend/src/provider/TokenProvider.js
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { TokenContext } from "../hooks/useTokenContext";
+import * as Api from "../api";
+
+const TokenProvider = ({ children }) => {
+  const [token, setToken] = useState("");
+
+  const fetchRegister = async (payload) => {
+    const { data: token } = await Api.fetchRegister(payload);
+
+    setToken(token);
+  };
+
+  const fetchLogin = async (payload) => {
+    const { data: token } = await Api.fetchLogin(payload);
+
+    setToken(token);
+  };
+
+  const resetToken = () => {
+    setToken("");
+  };
+
+  return (
+    <TokenContext.Provider
+      value={{ token, fetchRegister, fetchLogin, resetToken }}
+    >
+      {children}
+    </TokenContext.Provider>
+  );
+};
+
+export default TokenProvider;


### PR DESCRIPTION
## App 컴포넌트를 react로 전환

- 브랜과 페어로 진행했습니다.

### 변경사항

- 라우팅 설정
  - 로그인이 필요한 페이지에 접근 시 `alert` 후 로그인 페이지로 리다이렉트
- 기존 `vuex`로 관리되던 전역상태를 `ContextAPI`를 사용하도록 변경

### 공유할 내용

- 백엔드 서버 api 응답(모집 목록)이 비어있는데, api 명세가 제공되거나 mock 데이터를 추가해주시면 개발에 큰 도움이 될 것 같습니다.

close #262