### PR TITLE
fix(apply): improve the user interface

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -53,7 +53,7 @@ button {
 .main {
   flex: 1;
   margin: 0 auto;
-  padding: 2.5rem 0;
+  padding: 2.5rem 0.5rem;
 }
 
 input,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -33,7 +33,7 @@ ol {
 }
 
 a {
-  color: var(--black);
+  color: inherit;
   text-decoration: none;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -33,10 +33,12 @@ ol {
 }
 
 a {
+  color: var(--black);
   text-decoration: none;
 }
 
 button {
+  font-size: 0.875rem;
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/frontend/src/components/@common/Button/Button.module.css
+++ b/frontend/src/components/@common/Button/Button.module.css
@@ -18,23 +18,13 @@
   border: 1px solid var(--black);
 }
 
-.outlined:hover {
+.outlined:enabled:hover {
   background-color: var(--gray-001);
 }
 
 .contained {
   background-color: var(--black);
   color: var(--white);
-}
-
-.outlined {
-  color: var(--black);
-  background-color: var(--white);
-  border: 1px solid var(--black);
-}
-
-.outlined:hover {
-  background-color: var(--gray-001);
 }
 
 .cancel {

--- a/frontend/src/components/@common/Container/Container.js
+++ b/frontend/src/components/@common/Container/Container.js
@@ -1,7 +1,6 @@
-import React from "react";
-import PropTypes from "prop-types";
 import classNames from "classnames";
-
+import PropTypes from "prop-types";
+import React from "react";
 import styles from "./Container.module.css";
 
 export const CONTAINER_SIZE = {

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -22,7 +22,6 @@
 @media screen and (max-width: 800px) {
   .box {
     width: calc(100vw - 1rem);
-    margin: 0 0.5rem;
   }
 
   .narrow {
@@ -33,6 +32,5 @@
 @media screen and (max-width: 512px) {
   .narrow {
     width: calc(100vw - 1rem);
-    margin: 0 0.5rem;
   }
 }

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -21,7 +21,18 @@
 
 @media screen and (max-width: 800px) {
   .box {
-    width: 100%;
+    width: calc(100vw - 1rem);
+    margin: 0 0.5rem;
+  }
+
+  .narrow {
+    width: var(--pc-main-width-narrow);
+  }
+}
+
+@media screen and (max-width: 512px) {
+  .narrow {
+    width: calc(100vw - 1rem);
     margin: 0 0.5rem;
   }
 }

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -21,7 +21,7 @@
 
 @media screen and (max-width: 800px) {
   .box {
-    width: 100vw;
-    margin: 1rem 0;
+    width: 100%;
+    margin: 0 0.5rem;
   }
 }

--- a/frontend/src/components/@common/MessageTextarea/MessageTextarea.js
+++ b/frontend/src/components/@common/MessageTextarea/MessageTextarea.js
@@ -20,7 +20,9 @@ const MessageTextarea = ({
   return (
     <div className={classNames(styles.box, className)}>
       <div className={styles["text-field"]}>
-        <Label required={required}>{label}</Label>
+        <Label className={styles.label} required={required}>
+          {label}
+        </Label>
         {description && <Description>{description}</Description>}
         {maxLength && maxLength > 0 && (
           <div className={styles["length-limit"]}>

--- a/frontend/src/components/@common/MessageTextarea/MessageTextarea.module.css
+++ b/frontend/src/components/@common/MessageTextarea/MessageTextarea.module.css
@@ -7,6 +7,10 @@
   flex-direction: column;
 }
 
+.label {
+  margin-bottom: 0.375rem;
+}
+
 .length-limit {
   align-self: flex-end;
   color: var(--gray-007);
@@ -19,5 +23,5 @@
   margin-bottom: 10px;
   height: 12px;
   font-size: 12px;
-  color: #ff0000;
+  color: var(--red);
 }

--- a/frontend/src/components/@common/Radio/Radio.js
+++ b/frontend/src/components/@common/Radio/Radio.js
@@ -7,6 +7,7 @@ const Radio = ({ label, required, ...props }) => {
   return (
     <Label className={styles["radio-label"]}>
       <input type="radio" required={required} {...props} />
+      <div className={styles["custom-radio"]} />
       {label}
     </Label>
   );

--- a/frontend/src/components/@common/Radio/Radio.module.css
+++ b/frontend/src/components/@common/Radio/Radio.module.css
@@ -2,22 +2,23 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  margin-right: 0.625rem;
+  position: relative;
 }
 
 input[type="radio"] {
+  -webkit-border-radius: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  top: 0.625rem;
+  left: 0.625rem;
 }
 
-input[type="radio"]::before {
-  content: "";
+input[type="radio"] + .custom-radio {
   width: 1.25rem;
   height: 1.25rem;
   border-radius: 1.25rem;
@@ -27,6 +28,6 @@ input[type="radio"]::before {
   transition-duration: 0.2s;
 }
 
-input[type="radio"]:checked::before {
+input[type="radio"]:checked + .custom-radio {
   background: var(--black);
 }

--- a/frontend/src/components/@common/TextInput/TextInput.module.css
+++ b/frontend/src/components/@common/TextInput/TextInput.module.css
@@ -10,7 +10,8 @@
   border: 1px solid var(--blue);
 }
 
-.text-input:read-only {
+.text-input:read-only,
+.text-input:disabled {
   cursor: default;
   background: var(--gray-003);
 }

--- a/frontend/src/components/Footer/Footer.js
+++ b/frontend/src/components/Footer/Footer.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import styles from "./Footer.module.css";
 
 const Footer = () => {

--- a/frontend/src/components/Footer/Footer.module.css
+++ b/frontend/src/components/Footer/Footer.module.css
@@ -42,3 +42,25 @@
   color: #333;
   background-color: #fff;
 }
+
+@media screen and (max-width: 800px) {
+  .content-wrapper {
+    width: 100%;
+    margin: 0 0.5rem;
+  }
+}
+
+@media screen and (max-width: 513px) {
+  .logo {
+    width: 9rem;
+  }
+
+  .copyright {
+    font-size: 0.75rem;
+  }
+
+  .social a {
+    width: 2rem;
+    height: 2rem;
+  }
+}

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -42,6 +42,11 @@
   margin-right: 1rem;
 }
 
+.link-container,
+.link-container button {
+  color: var(--gray-008);
+}
+
 .member-menu-container {
   position: relative;
 }
@@ -132,7 +137,23 @@
   background-color: var(--gray-008);
 }
 
-.link-container,
-.link-container button {
-  color: var(--gray-008);
+@media screen and (max-width: 800px) {
+  .header {
+    padding: 0 0.5rem;
+  }
+}
+
+@media screen and (max-width: 513px) {
+  .logo {
+    width: 10rem;
+    margin-right: 0;
+  }
+
+  .title {
+    font-size: 1.125rem;
+  }
+
+  .link-container {
+    margin: 0;
+  }
 }

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.js
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.js
@@ -1,13 +1,10 @@
-import React, { useMemo } from "react";
-import PropTypes from "prop-types";
 import classNames from "classnames";
-
+import PropTypes from "prop-types";
+import React, { useMemo } from "react";
 import CalendarIcon from "../../assets/icon/calendar-icon.svg";
-
 import { formatDateTime } from "../../utils/format/date";
-
-import styles from "./RecruitmentItem.module.css";
 import Button from "../@common/Button/Button";
+import styles from "./RecruitmentItem.module.css";
 
 const RecruitmentItem = ({
   recruitment,
@@ -34,7 +31,7 @@ const RecruitmentItem = ({
           <strong>{recruitment.title}</strong>
         </p>
         <div className={styles.date}>
-          <img src={CalendarIcon} alt="달력 아이콘" />
+          <img src={CalendarIcon} alt="달력 아이콘" className={styles.icon} />
           <p>
             {formattedStartDateTime} ~ {formattedEndDateTime}
           </p>

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
@@ -30,3 +30,14 @@
 .button {
   min-width: 6rem;
 }
+
+@media screen and (max-width: 513px) {
+  .date {
+    gap: 0.25rem;
+    font-size: 0.875rem;
+  }
+
+  .icon {
+    width: 1rem;
+  }
+}

--- a/frontend/src/components/form/CheckBox/CheckBox.js
+++ b/frontend/src/components/form/CheckBox/CheckBox.js
@@ -14,6 +14,7 @@ const CheckBox = ({ label, name, checked, onChange, required, ...props }) => {
         required={required}
         {...props}
       />
+      <div className={styles["custom-checkbox"]} />
       {label}
     </Label>
   );

--- a/frontend/src/components/form/CheckBox/CheckBox.module.css
+++ b/frontend/src/components/form/CheckBox/CheckBox.module.css
@@ -3,32 +3,38 @@
   align-items: center;
   cursor: pointer;
   line-height: 1.25rem;
+  position: relative;
 }
 
 input[type="checkbox"] {
+  -webkit-border-radius: 0;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   outline: none;
-  cursor: pointer;
-  margin: 0;
-  margin-right: 0.5rem;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  top: 0.625rem;
+  left: 0.625rem;
 }
 
-input[type="checkbox"]::before {
+input[type="checkbox"] + .custom-checkbox::before {
   content: "\2713";
   display: flex;
   justify-content: center;
   align-items: center;
   width: 1.5rem;
   height: 1.5rem;
+  margin-right: 0.375rem;
   border-radius: 1.5rem;
   border: 1px solid var(--gray-006);
   background: var(--white);
   transition-duration: 0.2s;
 }
 
-input[type="checkbox"]:checked::before {
+input[type="checkbox"]:checked + .custom-checkbox::before {
   background: var(--black);
   color: var(--white);
 }

--- a/frontend/src/components/form/EmailField/EmailField.js
+++ b/frontend/src/components/form/EmailField/EmailField.js
@@ -140,13 +140,13 @@ const EmailField = ({
       {emailStatus === EMAIL_STATUS.WAITING_AUTHENTICATION && (
         <div className={styles.box}>
           <div className={styles.timer}>
-            인증코드 유효시간
+            인증 코드 유효시간
             <span className={styles["timer-time"]}>{formatTimerText(timerSeconds)}</span>
           </div>
           <div className={styles.box}>
             <div className={styles["text-field"]}>
               <Label className={styles.label} required>
-                이메일 인증코드
+                이메일 인증 코드
               </Label>
               <div className={styles["input-box"]}>
                 <TextInput

--- a/frontend/src/components/form/Form/Form.module.css
+++ b/frontend/src/components/form/Form/Form.module.css
@@ -5,7 +5,7 @@
 
 @media screen and (max-width: 512px) {
   .form {
-    width: 100vw;
+    width: 100%;
     margin: 0;
   }
 }

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -123,7 +123,9 @@ const ApplicationRegister = () => {
 
   return (
     <div className={styles.box}>
-      {currentRecruitment && <RecruitmentItem recruitment={currentRecruitment} />}
+      {currentRecruitment && (
+        <RecruitmentItem className={styles["recruitment-item"]} recruitment={currentRecruitment} />
+      )}
 
       <Container title="지원서 작성">
         <Form onSubmit={handleSubmit}>

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
@@ -51,10 +51,3 @@
 .buttons button {
   flex: 1;
 }
-
-@media screen and (max-width: 800px) {
-  .recruit-card,
-  .application-form {
-    width: 100vw;
-  }
-}

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
@@ -116,7 +116,7 @@ const AssignmentSubmit = () => {
           required
         />
         <p className={styles["info-message"]}>
-          작성하신 내용은 과제 제출 마감전까지 수정하실 수 있습니다.
+          작성하신 내용은 과제 제출 마감 전까지 수정할 수 있습니다.
         </p>
         <div className={styles.buttons}>
           <CancelButton confirmMessage={CONFIRM_MESSAGE.CANCEL_ASSIGNMENT_SUBMIT} />

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.stories.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.stories.js
@@ -1,8 +1,29 @@
 import AssignmentSubmit from "./AssignmentSubmit";
+import { Route, MemoryRouter } from "react-router-dom";
+import { missionDummy } from "../../mock/dummy";
 
 export default {
   title: "pages/AssignmentSubmit",
   component: AssignmentSubmit,
+  decorators: [
+    (Story) => (
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/assignment/new",
+            state: {
+              recruitmentId: 1,
+              currentMission: missionDummy[0],
+            },
+          },
+        ]}
+      >
+        <Route path="/assignment/:status">
+          <Story />
+        </Route>
+      </MemoryRouter>
+    ),
+  ],
 };
 
 const Template = (args) => <AssignmentSubmit {...args} />;

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -143,7 +143,9 @@ const MyApplication = () => {
               onClickButton={routeToApplicationForm(recruitment)}
             />
 
-            <hr className={styles.hr} />
+            {missions?.[recruitment.id] && missions[recruitment.id].length > 0 && (
+              <hr className={styles.hr} />
+            )}
 
             {missions?.[recruitment.id] &&
               missions[recruitment.id].map((mission) => (

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -52,10 +52,12 @@ const MyApplication = () => {
   const [myApplications, setMyApplications] = useState([]);
   const myRecruitments = useMemo(
     () =>
-      myApplications.map(({ recruitmentId, submitted }) => ({
-        ...recruitment.findById(recruitmentId),
-        submitted,
-      })),
+      myApplications
+        .map(({ recruitmentId, submitted }) => ({
+          ...recruitment.findById(recruitmentId),
+          submitted,
+        }))
+        .reverse(),
     [myApplications, recruitment]
   );
 

--- a/frontend/src/pages/MyApplication/MyApplication.stories.js
+++ b/frontend/src/pages/MyApplication/MyApplication.stories.js
@@ -17,6 +17,12 @@ Default.parameters = {
     rest.get(`${API_BASE_URL}/api/application-forms/me`, (req, res, ctx) => {
       return res(ctx.json({ message: "", body: myApplicationDummy }));
     }),
+    rest.get(
+      `${API_BASE_URL}/api/recruitments/${myApplicationDummy[0].recruitmentId}/missions/me`,
+      (req, res, ctx) => {
+        return res(ctx.json({ message: "", body: [] }));
+      }
+    ),
     rest.get(`${API_BASE_URL}/api/recruitments/:recruitmentId/missions/me`, (req, res, ctx) => {
       return res(ctx.json({ message: "", body: missionDummy }));
     }),

--- a/frontend/src/pages/MyPage/MyPage.js
+++ b/frontend/src/pages/MyPage/MyPage.js
@@ -25,7 +25,7 @@ const MyPage = () => {
   };
 
   return (
-    <Container title={`${userInfo?.name} 님`}>
+    <Container title={`${userInfo?.email ?? ""} 님`}>
       <div className={styles.box}>
         <div className={styles["illust-box"]}>
           <img src={myPageImage} alt="자기소개서 일러스트" />

--- a/frontend/src/pages/MyPage/MyPage.js
+++ b/frontend/src/pages/MyPage/MyPage.js
@@ -25,7 +25,7 @@ const MyPage = () => {
   };
 
   return (
-    <Container title={`${userInfo?.email ?? ""} 님`}>
+    <Container title={`${userInfo?.name ?? ""} 님`}>
       <div className={styles.box}>
         <div className={styles["illust-box"]}>
           <img src={myPageImage} alt="자기소개서 일러스트" />

--- a/frontend/src/pages/MyPage/MyPage.module.css
+++ b/frontend/src/pages/MyPage/MyPage.module.css
@@ -41,3 +41,9 @@
 .buttons button {
   flex: 1;
 }
+
+@media screen and (max-width: 512px) {
+  .illust-box {
+    display: none;
+  }
+}

--- a/frontend/src/pages/MyPageEdit/MyPageEdit.js
+++ b/frontend/src/pages/MyPageEdit/MyPageEdit.js
@@ -49,7 +49,7 @@ const MyPageEdit = () => {
   }, [userInfo]);
 
   return (
-    <Container title={`${userInfo?.email ?? ""} 님`}>
+    <Container title={`${userInfo?.name ?? ""} 님`}>
       <div className={styles.box}>
         <div className={styles["illust-box"]}>
           <img src={myPageImage} alt="자기소개서 일러스트" />

--- a/frontend/src/pages/MyPageEdit/MyPageEdit.js
+++ b/frontend/src/pages/MyPageEdit/MyPageEdit.js
@@ -60,6 +60,7 @@ const MyPageEdit = () => {
             name={MY_PAGE_EDIT_FORM_NAME.EMAIL}
             className={styles.input}
             value={userInfo?.email}
+            disabled
             readOnly
           />
           <MessageTextInput
@@ -75,6 +76,7 @@ const MyPageEdit = () => {
           <BirthField
             name={MY_PAGE_EDIT_FORM_NAME.BIRTHDAY}
             value={new Date(userInfo?.birthday)}
+            disabled
             readOnly
           />
 

--- a/frontend/src/pages/MyPageEdit/MyPageEdit.js
+++ b/frontend/src/pages/MyPageEdit/MyPageEdit.js
@@ -49,7 +49,7 @@ const MyPageEdit = () => {
   }, [userInfo]);
 
   return (
-    <Container title={`${userInfo?.name} 님`}>
+    <Container title={`${userInfo?.email ?? ""} 님`}>
       <div className={styles.box}>
         <div className={styles["illust-box"]}>
           <img src={myPageImage} alt="자기소개서 일러스트" />

--- a/frontend/src/pages/MyPageEdit/MyPageEdit.js
+++ b/frontend/src/pages/MyPageEdit/MyPageEdit.js
@@ -61,7 +61,6 @@ const MyPageEdit = () => {
             className={styles.input}
             value={userInfo?.email}
             disabled
-            readOnly
           />
           <MessageTextInput
             label="휴대폰 번호"
@@ -77,9 +76,7 @@ const MyPageEdit = () => {
             name={MY_PAGE_EDIT_FORM_NAME.BIRTHDAY}
             value={new Date(userInfo?.birthday)}
             disabled
-            readOnly
           />
-
           <div className={styles.buttons}>
             <CancelButton />
             <Button disabled={!isValid || isEmpty}>확인</Button>

--- a/frontend/src/pages/MyPageEdit/MyPageEdit.module.css
+++ b/frontend/src/pages/MyPageEdit/MyPageEdit.module.css
@@ -27,3 +27,9 @@
 .buttons button {
   flex: 1;
 }
+
+@media screen and (max-width: 512px) {
+  .illust-box {
+    display: none;
+  }
+}

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -1,16 +1,13 @@
-import React, { useMemo } from "react";
-import { Link, useHistory, useLocation, generatePath } from "react-router-dom";
 import classNames from "classnames";
-
+import React, { useMemo } from "react";
+import { generatePath, Link, useHistory, useLocation } from "react-router-dom";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
-
+import PATH, { PARAM } from "../../constants/path";
+import { RECRUITMENT_STATUS } from "../../constants/recruitment";
+import { RECRUITS_TAB, RECRUITS_TAB_LIST } from "../../constants/tab";
 import useRecruitmentContext from "../../hooks/useRecruitmentContext";
 import useTokenContext from "../../hooks/useTokenContext";
 import { generateQuery } from "../../utils/route/query";
-import PATH, { PARAM } from "../../constants/path";
-import { RECRUITS_TAB, RECRUITS_TAB_LIST } from "../../constants/tab";
-import { RECRUITMENT_STATUS } from "../../constants/recruitment";
-
 import styles from "./Recruits.module.css";
 
 const BUTTON_LABEL = {
@@ -61,7 +58,7 @@ const Recruits = () => {
   };
 
   return (
-    <div className={styles.box}>
+    <>
       <nav className={styles.tab}>
         <ul className={styles["tab-list"]}>
           {RECRUITS_TAB_LIST.map(({ name, label }) => (
@@ -84,21 +81,23 @@ const Recruits = () => {
         </ul>
       </nav>
 
-      {recruitment && (
-        <div className={styles["recruitment-list"]} role="list">
-          {sortedRecruitment.map((recruitment) => (
-            <RecruitmentItem
-              key={recruitment.id}
-              recruitment={recruitment}
-              isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
-              buttonLabel={BUTTON_LABEL[recruitment.status]}
-              onClickButton={() => goToNewApplicationFormPage(recruitment)}
-              role="listitem"
-            />
-          ))}
-        </div>
-      )}
-    </div>
+      <div className={styles["recruitment-list-box"]}>
+        {recruitment && (
+          <div className={styles["recruitment-list"]} role="list">
+            {sortedRecruitment.map((recruitment) => (
+              <RecruitmentItem
+                key={recruitment.id}
+                recruitment={recruitment}
+                isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
+                buttonLabel={BUTTON_LABEL[recruitment.status]}
+                onClickButton={() => goToNewApplicationFormPage(recruitment)}
+                role="listitem"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -73,6 +73,6 @@
 
   .recruitment-list-box {
     width: calc(100vw - 1rem);
-    margin: 3.625rem 0.5rem 0;
+    margin-top: 3.625rem;
   }
 }

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -67,6 +67,10 @@
 }
 
 @media screen and (max-width: 800px) {
+  .tab-item {
+    font-size: 0.875rem;
+  }
+
   .recruitment-list-box {
     width: calc(100vw - 1rem);
     margin: 3.625rem 0.5rem 0;

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -1,12 +1,8 @@
-.box {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
 .tab {
   position: fixed;
   top: 5.75rem;
+  left: 0;
+  right: 0;
   width: 100%;
   height: 3.625rem;
   background-color: var(--white);
@@ -15,7 +11,8 @@
 }
 
 .tab-list {
-  width: var(--pc-main-width);
+  width: 100%;
+  max-width: var(--pc-main-width);
   height: inherit;
   display: flex;
   align-items: center;
@@ -58,10 +55,20 @@
   font-weight: bold;
 }
 
-.recruitment-list {
-  margin-top: 3.625rem;
+.recruitment-list-box {
   width: var(--pc-main-width);
+  margin: 3.625rem auto 0;
+}
+
+.recruitment-list {
   display: flex;
   flex-direction: column;
   gap: 1.125rem;
+}
+
+@media screen and (max-width: 800px) {
+  .recruitment-list-box {
+    width: calc(100vw - 1rem);
+    margin: 3.625rem 0.5rem 0;
+  }
 }

--- a/src/main/resources/templates/mail/common.html
+++ b/src/main/resources/templates/mail/common.html
@@ -153,7 +153,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright © 우아한테크코스. All rights reserved
+                      Copyright 2021. 우아한테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/email-authentication.html
+++ b/src/main/resources/templates/mail/email-authentication.html
@@ -68,7 +68,7 @@
                         padding-top: 48px;
                       "
                     >
-                      이메일 인증코드
+                      이메일 인증 코드
                     </td>
                   </tr>
                   <tr>
@@ -110,9 +110,9 @@
                         text-align: center;
                       "
                     >
-                      이메일 인증코드가 발급 되었습니다.
+                      이메일 인증 코드가 발급되었습니다.
                       <br />
-                      해당 문자 를 인증코드 입력창에 입력해주세요.
+                      해당 문자를 인증 코드 입력창에 입력해 주세요.
                     </td>
                   </tr>
                 </table>
@@ -192,7 +192,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright © 우아한테크코스. All rights reserved
+                      Copyright 2021. 우아한테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -108,10 +108,11 @@
                         text-align: center;
                       "
                     >
-                      안녕하세요. <span th:text="${name}"></span>님 임시
-                      비밀번호가 발급 되었습니다. <br />
-                      로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정
-                      해주세요.
+                      안녕하세요. <span th:text="${name}"></span>님.
+                      <br /><br />
+                      임시 비밀번호가 발급되었습니다. <br />
+                      로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정해
+                      주세요.
                     </td>
                   </tr>
                   <tr>
@@ -232,7 +233,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright © 우아한테크코스. All rights reserved
+                      Copyright 2021. 우아한테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/submission-complete.html
+++ b/src/main/resources/templates/mail/submission-complete.html
@@ -84,11 +84,13 @@
                         text-align: center;
                       "
                     >
-                      안녕하세요. <span th:text="${name}"></span>님.<br />
-                      우아한테크코스 <span th:text="${recruit}"></span>
-                      지원이 완료되었습니다.
+                      안녕하세요. <span th:text="${name}"></span>님.
                       <br /><br />
-                      추후 진행사항은 해당 이메일을 통해 안내됩니다. 감사합니다.
+                      우아한테크코스 <span th:text="${recruit}"></span>
+                      지원이 완료되었습니다. 추후 진행 사항은 해당 이메일을 통해
+                      안내됩니다.
+                      <br /><br />
+                      감사합니다.
                     </td>
                   </tr>
                 </table>
@@ -168,7 +170,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright © 우아한테크코스. All rights reserved
+                      Copyright 2021. 우아한테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/submission-complete.html
+++ b/src/main/resources/templates/mail/submission-complete.html
@@ -86,10 +86,9 @@
                     >
                       안녕하세요. <span th:text="${name}"></span>님.
                       <br /><br />
-                      우아한테크코스 <span th:text="${recruit}"></span>
-                      지원이 완료되었습니다. 추후 진행 사항은 해당 이메일을 통해
-                      안내됩니다.
-                      <br /><br />
+                      우아한테크코스 <span th:text="${recruit}"></span> 지원이
+                      완료되었습니다.<br />추후 진행 사항은 해당 이메일을 통해
+                      안내됩니다. <br /><br />
                       감사합니다.
                     </td>
                   </tr>

--- a/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
@@ -173,7 +173,7 @@ internal class UserAuthenticationServiceTest {
         }
 
         @Test
-        fun `인증코드 요청시 이미 가입된 이메일이라면 예외가 발생한다`() {
+        fun `인증 코드 요청시 이미 가입된 이메일이라면 예외가 발생한다`() {
             every { userRepository.existsByEmail(any()) } returns true
             assertThrows<IllegalStateException> {
                 userAuthenticationService.generateAuthenticationCode(authenticationCode.email)


### PR DESCRIPTION
## 변경내용

- 모바일 화면에서 메인페이지 UI 깨지는 문제 해결
<img src="https://user-images.githubusercontent.com/45230497/138115912-7bd45adf-b463-4df2-80da-9412f7808cb2.png" alt="메인페이지 모바일" width="300" />

-  [사파리] 회원관리 툴팁 텍스트 크기 통일
<img src="https://user-images.githubusercontent.com/45230497/138116367-c39b6272-eda8-42f5-97ce-2582fa17a44f.png" alt="사파리 회원가입 툴팁" width="200" />

- [파이어폭스] 마이페이지 수정 화면 깨지는 문제 해결
  - 모바일 화면의 경우 이미지가 보이지 않도록 처리함
<img src="https://user-images.githubusercontent.com/45230497/138116936-ae2175a2-08a3-48ee-b0c9-390d9903f0c9.png" alt="파이어폭스 마이페이지 수정 모바일" width="300" />
<img src="https://user-images.githubusercontent.com/45230497/138117433-158b5d36-0ba4-4f1a-9c6f-5898b91e2d81.png" alt="파이어폭스 마이페이지 수정" width="400" />

- 내 지원 현황 페이지 과제가 존재하지 않는 경우 구분선 제거
<img src="https://user-images.githubusercontent.com/45230497/138117942-97425ad8-0abd-42ca-ae8d-20dfcc357c0c.png" alt="내 지원 현황 과제가 없는 경우" width="400" />

- 가장 최근에 지원한 모집이 상위에 노출되도록 변경

- 과제 소감 label 하단에 여백 추가
  - 글자수 표시가 생기면서 여백이 꼭 필요하진 않게 되었지만, 입력 글자수 제한이 없는 경우 input과 동일하게 여백이 나타나도록 수정했습니다.
<img src="https://user-images.githubusercontent.com/45230497/138118655-4ca49167-378f-4b1e-a021-13e57ef9cb52.png" alt="과제 제출 소감 입력창" width="400" />


## 작업하며...
- PC 크롬, 사파리, 파이어폭스에서 확인하며 작업했고 각 브라우저의 개발자도구에서 모바일 화면 크기로도 확인했지만, 실제 핸드폰으로 접속했을때 화면은 확인하지 못했습니다. 배포 후 한 번 더 체크해보면 좋을 것 같습니다(특히 아이폰)

Close #511 