### PR TITLE
feat(apply): change to keep logged in after refresh

### DIFF
--- a/frontend/src/constants/key.js
+++ b/frontend/src/constants/key.js
@@ -1,0 +1,3 @@
+export const LOCAL_STORAGE_KEY = {
+  ACCESS_TOKEN: "accessToken",
+};

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -15,7 +15,7 @@ export const ERROR_MESSAGE = {
   API: {
     ALREADY_REGISTER: "이미 지원한 이력이 있습니다.",
     ALREADY_HAS_APPLICATION:
-      "이미 신청서를 작성했습니다. 로그인 페이지로 이동합니다.",
+      "이미 신청서를 작성했습니다. 내 지원서 목록으로 이동합니다.",
     FETCHING_MY_APPLICATION: "내 지원서를 불러오는데 실패했습니다.",
   },
   ACCESS: {
@@ -25,7 +25,7 @@ export const ERROR_MESSAGE = {
     CANNOT_FIND_FORM_CONTEXT: "FormContext가 존재하지 않습니다.",
     CANNOT_FIND_RECRUITMENT_CONTEXT: "recruitmentContext가 존재하지 않습니다",
     CANNOT_FIND_TOKEN_CONTEXT: "TokenContext가 존재하지 않습니다",
-  }
+  },
 };
 
 export const SUCCESS_MESSAGE = {

--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -14,8 +14,6 @@ export const ERROR_MESSAGE = {
   },
   API: {
     ALREADY_REGISTER: "이미 지원한 이력이 있습니다.",
-    ALREADY_HAS_APPLICATION:
-      "이미 신청서를 작성했습니다. 내 지원서 목록으로 이동합니다.",
     FETCHING_MY_APPLICATION: "내 지원서를 불러오는데 실패했습니다.",
   },
   ACCESS: {

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -21,6 +21,7 @@ import {
   SUCCESS_MESSAGE,
 } from "../../constants/messages";
 import PATH, { PARAM } from "../../constants/path";
+import { RECRUITS_TAB } from "../../constants/tab";
 import useForm from "../../hooks/useForm";
 import useFormContext from "../../hooks/useFormContext";
 import useRecruitmentContext from "../../hooks/useRecruitmentContext";
@@ -151,7 +152,11 @@ const ApplicationRegister = () => {
 
         if (isAlreadyRegister) {
           alert(ERROR_MESSAGE.API.ALREADY_HAS_APPLICATION);
-          history.replace(PATH.LOGIN);
+
+          history.push({
+            pathname: PATH.RECRUITS,
+            search: generateQuery({ status: RECRUITS_TAB.APPLIED.name }),
+          });
         } else {
           alert(error.response.data.message);
           history.replace(PATH.HOME);

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -21,7 +21,6 @@ import {
   SUCCESS_MESSAGE,
 } from "../../constants/messages";
 import PATH, { PARAM } from "../../constants/path";
-import { RECRUITS_TAB } from "../../constants/tab";
 import useForm from "../../hooks/useForm";
 import useFormContext from "../../hooks/useFormContext";
 import useRecruitmentContext from "../../hooks/useRecruitmentContext";
@@ -151,12 +150,7 @@ const ApplicationRegister = () => {
           error.response.data.message === ERROR_MESSAGE.API.ALREADY_REGISTER;
 
         if (isAlreadyRegister) {
-          alert(ERROR_MESSAGE.API.ALREADY_HAS_APPLICATION);
-
-          history.push({
-            pathname: PATH.RECRUITS,
-            search: generateQuery({ status: RECRUITS_TAB.APPLIED.name }),
-          });
+          await fetchApplicationForm();
         } else {
           alert(error.response.data.message);
           history.replace(PATH.HOME);

--- a/frontend/src/provider/TokenProvider.js
+++ b/frontend/src/provider/TokenProvider.js
@@ -2,24 +2,30 @@ import React, { useState } from "react";
 
 import { TokenContext } from "../hooks/useTokenContext";
 import * as Api from "../api";
+import { LOCAL_STORAGE_KEY } from "../constants/key";
 
 const TokenProvider = ({ children }) => {
-  const [token, setToken] = useState("");
+  const [token, setToken] = useState(
+    () => localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN) || ""
+  );
 
   const postRegister = async (payload) => {
     const { data: token } = await Api.fetchRegister(payload);
 
     setToken(token);
+    localStorage.setItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN, token);
   };
 
   const fetchLogin = async (payload) => {
     const { data: token } = await Api.fetchLogin(payload);
 
     setToken(token);
+    localStorage.setItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN, token);
   };
 
   const resetToken = () => {
     setToken("");
+    localStorage.setItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN, "");
   };
 
   return (


### PR DESCRIPTION
- 로그인시 accessToken을 로컬스토리지에 저장
- 초기 App실행될 때 로컬스토리지에서 토큰 가져옴
- 지원서 작성 페이지에서는 createForm을 호출하는데, 이미 만들어진 경우라면 조회 api를 호출하도록 변경
- 이야기 해볼 거리
  - 토큰 유효시간이 제한될 것인지
  - 로컬스토리지에 저장하는것이 적절할지

관련 이슈: #44