### PR TITLE
feat(term): implement term management view

### DIFF
--- a/src/main/kotlin/apply/application/RecruitmentService.kt
+++ b/src/main/kotlin/apply/application/RecruitmentService.kt
@@ -5,7 +5,6 @@ import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.recruitment.getById
 import apply.domain.recruitmentitem.RecruitmentItem
 import apply.domain.recruitmentitem.RecruitmentItemRepository
-import apply.domain.term.Term
 import apply.domain.term.TermRepository
 import apply.domain.term.getById
 import org.springframework.stereotype.Service
@@ -69,10 +68,5 @@ class RecruitmentService(
         val term = termRepository.getById(recruitment.termId)
         val recruitmentItems = recruitmentItemRepository.findByRecruitmentIdOrderByPosition(recruitment.id)
         return RecruitmentData(recruitment, term, recruitmentItems)
-    }
-
-    fun findAllTermSelectData(): List<TermSelectData> {
-        val terms = listOf(Term.SINGLE) + termRepository.findAll().sortedBy { it.name }
-        return terms.map(::TermSelectData)
     }
 }

--- a/src/main/kotlin/apply/application/TermService.kt
+++ b/src/main/kotlin/apply/application/TermService.kt
@@ -2,7 +2,6 @@ package apply.application
 
 import apply.domain.term.Term
 import apply.domain.term.TermRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import javax.annotation.PostConstruct
@@ -29,10 +28,5 @@ class TermService(
     fun findAllTermSelectData(): List<TermSelectData> {
         val terms = listOf(Term.SINGLE) + termRepository.findAll().sortedBy { it.name }
         return terms.map(::TermSelectData)
-    }
-
-    fun getDataById(id: Long): TermSelectData {
-        val term = termRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("해당 id의 기수를 찾을 수 없습니다.")
-        return TermSelectData(term.name, term.id)
     }
 }

--- a/src/main/kotlin/apply/application/TermService.kt
+++ b/src/main/kotlin/apply/application/TermService.kt
@@ -1,0 +1,38 @@
+package apply.application
+
+import apply.domain.term.Term
+import apply.domain.term.TermRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import javax.annotation.PostConstruct
+
+@Transactional
+@Service
+class TermService(
+    private val termRepository: TermRepository
+) {
+    @PostConstruct
+    private fun populateDummy() {
+        if (termRepository.count() != 0L) {
+            return
+        }
+        val terms = listOf(
+            Term("1기"),
+            Term("2기"),
+            Term("3기"),
+            Term("4기")
+        )
+        termRepository.saveAll(terms)
+    }
+
+    fun findAllTermSelectData(): List<TermSelectData> {
+        val terms = listOf(Term.SINGLE) + termRepository.findAll().sortedBy { it.name }
+        return terms.map(::TermSelectData)
+    }
+
+    fun getDataById(id: Long): TermSelectData {
+        val term = termRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("해당 id의 기수를 찾을 수 없습니다.")
+        return TermSelectData(term.name, term.id)
+    }
+}

--- a/src/main/kotlin/apply/ui/admin/BaseLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/BaseLayout.kt
@@ -5,6 +5,7 @@ import apply.ui.admin.cheater.CheatersView
 import apply.ui.admin.evaluation.EvaluationsView
 import apply.ui.admin.mail.MailsView
 import apply.ui.admin.recruitment.RecruitmentsView
+import apply.ui.admin.term.TermsView
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.applayout.AppLayout
 import com.vaadin.flow.component.applayout.DrawerToggle
