### PR TITLE
fix(apply): 지원서 작성 페이지,  이미 지원한 기수의 다른 모집 페이지 진입시 에러메시지 정상화

### DIFF
--- a/frontend/src/hooks/useApplicationRegisterForm.js
+++ b/frontend/src/hooks/useApplicationRegisterForm.js
@@ -92,6 +92,12 @@ const useApplicationRegisterForm = ({
   const handleInitError = (error) => {
     if (!error) return;
 
+    if (error.response.status === 409) {
+      alert(error.response?.data.message);
+      history.push(PATH.HOME);
+      return;
+    }
+
     history.replace({
       pathname: generatePath(PATH.APPLICATION_FORM, {
         status: PARAM.APPLICATION_FORM_STATUS.EDIT,


### PR DESCRIPTION
POST /application-forms 409 에러응답코드로 응답시, 서버 에러메시지 반환 후 홈으로 이동처리했습니다