### PR TITLE
fix(user): add exception messages if user information does not match

### DIFF
--- a/src/main/kotlin/apply/domain/user/User.kt
+++ b/src/main/kotlin/apply/domain/user/User.kt
@@ -44,11 +44,6 @@ class User(
         UserInformation(name, email, phoneNumber, gender, birthday), password, id
     )
 
-    fun authenticate(user: User) {
-        authenticate(user.password)
-        identify(this.information == user.information)
-    }
-
     fun authenticate(password: Password) {
         identify(this.password == password) { "비밀번호가 일치하지 않습니다." }
     }

--- a/src/main/kotlin/apply/domain/user/User.kt
+++ b/src/main/kotlin/apply/domain/user/User.kt
@@ -50,7 +50,7 @@ class User(
     }
 
     fun authenticate(password: Password) {
-        identify(this.password == password)
+        identify(this.password == password) { "비밀번호가 일치하지 않습니다." }
     }
 
     fun changePassword(oldPassword: Password, newPassword: Password) {
@@ -59,7 +59,7 @@ class User(
     }
 
     fun resetPassword(name: String, birthday: LocalDate, password: String) {
-        identify(information.same(name, birthday))
+        identify(information.same(name, birthday)) { "사용자 정보가 일치하지 않습니다." }
         this.password = Password(password)
     }
 

--- a/src/test/kotlin/apply/domain/user/UserTest.kt
+++ b/src/test/kotlin/apply/domain/user/UserTest.kt
@@ -18,17 +18,6 @@ internal class UserTest {
     }
 
     @Test
-    fun `회원의 개인정보가 요청받은 개인정보와 일치하는지 확인한다`() {
-        assertDoesNotThrow { user.authenticate(createUser()) }
-    }
-
-    @Test
-    fun `회원의 개인정보가 요청받은 개인정보와 다를 경우 예외가 발생한다`() {
-        assertThatThrownBy { user.authenticate(createUser(name = "다른 이름")) }
-            .isInstanceOf(UserAuthenticationException::class.java)
-    }
-
-    @Test
     fun `회원의 비밀번호와 일치하는지 확인한다`() {
         assertDoesNotThrow { user.authenticate(PASSWORD) }
     }


### PR DESCRIPTION
이슈 : 400 메시지에 kotlin.unit 문구가 노출

원인 : 
- 비밀번호 또는 사용자 정보 확인 시, 예외 메시지를 지정하지 않아 'Kotlin.unit' 문구가 직접 반환

작업 내용 : 
- 비밀번호 수정 시 잘못된 기존 비밀번호를 입력하는 경우 '비밀번호가 일치하지 않습니다.' 반환
- 비밀번호 초기화 시 잘못된 사용자 정보를 입력하는 경우 '사용자 정보가 일치하지 않습니다.' 반환

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/46060746/137592104-2c8a7655-a8cc-44ec-9ca2-f6e09a05a2bd.png">

<img width="753" alt="image" src="https://user-images.githubusercontent.com/46060746/137592175-106dc777-13d0-48ff-960a-649d268c0c30.png">

close #475 