@@ -54,6 +55,7 @@ class BaseLayout(
     private fun createMenuItems(): List<MenuItem> {
         val recruitments = recruitmentService.findAll()
         return listOf(
+            "기수 관리" of TermsView::class.java,
             "모집 관리" of RecruitmentsView::class.java,
             "평가 관리" of EvaluationsView::class.java,
             "과제 관리".accordionOf("admin/missions", recruitments),

--- a/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
+++ b/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
@@ -32,7 +32,7 @@ class RecruitmentForm() : BindingIdentityFormLayout<RecruitmentData>(Recruitment
 
     init {
         val termButton = createTermManageButton()
-        add(title, term, termButton, startDateTime, endDateTime, recruitable, hidden)
+        add(term, termButton, title, startDateTime, endDateTime, recruitable, hidden)
         addFormItem(createAddButton(), "모집 항목")
         setResponsiveSteps(ResponsiveStep("0", 7))
         children.forEach {

--- a/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
+++ b/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
@@ -12,6 +12,7 @@ import support.views.BindingIdentityFormLayout
 import support.views.createBooleanRadioButtonGroup
 import support.views.createErrorSmallButton
 import support.views.createItemSelect
+import support.views.createPrimaryButton
 import support.views.createPrimarySmallButton
 import java.time.LocalDateTime
 
@@ -28,10 +29,22 @@ class RecruitmentForm() : BindingIdentityFormLayout<RecruitmentData>(Recruitment
     private val recruitmentItems: MutableList<RecruitmentItemForm> = mutableListOf()
 
     init {
-        add(title, term, startDateTime, endDateTime, recruitable, hidden)
+        val termButton = createTermManageButton()
+        add(title, term, termButton, startDateTime, endDateTime, recruitable, hidden)
         addFormItem(createAddButton(), "모집 항목")
-        setResponsiveSteps(ResponsiveStep("0", 1))
+        setResponsiveSteps(ResponsiveStep("0", 7))
+        children.forEach {
+            setColspan(it, 7)
+        }
+        setColspan(termButton,1)
+        setColspan(term, 6)
         drawRequired()
+    }
+
+    private fun createTermManageButton(): Button {
+        return createPrimaryButton("기수 관리") {
+
+        }
     }
 
     constructor(terms: List<TermSelectData>) : this() {

--- a/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
+++ b/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
@@ -3,6 +3,8 @@ package apply.ui.admin.recruitment
 import apply.application.RecruitmentData
 import apply.application.RecruitmentItemData
 import apply.application.TermSelectData
+import apply.ui.admin.term.TermsView
+import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.datetimepicker.DateTimePicker
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup
@@ -36,14 +38,14 @@ class RecruitmentForm() : BindingIdentityFormLayout<RecruitmentData>(Recruitment
         children.forEach {
             setColspan(it, 7)
         }
-        setColspan(termButton,1)
+        setColspan(termButton, 1)
         setColspan(term, 6)
         drawRequired()
     }
 
     private fun createTermManageButton(): Button {
         return createPrimaryButton("기수 관리") {
-
+            UI.getCurrent().navigate(TermsView::class.java)
         }
     }
 

--- a/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
+++ b/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentForm.kt
@@ -4,8 +4,6 @@ import apply.application.RecruitmentData
 import apply.application.RecruitmentItemData
 import apply.application.TermData
 import apply.application.TermResponse
-import apply.ui.admin.term.TermsView
-import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.datetimepicker.DateTimePicker
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup
@@ -15,7 +13,6 @@ import support.views.BindingIdentityFormLayout
 import support.views.createBooleanRadioButtonGroup
 import support.views.createErrorSmallButton
 import support.views.createItemSelect
-import support.views.createPrimaryButton
 import support.views.createPrimarySmallButton
 import java.time.LocalDateTime
 
@@ -32,15 +29,9 @@ class RecruitmentForm() : BindingIdentityFormLayout<RecruitmentData>(Recruitment
     private val recruitmentItems: MutableList<RecruitmentItemForm> = mutableListOf()
 
     init {
-        val termButton = createTermManageButton()
-        add(term, termButton, title, startDateTime, endDateTime, recruitable, hidden)
+        add(term, title, startDateTime, endDateTime, recruitable, hidden)
         addFormItem(createAddButton(), "모집 항목")
-        setResponsiveSteps(ResponsiveStep("0", 7))
-        children.forEach {
-            setColspan(it, 7)
-        }
-        setColspan(termButton, 1)
-        setColspan(term, 6)
+        setResponsiveSteps(ResponsiveStep("0", 1))
         drawRequired()
     }
 
@@ -62,12 +53,6 @@ class RecruitmentForm() : BindingIdentityFormLayout<RecruitmentData>(Recruitment
         this.endDateTime.value = endDateTime
         this.recruitable.value = recruitable
         this.hidden.value = hidden
-    }
-
-    private fun createTermManageButton(): Button {
-        return createPrimaryButton("기수 관리") {
-            UI.getCurrent().navigate(TermsView::class.java)
-        }
     }
 
     private fun createAddButton(): Button {

--- a/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentsFormView.kt
+++ b/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentsFormView.kt
@@ -1,6 +1,7 @@
 package apply.ui.admin.recruitment
 
 import apply.application.RecruitmentService
+import apply.application.TermService
 import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
@@ -22,10 +23,11 @@ import support.views.toDisplayName
 
 @Route(value = "admin/recruitments", layout = BaseLayout::class)
 class RecruitmentsFormView(
-    private val recruitmentService: RecruitmentService
+    private val recruitmentService: RecruitmentService,
+    private val termService: TermService,
 ) : VerticalLayout(), HasUrlParameter<String> {
     private val title: Title = Title()
-    private val recruitmentForm: RecruitmentForm = RecruitmentForm(recruitmentService.findAllTermSelectData())
+    private val recruitmentForm: RecruitmentForm = RecruitmentForm(termService.findAllTermSelectData())
     private val submitButton: Button = createSubmitButton()
 
     init {

--- a/src/main/kotlin/apply/ui/admin/term/TermForm.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermForm.kt
@@ -17,7 +17,7 @@ class TermForm() : BindingIdentityFormLayout<TermSelectData>(TermSelectData::cla
         return bindDefaultOrNull()
     }
 
-    override fun fill(data: TermSelectData) {
-        fillDefault(data)
+    override fun fill(term: TermSelectData) {
+        name.placeholder = term.name
     }
 }

--- a/src/main/kotlin/apply/ui/admin/term/TermForm.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermForm.kt
@@ -18,6 +18,6 @@ class TermForm() : BindingIdentityFormLayout<TermSelectData>(TermSelectData::cla
     }
 
     override fun fill(term: TermSelectData) {
-        name.placeholder = term.name
+        fillDefault(term)
     }
 }

--- a/src/main/kotlin/apply/ui/admin/term/TermForm.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermForm.kt
@@ -1,0 +1,23 @@
+package apply.ui.admin.term
+
+import apply.application.TermSelectData
+import com.vaadin.flow.component.textfield.TextField
+import support.views.BindingIdentityFormLayout
+
+class TermForm() : BindingIdentityFormLayout<TermSelectData>(TermSelectData::class) {
+    val name: TextField = TextField("기수 이름")
+
+    init {
+        add(name)
+        setResponsiveSteps(ResponsiveStep("0", 1))
+        drawRequired()
+    }
+
+    override fun bindOrNull(): TermSelectData? {
+        return bindDefaultOrNull()
+    }
+
+    override fun fill(data: TermSelectData) {
+        fillDefault(data)
+    }
+}

--- a/src/main/kotlin/apply/ui/admin/term/TermForm.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermForm.kt
@@ -5,7 +5,7 @@ import com.vaadin.flow.component.textfield.TextField
 import support.views.BindingIdentityFormLayout
 
 class TermForm : BindingIdentityFormLayout<TermData>(TermData::class) {
-    private val name: TextField = TextField("기수 이름")
+    private val name: TextField = TextField("기수명")
 
     init {
         add(name)

--- a/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
@@ -19,21 +19,21 @@ class TermFormDialog(
     displayName: String,
     reloadComponents: () -> Unit
 ) : Dialog() {
-    private val title: H2 = H2()
+    private val title: H2 = H2("기수 $displayName")
     private val termForm: TermForm = TermForm()
 
     init {
-        title.text = "기수 $displayName"
         add(createHeader(), termForm, createButtons(displayName, reloadComponents))
         width = "800px"
         open()
     }
 
-    constructor(termService: TermService, displayName: String, term: TermResponse, reloadComponents: () -> Unit) : this(
-        termService,
-        displayName,
-        reloadComponents
-    ) {
+    constructor(
+        termService: TermService,
+        displayName: String,
+        term: TermResponse,
+        reloadComponents: () -> Unit
+    ) : this(termService, displayName, reloadComponents) {
         termForm.fill(TermData(term.name, term.id))
     }
 

--- a/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
@@ -3,7 +3,6 @@ package apply.ui.admin.term
 import apply.application.TermSelectData
 import apply.application.TermService
 import com.vaadin.flow.component.Component
-import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.dialog.Dialog
 import com.vaadin.flow.component.html.H2
@@ -58,7 +57,7 @@ class TermFormDialog(
         return createPrimaryButton {
             termForm.bindOrNull()?.let {
                 // TODO : save
-                UI.getCurrent().navigate(TermsView::class.java)
+                close()
             }
         }
     }

--- a/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
@@ -1,5 +1,6 @@
 package apply.ui.admin.term
 
+import apply.application.TermSelectData
 import apply.application.TermService
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
@@ -28,10 +29,8 @@ class TermFormDialog(
         open()
     }
 
-    constructor(termService: TermService, displayName: String, name: String) : this(termService, displayName) {
-        termForm.apply {
-            this.name.placeholder = name
-        }
+    constructor(termService: TermService, displayName: String, term: TermSelectData) : this(termService, displayName) {
+        termForm.fill(term)
     }
 
     private fun createHeader(): VerticalLayout {
@@ -58,7 +57,6 @@ class TermFormDialog(
     private fun createSubmitButton(): Button {
         return createPrimaryButton {
             termForm.bindOrNull()?.let {
-                it.id
                 // TODO : save
                 UI.getCurrent().navigate(TermsView::class.java)
             }

--- a/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
@@ -1,0 +1,73 @@
+package apply.ui.admin.term
+
+import apply.application.TermService
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.UI
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.dialog.Dialog
+import com.vaadin.flow.component.html.H2
+import com.vaadin.flow.component.orderedlayout.FlexComponent
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import support.views.createContrastButton
+import support.views.createPrimaryButton
+
+class TermFormDialog(
+    private val termService: TermService,
+    displayName: String,
+) : Dialog() {
+    private val title: H2 = H2()
+    private val termForm: TermForm = TermForm()
+    private val submitButton: Button = createSubmitButton()
+
+    init {
+        setDisplayName(displayName)
+        add(createHeader(), termForm, createButtons())
+        width = "800px"
+        height = "40%"
+        open()
+    }
+
+    constructor(termService: TermService, displayName: String, name: String) : this(termService, displayName) {
+        termForm.apply {
+            this.name.placeholder = name
+        }
+    }
+
+    private fun createHeader(): VerticalLayout {
+        return VerticalLayout(title).apply {
+            alignItems = FlexComponent.Alignment.CENTER
+            isPadding = false
+            element.style.set("margin-bottom", "10px")
+        }
+    }
+
+    private fun setDisplayName(displayName: String) {
+        title.text = "기수 $displayName"
+        submitButton.text = displayName
+    }
+
+    private fun createButtons(): Component {
+        return HorizontalLayout(submitButton, createCancelButton()).apply {
+            setSizeFull()
+            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
+            element.style.set("margin-top", "20px")
+        }
+    }
+
+    private fun createSubmitButton(): Button {
+        return createPrimaryButton {
+            termForm.bindOrNull()?.let {
+                it.id
+                // TODO : save
+                UI.getCurrent().navigate(TermsView::class.java)
+            }
+        }
+    }
+
+    private fun createCancelButton(): Button {
+        return createContrastButton("취소") {
+            close()
+        }
+    }
+}

--- a/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermFormDialog.kt
@@ -26,7 +26,6 @@ class TermFormDialog(
         title.text = "기수 $displayName"
         add(createHeader(), termForm, createButtons(displayName, reloadComponents))
         width = "800px"
-        height = "40%"
         open()
     }
 
@@ -48,7 +47,7 @@ class TermFormDialog(
 
     private fun createButtons(displayName: String, reloadComponent: () -> Unit): Component {
         return HorizontalLayout(getCreateSubmitButton(displayName, reloadComponent), createCancelButton()).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.CENTER
             element.style.set("margin-top", "20px")
         }

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -1,0 +1,96 @@
+package apply.ui.admin.term
+
+import apply.application.TermSelectData
+import apply.application.TermService
+import apply.domain.term.Term
+import apply.ui.admin.BaseLayout
+import apply.ui.admin.recruitment.RecruitmentsFormView
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.UI
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.grid.Grid
+import com.vaadin.flow.component.html.H1
+import com.vaadin.flow.component.orderedlayout.FlexComponent
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.data.renderer.ComponentRenderer
+import com.vaadin.flow.data.renderer.Renderer
+import com.vaadin.flow.router.Route
+import support.views.EDIT_VALUE
+import support.views.NEW_VALUE
+import support.views.addSortableColumn
+import support.views.createDeleteButtonWithDialog
+import support.views.createErrorButton
+import support.views.createPrimaryButton
+import support.views.createPrimarySmallButton
+import support.views.toDisplayName
+
+@Route(value = "admin/terms", layout = BaseLayout::class)
+class TermsView(private val termService: TermService) : VerticalLayout() {
+
+    init {
+        add(createTitle(), createButton(), createGrid())
+    }
+
+    private fun createTitle(): Component {
+        return HorizontalLayout(H1("기수 관리")).apply {
+            setSizeFull()
+            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
+        }
+    }
+
+    private fun createGrid(): Component {
+        return Grid<TermSelectData>(10).apply {
+            addSortableColumn("기수 명", TermSelectData::name)
+            addColumn(createButtonRenderer()).apply { isAutoWidth = true }
+            setItems(termService.findAllTermSelectData())
+        }
+    }
+
+    private fun createButton(): Component {
+        return HorizontalLayout(
+            createErrorButton("돌아가기") {
+                UI.getCurrent().navigate(RecruitmentsFormView::class.java, NEW_VALUE)
+            },
+            createPrimaryButton("생성") {
+                TermFormDialog(termService, NEW_VALUE.toDisplayName())
+            }
+        ).apply {
+            setSizeFull()
+            justifyContentMode = FlexComponent.JustifyContentMode.END
+        }
+    }
+
+    private fun createButtonRenderer(): Renderer<TermSelectData> {
+        return ComponentRenderer<Component, TermSelectData> { it ->
+            createButtons(it)
+        }
+    }
+
+    private fun createButtons(term: TermSelectData): Component {
+        return HorizontalLayout(
+            createEditButton(term),
+            createDeleteButton(term)
+        )
+    }
+
+    private fun createEditButton(term: TermSelectData): Component {
+        return createPrimarySmallButton("수정") {
+            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term.name)
+        }.apply {
+            if (term.id == Term.SINGLE.id) {
+                isEnabled = false
+            }
+        }
+    }
+
+    private fun createDeleteButton(term: TermSelectData): Button {
+        return createDeleteButtonWithDialog("모집을 삭제하시겠습니까?") {
+            // TODO : delete
+        }.apply {
+            if (term.id == Term.SINGLE.id) {
+                isEnabled = false
+            }
+        }
+    }
+}

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -5,6 +5,7 @@ import apply.application.TermService
 import apply.domain.term.Term
 import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.grid.Grid
 import com.vaadin.flow.component.html.H1
@@ -38,7 +39,9 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
     private fun createButton(): Component {
         return HorizontalLayout(
             createPrimaryButton("생성") {
-                TermFormDialog(termService, NEW_VALUE.toDisplayName())
+                TermFormDialog(termService, NEW_VALUE.toDisplayName()) {
+                    UI.getCurrent().page.reload()
+                }
             }
         ).apply {
             setSizeFull()
@@ -59,11 +62,7 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
     }
 
     private fun createButtons(term: TermResponse): Component {
-        val block: Button.() -> Unit = {
-            if (term.id == Term.SINGLE.id) {
-                isEnabled = false
-            }
-        }
+        val block: Button.() -> Unit = { isEnabled = term.id != Term.SINGLE.id }
         return HorizontalLayout(
             createEditButton(term).apply(block),
             createDeleteButton(term).apply(block)
@@ -72,13 +71,15 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
 
     private fun createEditButton(term: TermResponse): Button {
         return createPrimarySmallButton("수정") {
-            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term)
+            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term) {
+                UI.getCurrent().page.reload()
+            }
         }
     }
 
     private fun createDeleteButton(term: TermResponse): Button {
         return createDeleteButtonWithDialog("기수를 삭제하시겠습니까?") {
-            // TODO : delete
+            termService.deleteById(term.id)
         }
     }
 }

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -76,7 +76,7 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
 
     private fun createEditButton(term: TermSelectData): Component {
         return createPrimarySmallButton("수정") {
-            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term.name)
+            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term)
         }.apply {
             if (term.id == Term.SINGLE.id) {
                 isEnabled = false

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -4,9 +4,7 @@ import apply.application.TermResponse
 import apply.application.TermService
 import apply.domain.term.Term
 import apply.ui.admin.BaseLayout
-import apply.ui.admin.recruitment.RecruitmentsFormView
 import com.vaadin.flow.component.Component
-import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.grid.Grid
 import com.vaadin.flow.component.html.H1
@@ -19,7 +17,6 @@ import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
 import support.views.addSortableColumn
-import support.views.createContrastButton
 import support.views.createDeleteButtonWithDialog
 import support.views.createPrimaryButton
 import support.views.createPrimarySmallButton
@@ -28,7 +25,7 @@ import support.views.toDisplayName
 @Route(value = "admin/terms", layout = BaseLayout::class)
 class TermsView(private val termService: TermService) : VerticalLayout() {
     init {
-        add(createTitle(), createButtons(), createGrid())
+        add(createTitle(), createButton(), createGrid())
     }
 
     private fun createTitle(): Component {
@@ -38,28 +35,22 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
         }
     }
 
-    private fun createGrid(): Component {
-        return Grid<TermResponse>(10).apply {
-            addSortableColumn("기수 명", TermResponse::name)
-            addColumn(createButtonRenderer()).apply {
-                isAutoWidth = true
-                justifyContentMode = FlexComponent.JustifyContentMode.END
-            }
-            setItems(termService.findAll())
-        }
-    }
-
-    private fun createButtons(): Component {
+    private fun createButton(): Component {
         return HorizontalLayout(
-            createContrastButton("돌아가기") {
-                UI.getCurrent().navigate(RecruitmentsFormView::class.java, NEW_VALUE)
-            },
             createPrimaryButton("생성") {
                 TermFormDialog(termService, NEW_VALUE.toDisplayName())
             }
         ).apply {
             setSizeFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
+        }
+    }
+
+    private fun createGrid(): Component {
+        return Grid<TermResponse>(10).apply {
+            addSortableColumn("기수명", TermResponse::name)
+            addColumn(createButtonRenderer()).apply { isAutoWidth = true }
+            setItems(termService.findAll())
         }
     }
 
@@ -85,7 +76,7 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
     }
 
     private fun createDeleteButton(term: TermResponse): Button {
-        return createDeleteButtonWithDialog("모집을 삭제하시겠습니까?") {
+        return createDeleteButtonWithDialog("기수를 삭제하시겠습니까?") {
             // TODO : delete
         }.apply {
             if (term.id == Term.SINGLE.id) {

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -66,7 +66,9 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
         return HorizontalLayout(
             createEditButton(term).apply(block),
             createDeleteButton(term).apply(block)
-        )
+        ).apply {
+            justifyContentMode = FlexComponent.JustifyContentMode.END
+        }
     }
 
     private fun createEditButton(term: TermResponse): Button {

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -59,29 +59,26 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
     }
 
     private fun createButtons(term: TermResponse): Component {
-        return HorizontalLayout(
-            createEditButton(term),
-            createDeleteButton(term)
-        )
-    }
-
-    private fun createEditButton(term: TermResponse): Component {
-        return createPrimarySmallButton("수정") {
-            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term)
-        }.apply {
+        val block: Button.() -> Unit = {
             if (term.id == Term.SINGLE.id) {
                 isEnabled = false
             }
+        }
+        return HorizontalLayout(
+            createEditButton(term).apply(block),
+            createDeleteButton(term).apply(block)
+        )
+    }
+
+    private fun createEditButton(term: TermResponse): Button {
+        return createPrimarySmallButton("수정") {
+            TermFormDialog(termService, EDIT_VALUE.toDisplayName(), term)
         }
     }
 
     private fun createDeleteButton(term: TermResponse): Button {
         return createDeleteButtonWithDialog("기수를 삭제하시겠습니까?") {
             // TODO : delete
-        }.apply {
-            if (term.id == Term.SINGLE.id) {
-                isEnabled = false
-            }
         }
     }
 }

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -19,8 +19,8 @@ import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
 import support.views.addSortableColumn
+import support.views.createContrastButton
 import support.views.createDeleteButtonWithDialog
-import support.views.createErrorButton
 import support.views.createPrimaryButton
 import support.views.createPrimarySmallButton
 import support.views.toDisplayName
@@ -29,7 +29,7 @@ import support.views.toDisplayName
 class TermsView(private val termService: TermService) : VerticalLayout() {
 
     init {
-        add(createTitle(), createButton(), createGrid())
+        add(createTitle(), createButtons(), createGrid())
     }
 
     private fun createTitle(): Component {
@@ -42,14 +42,17 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
     private fun createGrid(): Component {
         return Grid<TermSelectData>(10).apply {
             addSortableColumn("기수 명", TermSelectData::name)
-            addColumn(createButtonRenderer()).apply { isAutoWidth = true }
+            addColumn(createButtonRenderer()).apply {
+                isAutoWidth = true
+                justifyContentMode = FlexComponent.JustifyContentMode.END
+            }
             setItems(termService.findAllTermSelectData())
         }
     }
 
-    private fun createButton(): Component {
+    private fun createButtons(): Component {
         return HorizontalLayout(
-            createErrorButton("돌아가기") {
+            createContrastButton("돌아가기") {
                 UI.getCurrent().navigate(RecruitmentsFormView::class.java, NEW_VALUE)
             },
             createPrimaryButton("생성") {

--- a/src/main/kotlin/support/views/Buttons.kt
+++ b/src/main/kotlin/support/views/Buttons.kt
@@ -134,7 +134,8 @@ private fun Dialog.createCancelButton(clickListener: ClickListener): Button {
 
 private fun Dialog.createConfirmButton(clickListener: ClickListener): Button {
     return createPrimaryButton("확인") {
-        clickListener(it)
-        UI.getCurrent().page.reload()
+        runCatching { clickListener(it) }
+            .onSuccess { UI.getCurrent().page.reload() }
+            .onFailure { e -> createNotification(e.localizedMessage) }
     }
 }


### PR DESCRIPTION
Close #376 

## 구현 화면
+ 모집 생성 화면의 기수관리 버튼으로 접근
![image](https://user-images.githubusercontent.com/68985748/136533123-b5ed21f8-7ec0-4132-9d5a-8c3d7d8fd89a.png)
+ 기수 관리 화면 및 다이얼로그
![image](https://user-images.githubusercontent.com/68985748/136533284-7b29e2a0-bba1-4c69-8f44-1d7bdc4fb606.png)
![image](https://user-images.githubusercontent.com/68985748/136533407-09f89921-74dc-4e8f-9eb7-11e91a869879.png)
![image](https://user-images.githubusercontent.com/68985748/136533469-f4c3f76c-ea6b-41b2-a2c8-972a1b799eb2.png)

## 특이사항
+ RecruitmentService에 있던 `findAllTermSelectData()` TermService로 이동
+ TermsView에서 돌아가기 버튼 클릭시 다시 모집 생성 창으로 이동
+ 단독 모집은 DB에 존재하는 데이터가 아니고 디폴트 값이기 때문에 수정, 생성 버튼 비활성화
+ BindingIdentityFormLayout 사용
+ 추가되어야할 기능 TODO로 명시