### PR TITLE
feat(apply): add empty state ui

### DIFF
--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -84,16 +84,20 @@ const Recruits = () => {
       <div className={styles["recruitment-list-box"]}>
         {recruitment && (
           <div className={styles["recruitment-list"]} role="list">
-            {sortedRecruitment.map((recruitment) => (
-              <RecruitmentItem
-                key={recruitment.id}
-                recruitment={recruitment}
-                isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
-                buttonLabel={BUTTON_LABEL[recruitment.status]}
-                onClickButton={() => goToNewApplicationFormPage(recruitment)}
-                role="listitem"
-              />
-            ))}
+            {sortedRecruitment.length === 0 ? (
+              <div className={styles["empty-state-box"]}>텅 비었어요...</div>
+            ) : (
+              sortedRecruitment.map((recruitment) => (
+                <RecruitmentItem
+                  key={recruitment.id}
+                  recruitment={recruitment}
+                  isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
+                  buttonLabel={BUTTON_LABEL[recruitment.status]}
+                  onClickButton={() => goToNewApplicationFormPage(recruitment)}
+                  role="listitem"
+                />
+              ))
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -85,7 +85,7 @@ const Recruits = () => {
         {recruitment && (
           <div className={styles["recruitment-list"]} role="list">
             {sortedRecruitment.length === 0 ? (
-              <div className={styles["empty-state-box"]}>텅 비었어요...</div>
+              <div className={styles["empty-state-box"]}>해당하는 공고가 존재하지 않습니다.</div>
             ) : (
               sortedRecruitment.map((recruitment) => (
                 <RecruitmentItem

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -66,6 +66,17 @@
   gap: 1.125rem;
 }
 
+.empty-state-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 0;
+
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--gray-005);
+}
+
 @media screen and (max-width: 800px) {
   .tab-item {
     font-size: 0.875rem;

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -69,7 +69,6 @@
 .empty-state-box {
   display: flex;
   justify-content: center;
-  align-items: center;
   padding: 2rem 0;
 
   font-size: 2rem;


### PR DESCRIPTION
Close #545 

### 참고할 점
Sprint 3.0.0에서 메인 페이지의 UI가 많은 변화가 있을 예정입니다. 
그 이유는, 현재 `모집 종료`와 같은 탭 메뉴의 경우 불필요한 정보라고 생각하여 
`현재의 탭 메뉴 형식`에서 `리스트 형식`으로 작업이 이루어질 것 같습니다. 

그리하여, 현재 `empty stats ui`는 완전한 fix가 아니라는 점 참고해주시면 좋겠습니다. 😎

### 반영한 UI 스크린샷

<img src="https://user-images.githubusercontent.com/71116429/179665407-dcf0d4ca-52f2-45a9-94fa-196da0f4dd71.png" width="70%" alt="empty state ui screenshot" >


### 논의할 부분
- 현재 메시지 문구가 어떤지, 어떻게 수정하면 더 좋을지 궁금합니다. 🤔

