### PR TITLE
feat(user): Implement get my information

### DIFF
--- a/src/main/kotlin/apply/application/UserService.kt
+++ b/src/main/kotlin/apply/application/UserService.kt
@@ -21,6 +21,11 @@ class UserService(
         return userRepository.findAllByKeyword(keyword).map(::UserResponse)
     }
 
+    fun getInformation(id: Long): UserResponse {
+        val user = userRepository.getById(id)
+        return UserResponse(user)
+    }
+
     fun resetPassword(request: ResetPasswordRequest): String {
         return passwordGenerator.generate().also {
             getByEmail(request.email).resetPassword(request.name, request.birthday, it)

--- a/src/main/kotlin/apply/application/UserService.kt
+++ b/src/main/kotlin/apply/application/UserService.kt
@@ -21,11 +21,6 @@ class UserService(
         return userRepository.findAllByKeyword(keyword).map(::UserResponse)
     }
 
-    fun getInformation(id: Long): UserResponse {
-        val user = userRepository.getById(id)
-        return UserResponse(user)
-    }
-
     fun resetPassword(request: ResetPasswordRequest): String {
         return passwordGenerator.generate().also {
             getByEmail(request.email).resetPassword(request.name, request.birthday, it)
@@ -34,6 +29,11 @@ class UserService(
 
     fun editPassword(id: Long, request: EditPasswordRequest) {
         userRepository.getById(id).changePassword(request.password, request.newPassword)
+    }
+
+    fun getInformation(id: Long): UserResponse {
+        val user = userRepository.getById(id)
+        return UserResponse(user)
     }
 
     fun editInformation(id: Long, request: EditInformationRequest) {

--- a/src/main/kotlin/apply/ui/api/UserRestController.kt
+++ b/src/main/kotlin/apply/ui/api/UserRestController.kt
@@ -83,6 +83,14 @@ class UserRestController(
         return ResponseEntity.ok(ApiResponse.success(users))
     }
 
+    @GetMapping("/information")
+    fun getMyInformation(
+        @LoginUser user: User
+    ): ResponseEntity<ApiResponse<UserResponse>> {
+        val user = userService.getInformation(user.id)
+        return ResponseEntity.ok(ApiResponse.success(user))
+    }
+
     @PatchMapping("/information")
     fun editInformation(
         @RequestBody @Valid request: EditInformationRequest,

--- a/src/test/kotlin/apply/application/UserServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserServiceTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import support.test.UnitTest
@@ -94,6 +95,23 @@ internal class UserServiceTest {
             request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"))
             assertThrows<UserAuthenticationException> { subject() }
         }
+    }
+
+    @Test
+    fun `회원이 정보를 조회한다`() {
+        val user = createUser()
+        every { userRepository.getById(any()) } returns user
+
+        val expected = userService.getInformation(user.id)
+
+        assertAll(
+            { assertThat(expected.id).isNotNull },
+            { assertThat(expected.name).isNotNull },
+            { assertThat(expected.email).isNotNull },
+            { assertThat(expected.phoneNumber).isNotNull },
+            { assertThat(expected.gender).isNotNull },
+            { assertThat(expected.birthday).isNotNull }
+        )
     }
 
     @Test

--- a/src/test/kotlin/apply/ui/api/UserRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/UserRestControllerTest.kt
@@ -266,6 +266,23 @@ internal class UserRestControllerTest : RestControllerTest() {
     }
 
     @Test
+    fun `회원이 정보를 조회한다`() {
+        val response = UserResponse(createUser())
+        every { jwtTokenProvider.isValidToken("valid_token") } returns true
+        every { jwtTokenProvider.getSubject("valid_token") } returns userRequest.email
+        every { userService.getByEmail(userRequest.email) } returns userRequest.toEntity()
+        every { userService.getInformation(any()) } returns response
+
+        mockMvc.get("/api/users/information") {
+            contentType = MediaType.APPLICATION_JSON
+            header(AUTHORIZATION, "Bearer valid_token")
+        }.andExpect {
+            status { isOk }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(response))) }
+        }
+    }
+
+    @Test
     fun `회원이 정보를 변경한다`() {
         val request = EditInformationRequest("010-9999-9999")
         every { jwtTokenProvider.isValidToken("valid_token") } returns true


### PR DESCRIPTION
### 작업 내용

- 이전 버전에서는 `마이페이지`가 존재하지 않고 토큰으로 자신의 지원서를 조회하는 api 만 존재하였음
- `마이페이지` 기능 추가로 인해 토큰만으로 회원 자신의 정보 조회 api 기능이 필요해짐
- 회원 자신의 정보 조회 api 구현 

**Request**
`GET "/api/users/information"`

**Response**
```json
{
    "message": "",
    "body": {
        "id": 9,
        "name": "아마찌",
        "email": "mazzi@gmail.com",
        "phoneNumber": "010-0000-0000",
        "gender": "FEMALE",
        "birthday": "2021-12-21"
    }
}
```

Closed #386 

