### PR TITLE
feat(apply): implement password input capslock alert

### DIFF
--- a/frontend/src/constants/messages.js
+++ b/frontend/src/constants/messages.js
@@ -7,6 +7,7 @@ export const ERROR_MESSAGE = {
     NAME: "정확한 한글 이름을 입력해 주세요.",
     PASSWORD:
       "영문, 숫자, 특수문자 포함하여 8자에서 20자 이내로 입력해 주세요.",
+    PASSWORD_CAPSLOCK: "CapsLock이 켜져 있습니다.",
     RE_PASSWORD: "비밀번호를 확인해주세요.",
     PHONE_NUMBER: "정확한 전화번호를 입력해 주세요. ex) 010-1234-5678",
     REQUIRED: "필수 정보입니다.",

--- a/frontend/src/hooks/useForm.js
+++ b/frontend/src/hooks/useForm.js
@@ -34,7 +34,7 @@ const useForm = ({ validators, submit }) => {
     }
   };
 
-  const handleKeyUp = (event) => {
+  const handleCapsLockState = (event) => {
     if (event.target.type !== "password") return;
 
     setErrorMessage((prev) => ({
@@ -90,7 +90,7 @@ const useForm = ({ validators, submit }) => {
     isValid,
     isEmpty,
     handleChange,
-    handleKeyUp,
+    handleCapsLockState,
     handleSubmit,
     register,
     unRegister,

--- a/frontend/src/hooks/useForm.js
+++ b/frontend/src/hooks/useForm.js
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { ERROR_MESSAGE } from "../constants/messages";
+
 const useForm = ({ validators, submit }) => {
   const [value, setValue] = useState({});
   const [errorMessage, setErrorMessage] = useState({});
@@ -16,10 +18,12 @@ const useForm = ({ validators, submit }) => {
     }
 
     const validator = validators?.[target.name];
+
     if (!validator) return;
 
     try {
       const result = validator(target.value);
+
       if (typeof result === "function") {
         result(value);
       }
@@ -28,6 +32,17 @@ const useForm = ({ validators, submit }) => {
     } catch (error) {
       setErrorMessage((prev) => ({ ...prev, [target.name]: error.message }));
     }
+  };
+
+  const handleKeyUp = (event) => {
+    if (event.target.type !== "password") return;
+
+    setErrorMessage((prev) => ({
+      ...prev,
+      [event.target.name]: event.getModifierState("CapsLock")
+        ? ERROR_MESSAGE.VALIDATION.PASSWORD_CAPSLOCK
+        : prev[event.target.name],
+    }));
   };
 
   const handleSubmit = (event) => {
@@ -59,6 +74,7 @@ const useForm = ({ validators, submit }) => {
 
       return { ...prev };
     });
+
     setErrorMessage((prev) => {
       for (const val in prev) {
         prev[val] = null;
@@ -74,6 +90,7 @@ const useForm = ({ validators, submit }) => {
     isValid,
     isEmpty,
     handleChange,
+    handleKeyUp,
     handleSubmit,
     register,
     unRegister,

--- a/frontend/src/provider/FormProvider/InputField.js
+++ b/frontend/src/provider/FormProvider/InputField.js
@@ -3,9 +3,15 @@ import { TextField } from "../../components/form";
 import useFormContext from "../../hooks/useFormContext";
 import PropTypes from "prop-types";
 
-const InputField = ({ name, initialValue, ...props }) => {
-  const { value, errorMessage, handleChange, register, unRegister } =
-    useFormContext();
+const InputField = ({ name, initialValue, type, ...props }) => {
+  const {
+    value,
+    errorMessage,
+    handleChange,
+    handleKeyUp,
+    register,
+    unRegister,
+  } = useFormContext();
 
   useEffect(() => {
     register(name, initialValue);
@@ -18,9 +24,11 @@ const InputField = ({ name, initialValue, ...props }) => {
   return (
     <TextField
       name={name}
+      type={type ?? "text"}
       value={value[name]}
       errorMessage={errorMessage[name]}
       onChange={handleChange}
+      onKeyUp={type === "password" ? handleKeyUp : null}
       {...props}
     />
   );

--- a/frontend/src/provider/FormProvider/InputField.js
+++ b/frontend/src/provider/FormProvider/InputField.js
@@ -3,12 +3,12 @@ import { TextField } from "../../components/form";
 import useFormContext from "../../hooks/useFormContext";
 import PropTypes from "prop-types";
 
-const InputField = ({ name, initialValue, type, ...props }) => {
+const InputField = ({ name, initialValue, type = "text", ...props }) => {
   const {
     value,
     errorMessage,
     handleChange,
-    handleKeyUp,
+    handleCapsLockState,
     register,
     unRegister,
   } = useFormContext();
@@ -24,11 +24,11 @@ const InputField = ({ name, initialValue, type, ...props }) => {
   return (
     <TextField
       name={name}
-      type={type ?? "text"}
+      type={type}
       value={value[name]}
       errorMessage={errorMessage[name]}
       onChange={handleChange}
-      onKeyUp={type === "password" ? handleKeyUp : null}
+      onKeyUp={type === "password" ? handleCapsLockState : null}
       {...props}
     />
   );


### PR DESCRIPTION
keyup 이벤트의 getModifierState 를 활용해서 CapsLock을 감지합니다.

이후 input하단의 에러메시지로 CapsLock이 켜진 상태임을 알립니다.

![image](https://user-images.githubusercontent.com/44419181/134682174-d7964d20-89a3-49ad-9f0e-f563da6f5aef.png)

기존의 onChange 이벤트에서는 해당 메서드가 존재하지 않아서, keyUp이벤트를 감지하도록 input prop에 추가했습니다.

[참고 문서](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState)

브라우저 지원이 모디열키마다 들쑥날쑥인데 CapsLock은 전브라우저 다 지원합니당 

![image](https://user-images.githubusercontent.com/44419181/134682652-2ac10bc2-d784-44a0-826e-14a804301b2c.png)
