### PR TITLE
fix(exception): override request validation exception handler

### DIFF
--- a/src/main/kotlin/apply/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/apply/ui/api/ExceptionHandler.kt
@@ -2,6 +2,8 @@ package apply.ui.api
 
 import apply.domain.applicationform.DuplicateApplicationException
 import apply.domain.user.UserAuthenticationException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -15,6 +17,37 @@ import javax.persistence.EntityNotFoundException
 
 @RestControllerAdvice
 class ExceptionHandler : ResponseEntityExceptionHandler() {
+    override fun handleHttpMessageNotReadable(
+        ex: HttpMessageNotReadableException,
+        headers: HttpHeaders,
+        status: HttpStatus,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        logger.error("message", ex)
+        val message = when (val exception = ex.cause) {
+            is MissingKotlinParameterException -> "${exception.parameter.name.orEmpty()}: 널이어서는 안됩니다"
+            is InvalidFormatException -> "${exception.path.last().fieldName.orEmpty()}: 올바른 형식이어야 합니다"
+            else -> exception?.message.orEmpty()
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(message))
+    }
+
+    override fun handleMethodArgumentNotValid(
+        ex: MethodArgumentNotValidException,
+        headers: HttpHeaders,
+        status: HttpStatus,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        logger.error("message", ex)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(ex.messages()))
+    }
+
+    private fun MethodArgumentNotValidException.messages(): String {
+        return bindingResult.fieldErrors.joinToString(", ") { "${it.field}: ${it.defaultMessage.orEmpty()}" }
+    }
+
     @ExceptionHandler(IllegalArgumentException::class, IllegalStateException::class)
     fun handleBadRequestException(exception: RuntimeException): ResponseEntity<ApiResponse<Unit>> {
         logger.error("message", exception)
@@ -49,29 +82,4 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponse.error(exception.message))
     }
-
-    override fun handleMethodArgumentNotValid(
-        exception: MethodArgumentNotValidException,
-        headers: HttpHeaders,
-        status: HttpStatus,
-        request: WebRequest
-    ): ResponseEntity<Any> {
-        logger.error("message", exception)
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error(exception.messages()))
-    }
-
-    override fun handleHttpMessageNotReadable(
-        exception: HttpMessageNotReadableException,
-        headers: HttpHeaders,
-        status: HttpStatus,
-        request: WebRequest
-    ): ResponseEntity<Any> {
-        logger.error("message", exception)
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error(exception.message))
-    }
-
-    private fun MethodArgumentNotValidException.messages(): String =
-        this.bindingResult.fieldErrors.joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
 }


### PR DESCRIPTION
#### 작업 내용
- ResponseEntityExceptionHandler에서 잡고 있는 MethodArgumentNotValidException, HttpMessageNotReadableException 핸들러 재정의
  - MethodArgumentNotValidException: 요청값 검증 예외
  - HttpMessageNotReadableException : 요청 값을 읽을 수 없을 경우의 예외(null, format 등)

#### 특이사항 
  - 현재 dto에서 모든 프로퍼디가 not null이기 때문에 요청에서 필수 프로퍼티가 빠지면 `@NotNull`에서 예외가 발생하는 것이 아닌 
  다음과 같이 HttpMessageNotReadableException가 발생
```
org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Instantiation of [simple type, class apply.application.RegisterUserRequest] value failed for JSON property gender due to missing (therefore NULL) value for creator parameter gender which is a non-nullable type; nested exception is com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class apply.application.RegisterUserRequest] value failed for JSON property gender due to missing (therefore NULL) value for creator parameter gender which is a non-nullable type
```
- 해당 예외에 대해 `필수 요청값이 비어있습니다`의 메시지를 주려하였으나 `생년월일이 존재하지 않는 날짜(2월 30일)` 같은 경우도 동일한 예외가 발생하기 때문에 일단 예외 메시지를 그대로 반환해주고 있음

Closed #426 