### PR TITLE
fix(apply): encode css unicode contents

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "./color.css";
 
 :root {

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -58,7 +58,7 @@
 }
 
 .checkbox-label.unchecked::after {
-  content: "▾";
+  content: "\25BE";
   display: block;
   font-size: 1.25rem;
   margin-left: 0.375rem;
@@ -67,7 +67,7 @@
 }
 
 .checkbox-label.checked::after {
-  content: "▾";
+  content: "\25BE";
   display: block;
   font-size: 1.25rem;
   margin-left: 0.375rem;

--- a/frontend/src/components/form/CheckBox/CheckBox.module.css
+++ b/frontend/src/components/form/CheckBox/CheckBox.module.css
@@ -16,7 +16,7 @@ input[type="checkbox"] {
 }
 
 input[type="checkbox"]::before {
-  content: "✓";
+  content: "\2713";
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
### 현상
- 간헐적으로 아이콘 깨짐

### 원인
- 유니코드 문자 혹은 한글이 css content에 쓰인 경우, 브라우저 환경에 따라 깨져서 노출될 수 있습니다.
- 정확한 재현 스텝은 찾지 못했지만 테스트 중 꽤 자주 발견되어 수정해둡니다.

### 수정 내용
- CSS encoding 적용
- `::after` content 내용 유니코드로 변경

fix #454