### PR TITLE
refactor(test): migrate tests left after string spec migration to kotest describe spec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     asciidoctor("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testImplementation("io.kotest:kotest-runner-junit5:5.3.2")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.1")
 }
 
 dependencyManagement {

--- a/src/test/kotlin/apply/ProjectConfig.kt
+++ b/src/test/kotlin/apply/ProjectConfig.kt
@@ -1,0 +1,9 @@
+package apply
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.extensions.spring.SpringExtension
+
+object ProjectConfig : AbstractProjectConfig() {
+    override fun extensions(): List<Extension> = listOf(SpringExtension)
+}

--- a/src/test/kotlin/apply/ProjectConfig.kt
+++ b/src/test/kotlin/apply/ProjectConfig.kt
@@ -4,6 +4,6 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.extensions.spring.SpringExtension
 
-object ProjectConfig : AbstractProjectConfig() {
+class ProjectConfig : AbstractProjectConfig() {
     override fun extensions(): List<Extension> = listOf(SpringExtension)
 }

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -7,8 +7,8 @@ import apply.domain.cheater.Cheater
 import apply.domain.cheater.CheaterRepository
 import apply.domain.user.UserRepository
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -50,14 +50,14 @@ class ApplicantServiceTest : DescribeSpec({
                 val actual = applicantService.findAllByRecruitmentIdAndKeyword(1L)
 
                 actual shouldHaveSize 1
-                actual[0].isCheater.shouldBeTrue()
+                actual[0].isCheater shouldBe true
             }
 
             it("키워드로 찾은 지원자 정보와 부정 행위자 여부를 함께 제공한다") {
                 val actual = applicantService.findAllByRecruitmentIdAndKeyword(1L, "amazzi")
 
                 actual shouldHaveSize 1
-                actual[0].isCheater.shouldBeTrue()
+                actual[0].isCheater shouldBe true
             }
         }
     }

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -6,74 +6,59 @@ import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.cheater.Cheater
 import apply.domain.cheater.CheaterRepository
 import apply.domain.user.UserRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.slot
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import support.test.UnitTest
 
 @UnitTest
-class ApplicantServiceTest {
-    @MockK
-    private lateinit var userRepository: UserRepository
+class ApplicantServiceTest : DescribeSpec({
+    val userRepository: UserRepository = mockk()
+    val cheaterRepository: CheaterRepository = mockk()
+    val applicationFormRepository: ApplicationFormRepository = mockk()
+    val applicantService: ApplicantService =
+        ApplicantService(applicationFormRepository, userRepository, cheaterRepository)
 
-    @MockK
-    private lateinit var cheaterRepository: CheaterRepository
+    val userId = 1L
+    val email = "email@email.com"
 
-    @MockK
-    private lateinit var applicationFormRepository: ApplicationFormRepository
-
-    private lateinit var applicantService: ApplicantService
-
-    @BeforeEach
-    internal fun setUp() {
-        applicantService = ApplicantService(applicationFormRepository, userRepository, cheaterRepository)
-    }
-
-    @Nested
-    inner class Find {
-        @BeforeEach
-        internal fun setUp() {
-            val userId = 1L
-            val email = "email@email.com"
-
-            slot<Long>().also { slot ->
-                every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(capture(slot)) } answers {
-                    listOf(createApplicationForm(recruitmentId = slot.captured))
-                }
-            }
-
-            every { cheaterRepository.findAll() } returns listOf(Cheater(email))
-            slot<Iterable<Long>>().also { slot ->
-                every { userRepository.findAllById(capture(slot)) } answers {
-                    slot.captured.map { createUser(id = it, email = email) }
-                }
-            }
-
-            slot<String>().also { slot ->
-                every { userRepository.findAllByKeyword(capture(slot)) } answers {
-                    listOf(createUser(name = slot.captured, id = userId, email = email))
-                }
-            }
-        }
-
-        @Test
-        fun `지원자 정보와 부정 행위자 여부를 함께 제공한다`() {
-            val actual = applicantService.findAllByRecruitmentIdAndKeyword(1L)
-
-            assertThat(actual).hasSize(1)
-            assertThat(actual[0].isCheater).isTrue
-        }
-
-        @Test
-        fun `키워드로 찾은 지원자 정보와 부정 행위자 여부를 함께 제공한다`() {
-            val actual = applicantService.findAllByRecruitmentIdAndKeyword(1L, "amazzi")
-
-            assertThat(actual).hasSize(1)
-            assertThat(actual[0].isCheater).isTrue
+    slot<Long>().also { slot ->
+        every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(capture(slot)) } answers {
+            listOf(createApplicationForm(recruitmentId = slot.captured))
         }
     }
-}
+
+    every { cheaterRepository.findAll() } returns listOf(Cheater(email))
+    slot<Iterable<Long>>().also { slot ->
+        every { userRepository.findAllById(capture(slot)) } answers {
+            slot.captured.map { createUser(id = it, email = email) }
+        }
+    }
+
+    slot<String>().also { slot ->
+        every { userRepository.findAllByKeyword(capture(slot)) } answers {
+            listOf(createUser(name = slot.captured, id = userId, email = email))
+        }
+    }
+
+    describe("ApplicantService") {
+        context("지원자를 찾을 때") {
+            it("지원자 정보와 부정 행위자 여부를 함께 제공한다") {
+                val actual = applicantService.findAllByRecruitmentIdAndKeyword(1L)
+
+                actual shouldHaveSize 1
+                actual[0].isCheater.shouldBeTrue()
+            }
+
+            it("키워드로 찾은 지원자 정보와 부정 행위자 여부를 함께 제공한다") {
+                val actual = applicantService.findAllByRecruitmentIdAndKeyword(1L, "amazzi")
+
+                actual shouldHaveSize 1
+                actual[0].isCheater.shouldBeTrue()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/apply/application/ApplicantServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicantServiceTest.kt
@@ -15,12 +15,11 @@ import io.mockk.slot
 import support.test.UnitTest
 
 @UnitTest
-class ApplicantServiceTest : DescribeSpec({
+internal class ApplicantServiceTest : DescribeSpec({
     val userRepository: UserRepository = mockk()
     val cheaterRepository: CheaterRepository = mockk()
     val applicationFormRepository: ApplicationFormRepository = mockk()
-    val applicantService: ApplicantService =
-        ApplicantService(applicationFormRepository, userRepository, cheaterRepository)
+    val applicantService = ApplicantService(applicationFormRepository, userRepository, cheaterRepository)
 
     val userId = 1L
     val email = "email@email.com"

--- a/src/test/kotlin/apply/application/ApplicationFormIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormIntegrationTest.kt
@@ -9,7 +9,7 @@ import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.user.UserRepository
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import support.test.IntegrationTest
 import java.time.LocalDateTime
@@ -47,7 +47,7 @@ class ApplicationFormIntegrationTest(
                         submittedDateTime = LocalDateTime.now()
                     )
                 )
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id))
                 }
             }
@@ -66,7 +66,7 @@ class ApplicationFormIntegrationTest(
                     )
                 )
                 val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
-                shouldThrowExactly<DuplicateApplicationException> {
+                shouldThrow<DuplicateApplicationException> {
                     applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id))
                 }
             }
@@ -102,7 +102,7 @@ class ApplicationFormIntegrationTest(
                 )
                 val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
                 applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
-                shouldThrowExactly<DuplicateApplicationException> {
+                shouldThrow<DuplicateApplicationException> {
                     applicationFormService.update(
                         user.id,
                         UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)

--- a/src/test/kotlin/apply/application/ApplicationFormIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormIntegrationTest.kt
@@ -7,10 +7,9 @@ import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.applicationform.DuplicateApplicationException
 import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.user.UserRepository
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
 import support.test.IntegrationTest
 import java.time.LocalDateTime
 
@@ -20,90 +19,142 @@ class ApplicationFormIntegrationTest(
     private val userRepository: UserRepository,
     private val applicationFormRepository: ApplicationFormRepository,
     private val recruitmentRepository: RecruitmentRepository
-) {
-    @Test
-    fun `아직 지원하지 않은 경우 단독 모집에 지원 가능하다`() {
-        val recruitment = recruitmentRepository.save(createRecruitment(termId = 0L, recruitable = true))
-        val user = userRepository.save(createUser())
-        assertDoesNotThrow { applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id)) }
-    }
+) : DescribeSpec({
+    describe("ApplicationForm") {
+        context("모집 지원을 할 때 아직 지원하지 않은 경우") {
+            it("단독 모집에 지원 가능한다.") {
+                val recruitment = recruitmentRepository.save(createRecruitment(termId = 0L, recruitable = true))
+                val user = userRepository.save(createUser())
+                shouldNotThrow<Exception> {
+                    applicationFormService.create(
+                        user.id,
+                        CreateApplicationFormRequest(recruitment.id)
+                    )
+                }
+            }
+        }
 
-    @Test
-    fun `이미 지원한 지원에는 중복으로 지원할 수 없다`() {
-        val recruitment = recruitmentRepository.save(createRecruitment(termId = 0L, recruitable = true))
-        val user = userRepository.save(createUser())
-        applicationFormRepository.save(
-            createApplicationForm(
-                user.id,
-                recruitment.id,
-                submitted = true,
-                submittedDateTime = LocalDateTime.now()
-            )
-        )
-        assertThrows<IllegalStateException> {
-            applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id))
+        context("이미 지원한 지원에는") {
+            it("중복으로 지원할 수 없다.") {
+                val recruitment = recruitmentRepository.save(createRecruitment(termId = 0L, recruitable = true))
+                val user = userRepository.save(createUser())
+                applicationFormRepository.save(
+                    createApplicationForm(
+                        user.id,
+                        recruitment.id,
+                        submitted = true,
+                        submittedDateTime = LocalDateTime.now()
+                    )
+                )
+                shouldThrowExactly<IllegalStateException> {
+                    applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id))
+                }
+            }
+        }
+
+        context("동일한 기수의 다른 모집에는") {
+            it("지원할 수 없다.") {
+                val user = userRepository.save(createUser())
+                val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
+                applicationFormRepository.save(
+                    createApplicationForm(
+                        user.id,
+                        appliedRecruitment.id,
+                        submitted = true,
+                        submittedDateTime = LocalDateTime.now()
+                    )
+                )
+                val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
+                shouldThrowExactly<DuplicateApplicationException> {
+                    applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id))
+                }
+            }
+        }
+
+        context("동일한 기수의 다른 모집에 임시 저장되어 있어도") {
+            it("지원서를 제출할 수 있다.") {
+                val user = userRepository.save(createUser())
+                val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
+                applicationFormRepository.save(createApplicationForm(user.id, appliedRecruitment.id, submitted = false))
+                val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
+                applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
+                shouldNotThrow<Exception> {
+                    applicationFormService.update(
+                        user.id,
+                        UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
+                    )
+                }
+            }
+        }
+
+        context("동일한 기수의 다른 모집에 이미 지원서를 제출한 경우에는") {
+            it("지원서를 제출할 수 없다.") {
+                val user = userRepository.save(createUser())
+                val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
+                applicationFormRepository.save(
+                    createApplicationForm(
+                        user.id,
+                        appliedRecruitment.id,
+                        submitted = true,
+                        submittedDateTime = LocalDateTime.now()
+                    )
+                )
+                val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
+                applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
+                shouldThrowExactly<DuplicateApplicationException> {
+                    applicationFormService.update(
+                        user.id,
+                        UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
+                    )
+                }
+            }
         }
     }
 
-    @Test
-    fun `동일한 기수의 다른 모집에 지원할 수 없다`() {
-        val user = userRepository.save(createUser())
-        val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
-        applicationFormRepository.save(
-            createApplicationForm(
-                user.id,
-                appliedRecruitment.id,
-                submitted = true,
-                submittedDateTime = LocalDateTime.now()
-            )
-        )
-        val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
-        assertThrows<DuplicateApplicationException> {
-            applicationFormService.create(user.id, CreateApplicationFormRequest(recruitment.id))
-        }
-    }
+    // describe("지원서를 제출할 때") {
+    //     context("동일한 기수의 다른 모집에 임시 저장되어 있어도") {
+    //         it("지원서를 제출할 수 있다.") {
+    //             val user = userRepository.save(createUser())
+    //             val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
+    //             applicationFormRepository.save(createApplicationForm(user.id, appliedRecruitment.id, submitted = false))
+    //             val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
+    //             applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
+    //             shouldNotThrow<Exception> {
+    //                 applicationFormService.update(
+    //                     user.id,
+    //                     UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
+    //                 )
+    //             }
+    //         }
+    //     }
+    //
+    //     context("동일한 기수의 다른 모집에 이미 지원서를 제출한 경우에는") {
+    //         it("지원서를 제출할 수 없다.") {
+    //             val user = userRepository.save(createUser())
+    //             val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
+    //             applicationFormRepository.save(
+    //                 createApplicationForm(
+    //                     user.id,
+    //                     appliedRecruitment.id,
+    //                     submitted = true,
+    //                     submittedDateTime = LocalDateTime.now()
+    //                 )
+    //             )
+    //             val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
+    //             applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
+    //             shouldThrowExactly<DuplicateApplicationException> {
+    //                 applicationFormService.update(
+    //                     user.id,
+    //                     UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
+    //                 )
+    //             }
+    //         }
+    //     }
+    // }
 
-    @Test
-    fun `동일한 기수의 다른 모집에 임시 저장되어 있어도 지원서를 제출할 수 있다`() {
-        val user = userRepository.save(createUser())
-        val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
-        applicationFormRepository.save(createApplicationForm(user.id, appliedRecruitment.id, submitted = false))
-        val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
-        applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
-        assertDoesNotThrow {
-            applicationFormService.update(
-                user.id,
-                UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
-            )
-        }
-    }
-
-    @Test
-    fun `동일한 기수의 다른 모집에 이미 지원서를 제출한 경우에는 지원서를 제출할 수 없다`() {
-        val user = userRepository.save(createUser())
-        val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
-        applicationFormRepository.save(
-            createApplicationForm(
-                user.id,
-                appliedRecruitment.id,
-                submitted = true,
-                submittedDateTime = LocalDateTime.now()
-            )
-        )
-        val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
-        applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
-        assertThrows<DuplicateApplicationException> {
-            applicationFormService.update(
-                user.id,
-                UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
-            )
-        }
-    }
-
-    @AfterEach
-    internal fun tearDown() {
+    afterEach {
         userRepository.deleteAll()
         applicationFormRepository.deleteAll()
         recruitmentRepository.deleteAll()
     }
-}
+})

--- a/src/test/kotlin/apply/application/ApplicationFormIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormIntegrationTest.kt
@@ -8,6 +8,7 @@ import apply.domain.applicationform.DuplicateApplicationException
 import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.user.UserRepository
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
 import support.test.IntegrationTest
@@ -25,7 +26,7 @@ class ApplicationFormIntegrationTest(
             it("단독 모집에 지원 가능한다.") {
                 val recruitment = recruitmentRepository.save(createRecruitment(termId = 0L, recruitable = true))
                 val user = userRepository.save(createUser())
-                shouldNotThrow<Exception> {
+                shouldNotThrowAny {
                     applicationFormService.create(
                         user.id,
                         CreateApplicationFormRequest(recruitment.id)
@@ -110,47 +111,6 @@ class ApplicationFormIntegrationTest(
             }
         }
     }
-
-    // describe("지원서를 제출할 때") {
-    //     context("동일한 기수의 다른 모집에 임시 저장되어 있어도") {
-    //         it("지원서를 제출할 수 있다.") {
-    //             val user = userRepository.save(createUser())
-    //             val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
-    //             applicationFormRepository.save(createApplicationForm(user.id, appliedRecruitment.id, submitted = false))
-    //             val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
-    //             applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
-    //             shouldNotThrow<Exception> {
-    //                 applicationFormService.update(
-    //                     user.id,
-    //                     UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
-    //                 )
-    //             }
-    //         }
-    //     }
-    //
-    //     context("동일한 기수의 다른 모집에 이미 지원서를 제출한 경우에는") {
-    //         it("지원서를 제출할 수 없다.") {
-    //             val user = userRepository.save(createUser())
-    //             val appliedRecruitment = recruitmentRepository.save(createRecruitment(termId = 1L))
-    //             applicationFormRepository.save(
-    //                 createApplicationForm(
-    //                     user.id,
-    //                     appliedRecruitment.id,
-    //                     submitted = true,
-    //                     submittedDateTime = LocalDateTime.now()
-    //                 )
-    //             )
-    //             val recruitment = recruitmentRepository.save(createRecruitment(termId = 1L, recruitable = true))
-    //             applicationFormRepository.save(createApplicationForm(user.id, recruitment.id, submitted = false))
-    //             shouldThrowExactly<DuplicateApplicationException> {
-    //                 applicationFormService.update(
-    //                     user.id,
-    //                     UpdateApplicationFormRequest(recruitmentId = recruitment.id, submitted = true)
-    //                 )
-    //             }
-    //         }
-    //     }
-    // }
 
     afterEach {
         userRepository.deleteAll()

--- a/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
@@ -16,6 +16,7 @@ import apply.domain.recruitmentitem.RecruitmentItemRepository
 import apply.pass
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
@@ -126,7 +127,7 @@ class ApplicationFormServiceTest : DescribeSpec({
 
             val expected = applicationFormService.getMyApplicationForms(userId)
 
-            assertSoftly {
+            assertSoftly(expected) {
                 expected.shouldNotBeNull()
                 expected shouldHaveSize 2
             }
@@ -138,7 +139,7 @@ class ApplicationFormServiceTest : DescribeSpec({
 
                 val expected = applicationFormService.getMyApplicationForms(userId)
 
-                assertSoftly {
+                assertSoftly(expected) {
                     expected.shouldNotBeNull()
                     expected shouldHaveSize 0
                 }
@@ -151,7 +152,7 @@ class ApplicationFormServiceTest : DescribeSpec({
             every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
             every { applicationValidator.validate(any(), any()) } just Runs
 
-            shouldNotThrow<Exception> { applicationFormService.create(userId, createApplicationFormRequest) }
+            shouldNotThrowAny { applicationFormService.create(userId, createApplicationFormRequest) }
         }
 
         context("이미 작성한 지원서가 있는 경우") {

--- a/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
@@ -14,284 +14,268 @@ import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.recruitmentitem.RecruitmentItem
 import apply.domain.recruitmentitem.RecruitmentItemRepository
 import apply.pass
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import support.test.UnitTest
 import java.time.LocalDateTime
 
 @UnitTest
-class ApplicationFormServiceTest {
+class ApplicationFormServiceTest : DescribeSpec({
     @MockK
-    private lateinit var applicationFormRepository: ApplicationFormRepository
-
-    @MockK
-    private lateinit var recruitmentRepository: RecruitmentRepository
+    val applicationFormRepository: ApplicationFormRepository = mockk()
 
     @MockK
-    private lateinit var recruitmentItemRepository: RecruitmentItemRepository
+    val recruitmentRepository: RecruitmentRepository = mockk()
 
     @MockK
-    private lateinit var applicationValidator: ApplicationValidator
+    val recruitmentItemRepository: RecruitmentItemRepository = mockk()
 
-    private lateinit var applicationFormService: ApplicationFormService
+    @MockK
+    val applicationValidator: ApplicationValidator = mockk()
 
-    private lateinit var applicationForm1: ApplicationForm
-    private lateinit var applicationForm2: ApplicationForm
-    private lateinit var applicationFormSubmitted: ApplicationForm
-    private lateinit var applicationForms: List<ApplicationForm>
-    private lateinit var applicationFormResponse: ApplicationFormResponse
-    private lateinit var createApplicationFormRequest: CreateApplicationFormRequest
-    private lateinit var updateApplicationFormRequest: UpdateApplicationFormRequest
-    private lateinit var updateApplicationFormRequestWithPassword: UpdateApplicationFormRequest
+    val userId: Long = 1L
 
-    private lateinit var recruitment: Recruitment
-    private lateinit var recruitmentItems: List<RecruitmentItem>
-    private lateinit var recruitmentNotRecruiting: Recruitment
-    private lateinit var recruitmentHidden: Recruitment
+    val applicationFormService: ApplicationFormService = ApplicationFormService(
+        applicationFormRepository,
+        recruitmentRepository,
+        recruitmentItemRepository,
+        applicationValidator
+    )
 
-    private val userId: Long = 1L
+    val applicationForm1: ApplicationForm = createApplicationForm()
+    val applicationForm2: ApplicationForm = createApplicationForm(userId = 2L)
+    val applicationFormSubmitted: ApplicationForm = createApplicationForm(userId = 3L).apply { submit(pass) }
+    val applicationForms: List<ApplicationForm> = createApplicationForms()
+    val applicationFormResponse: ApplicationFormResponse = ApplicationFormResponse(
+        id = applicationForm1.id,
+        recruitmentId = applicationForm1.recruitmentId,
+        referenceUrl = applicationForm1.referenceUrl,
+        submitted = applicationForm1.submitted,
+        answers = applicationForm1.answers.items.map { AnswerResponse(it.contents, it.recruitmentItemId) },
+        createdDateTime = applicationForm1.createdDateTime,
+        modifiedDateTime = applicationForm1.modifiedDateTime,
+        submittedDateTime = applicationForm1.submittedDateTime
+    )
+    val createApplicationFormRequest: CreateApplicationFormRequest = CreateApplicationFormRequest(userId)
+    val updateApplicationFormRequest: UpdateApplicationFormRequest = UpdateApplicationFormRequest(
+        recruitmentId = applicationForm1.recruitmentId,
+        referenceUrl = applicationForm1.referenceUrl,
+        submitted = false,
+        answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) }
+    )
+    val updateApplicationFormRequestWithPassword: UpdateApplicationFormRequest = UpdateApplicationFormRequest(
+        recruitmentId = applicationForm1.recruitmentId,
+        referenceUrl = applicationForm1.referenceUrl,
+        submitted = false,
+        answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) }
+    )
 
-    @BeforeEach
-    internal fun setUp() {
-        this.applicationFormService = ApplicationFormService(
-            applicationFormRepository,
-            recruitmentRepository,
-            recruitmentItemRepository,
-            applicationValidator
-        )
-
-        applicationForm1 = createApplicationForm()
-
-        applicationForm2 = createApplicationForm(userId = 2L)
-
-        applicationFormSubmitted = createApplicationForm(userId = 3L).apply { submit(pass) }
-
-        applicationForms = createApplicationForms()
-
-        applicationFormResponse = ApplicationFormResponse(
-            id = applicationForm1.id,
+    val recruitment: Recruitment = createRecruitment(hidden = false)
+    val recruitmentItems: List<RecruitmentItem> = listOf(
+        createRecruitmentItem(
             recruitmentId = applicationForm1.recruitmentId,
-            referenceUrl = applicationForm1.referenceUrl,
-            submitted = applicationForm1.submitted,
-            answers = applicationForm1.answers.items.map { AnswerResponse(it.contents, it.recruitmentItemId) },
-            createdDateTime = applicationForm1.createdDateTime,
-            modifiedDateTime = applicationForm1.modifiedDateTime,
-            submittedDateTime = applicationForm1.submittedDateTime
-        )
-
-        createApplicationFormRequest = CreateApplicationFormRequest(userId)
-
-        updateApplicationFormRequest = UpdateApplicationFormRequest(
+            position = 1,
+            id = 1L
+        ),
+        createRecruitmentItem(
             recruitmentId = applicationForm1.recruitmentId,
-            referenceUrl = applicationForm1.referenceUrl,
-            submitted = false,
-            answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) }
+            position = 2,
+            id = 2L
         )
+    )
+    val recruitmentNotRecruiting: Recruitment = createRecruitment(
+        startDateTime = LocalDateTime.now().minusHours(2),
+        endDateTime = LocalDateTime.now().minusHours(1),
+        hidden = false
+    )
+    val recruitmentHidden: Recruitment = createRecruitment()
 
-        recruitmentItems = listOf(
-            createRecruitmentItem(
-                recruitmentId = applicationForm1.recruitmentId,
-                position = 1,
-                id = 1L
-            ),
-            createRecruitmentItem(
-                recruitmentId = applicationForm1.recruitmentId,
-                position = 2,
-                id = 2L
-            )
-        )
+    describe("ApplicationFormService") {
+        context("지원서가 있으면") {
+            it("지원서를 불러온다") {
+                every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
 
-        updateApplicationFormRequestWithPassword = UpdateApplicationFormRequest(
-            recruitmentId = applicationForm1.recruitmentId,
-            referenceUrl = applicationForm1.referenceUrl,
-            submitted = false,
-            answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) }
-        )
-
-        recruitment = createRecruitment(hidden = false)
-
-        recruitmentNotRecruiting = createRecruitment(
-            startDateTime = LocalDateTime.now().minusHours(2),
-            endDateTime = LocalDateTime.now().minusHours(1),
-            hidden = false
-        )
-
-        recruitmentHidden = createRecruitment()
-    }
-
-    @Test
-    fun `지원서가 있으면 지원서를 불러온다`() {
-        every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
-
-        assertThat(applicationFormService.getApplicationForm(userId, 1L)).isEqualTo(applicationFormResponse)
-    }
-
-    @Test
-    fun `지원서가 없으면 예외를 던진다`() {
-        every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns null
-
-        assertThrows<IllegalArgumentException> { applicationFormService.getApplicationForm(1L, 1L) }
-    }
-
-    @Test
-    fun `지원자가 자신의 지원서를 모두 불러온다`() {
-        every { applicationFormRepository.findAllByUserId(userId) } returns applicationForms
-
-        val expected = applicationFormService.getMyApplicationForms(userId)
-
-        assertAll(
-            { assertThat(expected).isNotNull },
-            { assertThat(expected).hasSize(2) }
-        )
-    }
-
-    @Test
-    fun `지원자가 지원한 지원서가 없으면 빈 리스트를 불러온다`() {
-        every { applicationFormRepository.findAllByUserId(userId) } returns emptyList()
-
-        val expected = applicationFormService.getMyApplicationForms(userId)
-
-        assertAll(
-            { assertThat(expected).isNotNull },
-            { assertThat(expected).hasSize(0) }
-        )
-    }
-
-    @Test
-    fun `지원서를 생성한다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        every { applicationFormRepository.existsByRecruitmentIdAndUserId(any(), any()) } returns false
-        every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
-        every { applicationValidator.validate(any(), any()) } just Runs
-
-        assertDoesNotThrow { applicationFormService.create(userId, createApplicationFormRequest) }
-    }
-
-    @Test
-    fun `이미 작성한 지원서가 있는 경우 지원할 수 없다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        every { applicationFormRepository.existsByRecruitmentIdAndUserId(any(), any()) } returns true
-        every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
-        every { applicationValidator.validate(any(), any()) } just Runs
-
-        assertThrows<IllegalStateException> {
-            applicationFormService.create(
-                userId,
-                createApplicationFormRequest
-            )
+                applicationFormService.getApplicationForm(userId, 1L) shouldBe applicationFormResponse
+            }
         }
-    }
 
-    @Test
-    fun `모집이 없는 경우 지원할 수 없다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns null
+        context("지원서가 없으면") {
+            it("예외를 던진다") {
+                every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns null
 
-        assertThrows<NoSuchElementException> {
-            applicationFormService.create(
-                userId,
-                createApplicationFormRequest
-            )
+                shouldThrowExactly<IllegalArgumentException> {
+                    applicationFormService.getApplicationForm(1L, 1L)
+                }
+            }
         }
-    }
 
-    @Test
-    fun `지원서를 수정한다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
-        every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
-        every { applicationFormRepository.save(any()) } returns applicationForm1
+        it("지원자가 자신의 지원서를 모두 불러온다") {
+            every { applicationFormRepository.findAllByUserId(userId) } returns applicationForms
 
-        assertDoesNotThrow { applicationFormService.update(userId, updateApplicationFormRequest) }
-    }
+            val expected = applicationFormService.getMyApplicationForms(userId)
 
-    @Test
-    fun `지원서가 없는 경우 수정할 수 없다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
-        every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
-        every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns null
-
-        assertThrows<IllegalArgumentException> {
-            applicationFormService.update(
-                userId,
-                updateApplicationFormRequest
-            )
+            assertSoftly {
+                expected.shouldNotBeNull()
+                expected shouldHaveSize 2
+            }
         }
-    }
 
-    @Test
-    fun `모집중이 아닌 지원서를 수정할 수 없다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitmentNotRecruiting
+        context("지원자가 지원한 지원서가 없으면") {
+            it("빈 리스트를 불러온다") {
+                every { applicationFormRepository.findAllByUserId(userId) } returns emptyList()
 
-        assertThrows<IllegalStateException> {
-            applicationFormService.update(
-                userId,
-                updateApplicationFormRequest
-            )
+                val expected = applicationFormService.getMyApplicationForms(userId)
+
+                assertSoftly {
+                    expected.shouldNotBeNull()
+                    expected shouldHaveSize 0
+                }
+            }
         }
-    }
 
-    @Test
-    fun `제출한 지원서를 열람할 수 없다`() {
-        every {
-            applicationFormRepository.findByRecruitmentIdAndUserId(
-                any(),
-                any()
-            )
-        } returns applicationFormSubmitted
+        it("지원서를 생성한다") {
+            every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+            every { applicationFormRepository.existsByRecruitmentIdAndUserId(any(), any()) } returns false
+            every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
+            every { applicationValidator.validate(any(), any()) } just Runs
 
-        assertThrows<IllegalStateException> {
-            applicationFormService.getApplicationForm(
-                userId = 3L,
-                recruitmentId = 1L
-            )
+            shouldNotThrow<Exception> { applicationFormService.create(userId, createApplicationFormRequest) }
         }
-    }
 
-    @Test
-    fun `작성하지 않은 문항이 존재하는 경우 제출할 수 없다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
-        every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
-        every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
+        context("이미 작성한 지원서가 있는 경우") {
+            it("지원할 수 없다") {
+                every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+                every { applicationFormRepository.existsByRecruitmentIdAndUserId(any(), any()) } returns true
+                every { applicationFormRepository.save(any<ApplicationForm>()) } returns mockk()
+                every { applicationValidator.validate(any(), any()) } just Runs
 
-        assertThrows<IllegalArgumentException> {
-            applicationFormService.update(
-                userId,
-                UpdateApplicationFormRequest(recruitmentId = 1L, submitted = true)
-            )
-        }
-    }
-
-    @Test
-    fun `유효하지 않은 문항이 존재하는 경우 제출할 수 없다`() {
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
-        every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
-        every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
-
-        assertThrows<IllegalArgumentException> {
-            applicationFormService.update(
-                userId,
-                UpdateApplicationFormRequest(
-                    recruitmentId = 1L,
-                    submitted = true,
-                    answers = listOf(
-                        createExceededAnswerRequest(recruitmentItemId = 1L),
-                        createAnswerRequest(recruitmentItemId = 2L)
+                shouldThrow<IllegalStateException> {
+                    applicationFormService.create(
+                        userId,
+                        createApplicationFormRequest
                     )
-                )
-            )
+                }
+            }
+        }
+
+        context("모집이 없는 경우") {
+            it("지원할 수 없다") {
+                every { recruitmentRepository.findByIdOrNull(any()) } returns null
+
+                shouldThrowExactly<NoSuchElementException> {
+                    applicationFormService.create(
+                        userId,
+                        createApplicationFormRequest
+                    )
+                }
+            }
+        }
+
+        it("지원서를 수정한다") {
+            every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+            every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
+            every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
+            every { applicationFormRepository.save(any()) } returns applicationForm1
+
+            shouldNotThrow<Exception> { applicationFormService.update(userId, updateApplicationFormRequest) }
+        }
+
+        context("지원서가 없는 경우") {
+            it("수정할 수 없다") {
+                every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
+                every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
+                every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns null
+
+                shouldThrowExactly<IllegalArgumentException> {
+                    applicationFormService.update(
+                        userId,
+                        updateApplicationFormRequest
+                    )
+                }
+            }
+        }
+
+        context("모집중이 아닌 지원서는") {
+            it("수정할 수 없다") {
+                every { recruitmentRepository.findByIdOrNull(any()) } returns recruitmentNotRecruiting
+
+                shouldThrowExactly<IllegalStateException> {
+                    applicationFormService.update(
+                        userId,
+                        updateApplicationFormRequest
+                    )
+                }
+            }
+        }
+
+        context("제출한 지원서는") {
+            it("열람할 수 없다") {
+                every {
+                    applicationFormRepository.findByRecruitmentIdAndUserId(
+                        any(),
+                        any()
+                    )
+                } returns applicationFormSubmitted
+
+                shouldThrowExactly<IllegalStateException> {
+                    applicationFormService.getApplicationForm(
+                        userId = 3L,
+                        recruitmentId = 1L
+                    )
+                }
+            }
+        }
+
+        context("작성하지 않은 문항이 존재하는 경우") {
+            it("제출할 수 없다") {
+                every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
+                every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
+                every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
+
+                shouldThrowExactly<IllegalArgumentException> {
+                    applicationFormService.update(
+                        userId,
+                        UpdateApplicationFormRequest(recruitmentId = 1L, submitted = true)
+                    )
+                }
+            }
+        }
+
+        context("유효하지 않은 문항이 존재하는 경우") {
+            it("제출할 수 없다") {
+                every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns recruitmentItems
+                every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
+                every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
+
+                shouldThrowExactly<IllegalArgumentException> {
+                    applicationFormService.update(
+                        userId,
+                        UpdateApplicationFormRequest(
+                            recruitmentId = 1L,
+                            submitted = true,
+                            answers = listOf(
+                                createExceededAnswerRequest(recruitmentItemId = 1L),
+                                createAnswerRequest(recruitmentItemId = 2L)
+                            )
+                        )
+                    )
+                }
+            }
         }
     }
-}
+})

--- a/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
@@ -18,7 +18,6 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -116,7 +115,7 @@ class ApplicationFormServiceTest : DescribeSpec({
             it("예외를 던진다") {
                 every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns null
 
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     applicationFormService.getApplicationForm(1L, 1L)
                 }
             }
@@ -175,7 +174,7 @@ class ApplicationFormServiceTest : DescribeSpec({
             it("지원할 수 없다") {
                 every { recruitmentRepository.findByIdOrNull(any()) } returns null
 
-                shouldThrowExactly<NoSuchElementException> {
+                shouldThrow<NoSuchElementException> {
                     applicationFormService.create(
                         userId,
                         createApplicationFormRequest
@@ -200,7 +199,7 @@ class ApplicationFormServiceTest : DescribeSpec({
                 every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
                 every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns null
 
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     applicationFormService.update(
                         userId,
                         updateApplicationFormRequest
@@ -213,7 +212,7 @@ class ApplicationFormServiceTest : DescribeSpec({
             it("수정할 수 없다") {
                 every { recruitmentRepository.findByIdOrNull(any()) } returns recruitmentNotRecruiting
 
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     applicationFormService.update(
                         userId,
                         updateApplicationFormRequest
@@ -231,7 +230,7 @@ class ApplicationFormServiceTest : DescribeSpec({
                     )
                 } returns applicationFormSubmitted
 
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     applicationFormService.getApplicationForm(
                         userId = 3L,
                         recruitmentId = 1L
@@ -247,7 +246,7 @@ class ApplicationFormServiceTest : DescribeSpec({
                 every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
                 every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
 
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     applicationFormService.update(
                         userId,
                         UpdateApplicationFormRequest(recruitmentId = 1L, submitted = true)
@@ -263,7 +262,7 @@ class ApplicationFormServiceTest : DescribeSpec({
                 every { applicationFormRepository.existsByUserIdAndSubmittedTrue(any()) } returns false
                 every { applicationFormRepository.findByRecruitmentIdAndUserId(any(), any()) } returns applicationForm1
 
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     applicationFormService.update(
                         userId,
                         UpdateApplicationFormRequest(

--- a/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
@@ -1,11 +1,6 @@
 package apply.application
 
-import apply.createAnswerRequest
-import apply.createApplicationForm
-import apply.createApplicationForms
-import apply.createExceededAnswerRequest
-import apply.createRecruitment
-import apply.createRecruitmentItem
+import apply.*
 import apply.domain.applicationform.ApplicationForm
 import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.applicationform.ApplicationValidator
@@ -13,7 +8,6 @@ import apply.domain.recruitment.Recruitment
 import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.recruitmentitem.RecruitmentItem
 import apply.domain.recruitmentitem.RecruitmentItemRepository
-import apply.pass
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -45,9 +39,9 @@ class ApplicationFormServiceTest : DescribeSpec({
     @MockK
     val applicationValidator: ApplicationValidator = mockk()
 
-    val userId: Long = 1L
+    val userId = 1L
 
-    val applicationFormService: ApplicationFormService = ApplicationFormService(
+    val applicationFormService = ApplicationFormService(
         applicationFormRepository,
         recruitmentRepository,
         recruitmentItemRepository,
@@ -58,7 +52,7 @@ class ApplicationFormServiceTest : DescribeSpec({
     val applicationForm2: ApplicationForm = createApplicationForm(userId = 2L)
     val applicationFormSubmitted: ApplicationForm = createApplicationForm(userId = 3L).apply { submit(pass) }
     val applicationForms: List<ApplicationForm> = createApplicationForms()
-    val applicationFormResponse: ApplicationFormResponse = ApplicationFormResponse(
+    val applicationFormResponse = ApplicationFormResponse(
         id = applicationForm1.id,
         recruitmentId = applicationForm1.recruitmentId,
         referenceUrl = applicationForm1.referenceUrl,
@@ -68,14 +62,14 @@ class ApplicationFormServiceTest : DescribeSpec({
         modifiedDateTime = applicationForm1.modifiedDateTime,
         submittedDateTime = applicationForm1.submittedDateTime
     )
-    val createApplicationFormRequest: CreateApplicationFormRequest = CreateApplicationFormRequest(userId)
-    val updateApplicationFormRequest: UpdateApplicationFormRequest = UpdateApplicationFormRequest(
+    val createApplicationFormRequest = CreateApplicationFormRequest(userId)
+    val updateApplicationFormRequest = UpdateApplicationFormRequest(
         recruitmentId = applicationForm1.recruitmentId,
         referenceUrl = applicationForm1.referenceUrl,
         submitted = false,
         answers = applicationForm1.answers.items.map { AnswerRequest(it.contents, it.recruitmentItemId) }
     )
-    val updateApplicationFormRequestWithPassword: UpdateApplicationFormRequest = UpdateApplicationFormRequest(
+    val updateApplicationFormRequestWithPassword = UpdateApplicationFormRequest(
         recruitmentId = applicationForm1.recruitmentId,
         referenceUrl = applicationForm1.referenceUrl,
         submitted = false,

--- a/src/test/kotlin/apply/application/AssignmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/AssignmentServiceTest.kt
@@ -11,12 +11,10 @@ import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
 import io.kotest.assertions.assertSoftly
-import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldBeBlank
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.data.repository.findByIdOrNull
@@ -48,7 +46,7 @@ class AssignmentServiceTest : DescribeSpec({
                 )
             } returns createEvaluationTarget()
             every { assignmentRepository.save(any()) } returns createAssignment()
-            shouldNotThrow<Exception> { assignmentService.create(missionId, loginUser.id, createAssignmentRequest()) }
+            shouldNotThrowAny { assignmentService.create(missionId, loginUser.id, createAssignmentRequest()) }
         }
 
         context("과제 제출 기간이 아니면") {
@@ -110,20 +108,20 @@ class AssignmentServiceTest : DescribeSpec({
                 every { assignmentRepository.save(any()) } returns createAssignment()
 
                 assignmentService.create(missionId, loginUser.id, createAssignmentRequest())
-                evaluationTarget.isPassed.shouldBeTrue()
+                evaluationTarget.isPassed shouldBe true
             }
         }
 
         it("제출한 과제 제출물을 수정할 수 있다") {
             every { missionRepository.getById(any()) } returns createMission()
             every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns createAssignment()
-            shouldNotThrow<Exception> { assignmentService.update(1L, 1L, createAssignmentRequest()) }
+            shouldNotThrowAny { assignmentService.update(1L, 1L, createAssignmentRequest()) }
         }
 
         context("과제를 제출한 적이 있는 경우") {
             it("제출물 조회시 제출물을 반환한다") {
                 every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns createAssignment()
-                shouldNotThrow<Exception> { assignmentService.getByUserIdAndMissionId(loginUser.id, missionId) }
+                shouldNotThrowAny { assignmentService.getByUserIdAndMissionId(loginUser.id, missionId) }
             }
         }
 
@@ -176,10 +174,10 @@ class AssignmentServiceTest : DescribeSpec({
 
                 val actual = subject()
 
-                assertSoftly {
-                    actual.githubUsername.shouldBeBlank()
-                    actual.pullRequestUrl.shouldBeBlank()
-                    actual.note.shouldBeBlank()
+                assertSoftly(actual) {
+                    actual.githubUsername shouldBe ""
+                    actual.pullRequestUrl shouldBe ""
+                    actual.note shouldBe ""
                 }
             }
 
@@ -191,7 +189,7 @@ class AssignmentServiceTest : DescribeSpec({
 
                 val actual = subject()
 
-                assertSoftly {
+                assertSoftly(actual) {
                     actual.githubUsername shouldBe assignment.githubUsername
                     actual.pullRequestUrl shouldBe assignment.pullRequestUrl
                     actual.note shouldBe assignment.note

--- a/src/test/kotlin/apply/application/AssignmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/AssignmentServiceTest.kt
@@ -10,186 +10,193 @@ import apply.domain.evaluationtarget.EvaluationStatus
 import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeBlank
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
+import io.mockk.mockk
 import org.springframework.data.repository.findByIdOrNull
 import support.test.UnitTest
 import java.time.LocalDateTime
 
 @UnitTest
-class AssignmentServiceTest {
-    @MockK
-    private lateinit var assignmentRepository: AssignmentRepository
+class AssignmentServiceTest : DescribeSpec({
+    val assignmentRepository: AssignmentRepository = mockk()
 
-    @MockK
-    private lateinit var missionRepository: MissionRepository
+    val missionRepository: MissionRepository = mockk()
 
-    @MockK
-    private lateinit var evaluationTargetRepository: EvaluationTargetRepository
+    val evaluationTargetRepository: EvaluationTargetRepository = mockk()
 
-    private lateinit var assignmentService: AssignmentService
+    val assignmentService: AssignmentService =
+        AssignmentService(assignmentRepository, missionRepository, evaluationTargetRepository)
 
-    private val loginUser = createUser()
-    private val missionId = 1L
+    val loginUser = createUser()
+    val missionId = 1L
 
-    @BeforeEach
-    internal fun setUp() {
-        assignmentService = AssignmentService(assignmentRepository, missionRepository, evaluationTargetRepository)
-    }
-
-    @Test
-    fun `과제 제출물을 생성한다`() {
-        every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
-        every { missionRepository.getById(any()) } returns createMission()
-        every { evaluationTargetRepository.findByEvaluationIdAndUserId(any(), any()) } returns createEvaluationTarget()
-        every { assignmentRepository.save(any()) } returns createAssignment()
-        assertDoesNotThrow { assignmentService.create(missionId, loginUser.id, createAssignmentRequest()) }
-    }
-
-    @Test
-    fun `과제 제출 기간이 아니면 생성할 수 없다`() {
-        every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
-        every { missionRepository.getById(any()) } returns createMission(
-            startDateTime = LocalDateTime.now().minusDays(2), endDateTime = LocalDateTime.now().minusDays(1)
-        )
-        assertThrows<IllegalStateException> {
-            assignmentService.create(
-                missionId,
-                loginUser.id,
-                createAssignmentRequest()
-            )
-        }
-    }
-
-    @Test
-    fun `이미 제출한 이력이 있는 경우 새로 제출할 수 없다`() {
-        every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns true
-        assertThrows<IllegalStateException> { assignmentService.create(1L, 1L, createAssignmentRequest()) }
-    }
-
-    @Test
-    fun `평가 대상자가 아닌 경우 과제를 제출할 수 없다`() {
-        every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
-        every { missionRepository.getById(any()) } returns createMission()
-        every { evaluationTargetRepository.findByEvaluationIdAndUserId(any(), any()) } returns null
-        assertThrows<IllegalArgumentException> {
-            assignmentService.create(
-                missionId,
-                loginUser.id,
-                createAssignmentRequest()
-            )
-        }
-    }
-
-    @Test
-    fun `평가 상태가 'Waiting'이라면, 'Pass'로 업데이트한다`() {
-        val evaluationTarget = createEvaluationTarget(evaluationStatus = EvaluationStatus.WAITING)
-
-        every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
-        every { missionRepository.getById(any()) } returns createMission()
-        every { evaluationTargetRepository.findByEvaluationIdAndUserId(any(), any()) } returns evaluationTarget
-        every { assignmentRepository.save(any()) } returns createAssignment()
-
-        assignmentService.create(missionId, loginUser.id, createAssignmentRequest())
-        assertThat(evaluationTarget.isPassed).isTrue
-    }
-
-    @Test
-    fun `제출한 과제 제출물을 수정할 수 있다`() {
-        every { missionRepository.getById(any()) } returns createMission()
-        every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns createAssignment()
-        assertDoesNotThrow { assignmentService.update(1L, 1L, createAssignmentRequest()) }
-    }
-
-    @Test
-    fun `과제를 제출한 적이 있는 경우 제출물 조회시 제출물을 반환한다`() {
-        every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns createAssignment()
-        assertDoesNotThrow { assignmentService.getByUserIdAndMissionId(loginUser.id, missionId) }
-    }
-
-    @Test
-    fun `과제를 제출한 적이 없는 경우 제출물 조회시 예외를 반환한다`() {
-        every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
-        assertThrows<IllegalArgumentException> {
-            assignmentService.getByUserIdAndMissionId(
-                loginUser.id,
-                missionId
-            )
-        }
-    }
-
-    @Test
-    fun `제출 불가능한 과제의 과제 제출물을 수정할 수 없다`() {
-        every { missionRepository.getById(any()) } returns createMission(submittable = false)
-        assertThrows<IllegalStateException> { assignmentService.update(1L, 1L, createAssignmentRequest()) }
-    }
-
-    @Test
-    fun `과제 제출 기간이 아니면 과제 제출물을 수정할 수 없다`() {
-        every { missionRepository.getById(any()) } returns createMission(
-            startDateTime = LocalDateTime.now().minusDays(2), endDateTime = LocalDateTime.now().minusDays(1)
-        )
-        assertThrows<IllegalStateException> { assignmentService.update(1L, 1L, createAssignmentRequest()) }
-    }
-
-    @Test
-    fun `제출한 과제 제출물이 없는 경우 수정할 수 없다`() {
-        every { missionRepository.getById(any()) } returns createMission()
-        every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
-        assertThrows<IllegalArgumentException> { assignmentService.update(1L, 1L, createAssignmentRequest()) }
-    }
-
-    @DisplayName("과제 id와 평가 대상자 id로 과제 제출물 조회는")
-    @Nested
-    inner class Find {
-        fun subject(): AssignmentData {
-            return assignmentService.findByEvaluationTargetId(1L)!!
+    describe("AssignmentService") {
+        it("과제 제출물을 생성한다") {
+            every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
+            every { missionRepository.getById(any()) } returns createMission()
+            every {
+                evaluationTargetRepository.findByEvaluationIdAndUserId(
+                    any(),
+                    any()
+                )
+            } returns createEvaluationTarget()
+            every { assignmentRepository.save(any()) } returns createAssignment()
+            shouldNotThrow<Exception> { assignmentService.create(missionId, loginUser.id, createAssignmentRequest()) }
         }
 
-        @Test
-        fun `평가 대상자가 존재하지 않으면 예외가 발생한다`() {
-            every { evaluationTargetRepository.findByIdOrNull(any()) } returns null
+        context("과제 제출 기간이 아니면") {
+            it("과제 제출물을 생성할 수 없다") {
+                every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
+                every { missionRepository.getById(any()) } returns createMission(
+                    startDateTime = LocalDateTime.now().minusDays(2), endDateTime = LocalDateTime.now().minusDays(1)
+                )
+                shouldThrowExactly<IllegalStateException> {
+                    assignmentService.create(
+                        missionId,
+                        loginUser.id,
+                        createAssignmentRequest()
+                    )
+                }
+            }
 
-            assertThrows<NoSuchElementException> { subject() }
+            it("과제 제출물을 수정할 수 없다") {
+                every { missionRepository.getById(any()) } returns createMission(
+                    startDateTime = LocalDateTime.now().minusDays(2), endDateTime = LocalDateTime.now().minusDays(1)
+                )
+                shouldThrowExactly<IllegalStateException> {
+                    assignmentService.update(1L, 1L, createAssignmentRequest())
+                }
+            }
         }
 
-        @Test
-        fun `평가 대상자가 제출한 과제 제출물이 없으면 빈 과제 제출물 데이터를 반환한다`() {
-            every { evaluationTargetRepository.findByIdOrNull(any()) } returns createEvaluationTarget()
-            every { missionRepository.findByEvaluationId(any()) } returns createMission()
-            every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
-
-            val actual = subject()
-
-            assertAll(
-                { assertThat(actual.githubUsername).isBlank() },
-                { assertThat(actual.pullRequestUrl).isBlank() },
-                { assertThat(actual.note).isBlank() }
-            )
+        context("이미 제출한 이력이 있는 경우") {
+            it("새로 제출할 수 없다") {
+                every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns true
+                shouldThrowExactly<IllegalStateException> {
+                    assignmentService.create(1L, 1L, createAssignmentRequest())
+                }
+            }
         }
 
-        @Test
-        fun `평가 대상자가 제출한 과제 제출물이 있으면 평가 대상자가 제출한 과제 제출물 데이터를 반환한다`() {
-            val assignment = createAssignment()
-            every { evaluationTargetRepository.findByIdOrNull(any()) } returns createEvaluationTarget()
-            every { missionRepository.findByEvaluationId(any()) } returns createMission()
-            every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns assignment
+        context("평가 대상자가 아닌 경우") {
+            it("과제를 제출할 수 없다") {
+                every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
+                every { missionRepository.getById(any()) } returns createMission()
+                every { evaluationTargetRepository.findByEvaluationIdAndUserId(any(), any()) } returns null
+                shouldThrowExactly<IllegalArgumentException> {
+                    assignmentService.create(
+                        missionId,
+                        loginUser.id,
+                        createAssignmentRequest()
+                    )
+                }
+            }
+        }
 
-            val actual = subject()
+        context("평가 상태가 'Waiting'이라면") {
+            it("'Pass'로 업데이트한다") {
+                val evaluationTarget = createEvaluationTarget(evaluationStatus = EvaluationStatus.WAITING)
 
-            assertAll(
-                { assertThat(actual.githubUsername).isEqualTo(assignment.githubUsername) },
-                { assertThat(actual.pullRequestUrl).isEqualTo(assignment.pullRequestUrl) },
-                { assertThat(actual.note).isEqualTo(assignment.note) }
-            )
+                every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
+                every { missionRepository.getById(any()) } returns createMission()
+                every { evaluationTargetRepository.findByEvaluationIdAndUserId(any(), any()) } returns evaluationTarget
+                every { assignmentRepository.save(any()) } returns createAssignment()
+
+                assignmentService.create(missionId, loginUser.id, createAssignmentRequest())
+                evaluationTarget.isPassed.shouldBeTrue()
+            }
+        }
+
+        it("제출한 과제 제출물을 수정할 수 있다") {
+            every { missionRepository.getById(any()) } returns createMission()
+            every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns createAssignment()
+            shouldNotThrow<Exception> { assignmentService.update(1L, 1L, createAssignmentRequest()) }
+        }
+
+        context("과제를 제출한 적이 있는 경우") {
+            it("제출물 조회시 제출물을 반환한다") {
+                every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns createAssignment()
+                shouldNotThrow<Exception> { assignmentService.getByUserIdAndMissionId(loginUser.id, missionId) }
+            }
+        }
+
+        context("과제를 제출한 적이 없는 경우") {
+            it("제출물 조회시 예외를 반환한다") {
+                every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
+                shouldThrowExactly<IllegalArgumentException> {
+                    assignmentService.getByUserIdAndMissionId(
+                        loginUser.id,
+                        missionId
+                    )
+                }
+            }
+        }
+
+        context("제출 불가능한 과제의") {
+            it("과제 제출물을 수정할 수 없다") {
+                every { missionRepository.getById(any()) } returns createMission(submittable = false)
+                shouldThrowExactly<IllegalStateException> {
+                    assignmentService.update(1L, 1L, createAssignmentRequest())
+                }
+            }
+        }
+
+        context("제출한 과제 제출물이 없는 경우") {
+            it("수정할 수 없다") {
+                every { missionRepository.getById(any()) } returns createMission()
+                every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
+                shouldThrowExactly<IllegalArgumentException> {
+                    assignmentService.update(1L, 1L, createAssignmentRequest())
+                }
+            }
+        }
+
+        context("과제 id와 평가 대상자 id로 과제 제출물 조회는") {
+            fun subject(): AssignmentData {
+                return assignmentService.findByEvaluationTargetId(1L)!!
+            }
+
+            it("평가 대상자가 존재하지 않으면 예외가 발생한다") {
+                every { evaluationTargetRepository.findByIdOrNull(any()) } returns null
+
+                shouldThrowExactly<NoSuchElementException> { subject() }
+            }
+
+            it("평가 대상자가 제출한 과제 제출물이 없으면 빈 과제 제출물 데이터를 반환한다") {
+                every { evaluationTargetRepository.findByIdOrNull(any()) } returns createEvaluationTarget()
+                every { missionRepository.findByEvaluationId(any()) } returns createMission()
+                every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
+
+                val actual = subject()
+
+                assertSoftly {
+                    actual.githubUsername.shouldBeBlank()
+                    actual.pullRequestUrl.shouldBeBlank()
+                    actual.note.shouldBeBlank()
+                }
+            }
+
+            it("평가 대상자가 제출한 과제 제출물이 있으면 평가 대상자가 제출한 과제 제출물 데이터를 반환한다") {
+                val assignment = createAssignment()
+                every { evaluationTargetRepository.findByIdOrNull(any()) } returns createEvaluationTarget()
+                every { missionRepository.findByEvaluationId(any()) } returns createMission()
+                every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns assignment
+
+                val actual = subject()
+
+                assertSoftly {
+                    actual.githubUsername shouldBe assignment.githubUsername
+                    actual.pullRequestUrl shouldBe assignment.pullRequestUrl
+                    actual.note shouldBe assignment.note
+                }
+            }
         }
     }
-}
+})

--- a/src/test/kotlin/apply/application/AssignmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/AssignmentServiceTest.kt
@@ -12,7 +12,7 @@ import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -55,7 +55,7 @@ class AssignmentServiceTest : DescribeSpec({
                 every { missionRepository.getById(any()) } returns createMission(
                     startDateTime = LocalDateTime.now().minusDays(2), endDateTime = LocalDateTime.now().minusDays(1)
                 )
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     assignmentService.create(
                         missionId,
                         loginUser.id,
@@ -68,7 +68,7 @@ class AssignmentServiceTest : DescribeSpec({
                 every { missionRepository.getById(any()) } returns createMission(
                     startDateTime = LocalDateTime.now().minusDays(2), endDateTime = LocalDateTime.now().minusDays(1)
                 )
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     assignmentService.update(1L, 1L, createAssignmentRequest())
                 }
             }
@@ -77,7 +77,7 @@ class AssignmentServiceTest : DescribeSpec({
         context("이미 제출한 이력이 있는 경우") {
             it("새로 제출할 수 없다") {
                 every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns true
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     assignmentService.create(1L, 1L, createAssignmentRequest())
                 }
             }
@@ -88,7 +88,7 @@ class AssignmentServiceTest : DescribeSpec({
                 every { assignmentRepository.existsByUserIdAndMissionId(any(), any()) } returns false
                 every { missionRepository.getById(any()) } returns createMission()
                 every { evaluationTargetRepository.findByEvaluationIdAndUserId(any(), any()) } returns null
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     assignmentService.create(
                         missionId,
                         loginUser.id,
@@ -128,7 +128,7 @@ class AssignmentServiceTest : DescribeSpec({
         context("과제를 제출한 적이 없는 경우") {
             it("제출물 조회시 예외를 반환한다") {
                 every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     assignmentService.getByUserIdAndMissionId(
                         loginUser.id,
                         missionId
@@ -140,7 +140,7 @@ class AssignmentServiceTest : DescribeSpec({
         context("제출 불가능한 과제의") {
             it("과제 제출물을 수정할 수 없다") {
                 every { missionRepository.getById(any()) } returns createMission(submittable = false)
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     assignmentService.update(1L, 1L, createAssignmentRequest())
                 }
             }
@@ -150,7 +150,7 @@ class AssignmentServiceTest : DescribeSpec({
             it("수정할 수 없다") {
                 every { missionRepository.getById(any()) } returns createMission()
                 every { assignmentRepository.findByUserIdAndMissionId(any(), any()) } returns null
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     assignmentService.update(1L, 1L, createAssignmentRequest())
                 }
             }
@@ -164,7 +164,7 @@ class AssignmentServiceTest : DescribeSpec({
             it("평가 대상자가 존재하지 않으면 예외가 발생한다") {
                 every { evaluationTargetRepository.findByIdOrNull(any()) } returns null
 
-                shouldThrowExactly<NoSuchElementException> { subject() }
+                shouldThrow<NoSuchElementException> { subject() }
             }
 
             it("평가 대상자가 제출한 과제 제출물이 없으면 빈 과제 제출물 데이터를 반환한다") {

--- a/src/test/kotlin/apply/application/AssignmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/AssignmentServiceTest.kt
@@ -1,10 +1,6 @@
 package apply.application
 
-import apply.createAssignment
-import apply.createAssignmentRequest
-import apply.createEvaluationTarget
-import apply.createMission
-import apply.createUser
+import apply.*
 import apply.domain.assignment.AssignmentRepository
 import apply.domain.evaluationtarget.EvaluationStatus
 import apply.domain.evaluationtarget.EvaluationTargetRepository
@@ -29,7 +25,7 @@ class AssignmentServiceTest : DescribeSpec({
 
     val evaluationTargetRepository: EvaluationTargetRepository = mockk()
 
-    val assignmentService: AssignmentService =
+    val assignmentService =
         AssignmentService(assignmentRepository, missionRepository, evaluationTargetRepository)
 
     val loginUser = createUser()

--- a/src/test/kotlin/apply/application/CheaterServiceTest.kt
+++ b/src/test/kotlin/apply/application/CheaterServiceTest.kt
@@ -4,40 +4,33 @@ import apply.createCheaterData
 import apply.domain.cheater.Cheater
 import apply.domain.cheater.CheaterRepository
 import apply.domain.user.UserRepository
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
+import io.mockk.mockk
 import support.test.UnitTest
 
 @UnitTest
-internal class CheaterServiceTest {
-    @MockK
-    private lateinit var userRepository: UserRepository
+internal class CheaterServiceTest : DescribeSpec({
+    val userRepository: UserRepository = mockk()
+    val cheaterRepository: CheaterRepository = mockk()
+    val cheaterService: CheaterService = CheaterService(userRepository, cheaterRepository)
 
-    @MockK
-    private lateinit var cheaterRepository: CheaterRepository
-    private lateinit var cheaterService: CheaterService
+    describe("CheaterService") {
+        it("부정 행위자를 추가한다") {
+            val cheaterData = createCheaterData()
+            every { cheaterRepository.existsByEmail(any()) } returns false
+            every { cheaterRepository.save(any()) } returns Cheater(cheaterData.email, cheaterData.description)
+            shouldNotThrow<Exception> { cheaterService.save(cheaterData) }
+        }
 
-    @BeforeEach
-    internal fun setUp() {
-        cheaterService = CheaterService(userRepository, cheaterRepository)
+        context("이미 등록된 부정 행위자를 추가하는 경우") {
+            it("예외를 던진다") {
+                val cheaterData = createCheaterData()
+                every { cheaterRepository.existsByEmail(any()) } returns true
+                shouldThrow<IllegalArgumentException> { cheaterService.save(cheaterData) }
+            }
+        }
     }
-
-    @Test
-    fun `부정 행위자를 추가한다`() {
-        val cheaterData = createCheaterData()
-        every { cheaterRepository.existsByEmail(any()) } returns false
-        every { cheaterRepository.save(any()) } returns Cheater(cheaterData.email, cheaterData.description)
-        assertDoesNotThrow { cheaterService.save(cheaterData) }
-    }
-
-    @Test
-    fun `이미 등록된 부정 행위자를 추가하는 경우 예외를 던진다`() {
-        val cheaterData = createCheaterData()
-        every { cheaterRepository.existsByEmail(any()) } returns true
-        assertThrows<IllegalArgumentException> { cheaterService.save(cheaterData) }
-    }
-}
+})

--- a/src/test/kotlin/apply/application/CheaterServiceTest.kt
+++ b/src/test/kotlin/apply/application/CheaterServiceTest.kt
@@ -4,7 +4,7 @@ import apply.createCheaterData
 import apply.domain.cheater.Cheater
 import apply.domain.cheater.CheaterRepository
 import apply.domain.user.UserRepository
-import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
@@ -22,7 +22,7 @@ internal class CheaterServiceTest : DescribeSpec({
             val cheaterData = createCheaterData()
             every { cheaterRepository.existsByEmail(any()) } returns false
             every { cheaterRepository.save(any()) } returns Cheater(cheaterData.email, cheaterData.description)
-            shouldNotThrow<Exception> { cheaterService.save(cheaterData) }
+            shouldNotThrowAny { cheaterService.save(cheaterData) }
         }
 
         context("이미 등록된 부정 행위자를 추가하는 경우") {

--- a/src/test/kotlin/apply/application/CheaterServiceTest.kt
+++ b/src/test/kotlin/apply/application/CheaterServiceTest.kt
@@ -15,7 +15,7 @@ import support.test.UnitTest
 internal class CheaterServiceTest : DescribeSpec({
     val userRepository: UserRepository = mockk()
     val cheaterRepository: CheaterRepository = mockk()
-    val cheaterService: CheaterService = CheaterService(userRepository, cheaterRepository)
+    val cheaterService = CheaterService(userRepository, cheaterRepository)
 
     describe("CheaterService") {
         it("부정 행위자를 추가한다") {

--- a/src/test/kotlin/apply/application/EvaluationServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationServiceTest.kt
@@ -83,7 +83,7 @@ internal class EvaluationServiceTest : DescribeSpec({
 
             evaluationService.deleteById(2L)
 
-            assertSoftly {
+            assertSoftly(evaluationsWithDuplicatedBeforeEvaluationId) {
                 evaluationsWithDuplicatedBeforeEvaluationId[2].beforeEvaluationId shouldBe 0L
                 evaluationsWithDuplicatedBeforeEvaluationId[3].beforeEvaluationId shouldBe 0L
             }

--- a/src/test/kotlin/apply/application/EvaluationServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationServiceTest.kt
@@ -10,96 +10,83 @@ import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluationItem.EvaluationItemRepository
 import apply.domain.recruitment.Recruitment
 import apply.domain.recruitment.RecruitmentRepository
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.mockk.mockk
 import support.test.UnitTest
 import java.util.Optional
 
 @UnitTest
-internal class EvaluationServiceTest {
+internal class EvaluationServiceTest : DescribeSpec({
     @MockK
-    private lateinit var recruitmentRepository: RecruitmentRepository
-
-    @MockK
-    private lateinit var evaluationRepository: EvaluationRepository
+    val recruitmentRepository: RecruitmentRepository = mockk()
 
     @MockK
-    private lateinit var evaluationItemRepository: EvaluationItemRepository
+    val evaluationRepository: EvaluationRepository = mockk()
 
-    private lateinit var evaluationService: EvaluationService
-    private lateinit var recruitments: List<Recruitment>
-    private lateinit var preCourseEvaluation: Evaluation
-    private lateinit var firstEvaluation: Evaluation
-    private lateinit var secondEvaluation: Evaluation
-    private lateinit var evaluations: List<Evaluation>
+    @MockK
+    val evaluationItemRepository: EvaluationItemRepository = mockk()
 
-    @BeforeEach
-    internal fun setUp() {
-        evaluationService = EvaluationService(evaluationRepository, evaluationItemRepository, recruitmentRepository)
+    val evaluationService: EvaluationService =
+        EvaluationService(evaluationRepository, evaluationItemRepository, recruitmentRepository)
+    val recruitments: List<Recruitment> = listOf(
+        createRecruitment(recruitable = false),
+        createRecruitment(recruitable = true)
+    )
+    val preCourseEvaluation: Evaluation = createEvaluation(title = EVALUATION_TITLE1, beforeEvaluationId = 0L, id = 1L)
+    val firstEvaluation: Evaluation = createEvaluation(title = EVALUATION_TITLE2, beforeEvaluationId = 1L, id = 2L)
+    val secondEvaluation: Evaluation = createEvaluation(title = EVALUATION_TITLE3, beforeEvaluationId = 2L, id = 3L)
+    val evaluations: List<Evaluation> = listOf(preCourseEvaluation, firstEvaluation, secondEvaluation)
 
-        recruitments = listOf(
-            createRecruitment(recruitable = false),
-            createRecruitment(recruitable = true)
-        )
+    describe("EvaluationService") {
+        it("평가와 모집 정보를 함께 제공한다") {
+            every { evaluationRepository.findAll() } returns evaluations
+            every { recruitmentRepository.getOne(any()) } returns recruitments[0]
+            every { evaluationRepository.findById(1L) } returns Optional.of(evaluations[0])
+            every { evaluationRepository.findById(2L) } returns Optional.of(evaluations[1])
 
-        preCourseEvaluation = createEvaluation(title = EVALUATION_TITLE1, beforeEvaluationId = 0L, id = 1L)
+            val findAllWithRecruitment = evaluationService.findAllWithRecruitment()
 
-        firstEvaluation = createEvaluation(title = EVALUATION_TITLE2, beforeEvaluationId = 1L, id = 2L)
+            assertSoftly {
+                findAllWithRecruitment[1].id shouldBe 2L
+                firstEvaluation.title shouldBe findAllWithRecruitment[1].title
+                firstEvaluation.description shouldBe findAllWithRecruitment[1].description
+                recruitments[0].title shouldBe findAllWithRecruitment[1].recruitmentTitle
+                firstEvaluation.recruitmentId shouldBe findAllWithRecruitment[1].recruitmentId
+                preCourseEvaluation.title shouldBe findAllWithRecruitment[1].beforeEvaluationTitle
+                preCourseEvaluation.id shouldBe findAllWithRecruitment[1].beforeEvaluationId
+            }
+        }
 
-        secondEvaluation = createEvaluation(title = EVALUATION_TITLE3, beforeEvaluationId = 2L, id = 3L)
+        it("삭제된 평가를 이전 평가로 가지는 평가의 이전 평가를 초기화한다") {
+            every { evaluationRepository.findAll() } returns evaluations
+            every { evaluationRepository.deleteById(any()) } just Runs
 
-        evaluations = listOf(preCourseEvaluation, firstEvaluation, secondEvaluation)
+            evaluationService.deleteById(2L)
+
+            evaluations[2].beforeEvaluationId shouldBe 0L
+        }
+
+        it("삭제된 평가를 이전 평가로 가지는 평가들의 이전 평가를 초기화한다") {
+            val thirdEvaluation = createEvaluation(beforeEvaluationId = 2L, id = 4L)
+
+            val evaluationsWithDuplicatedBeforeEvaluationId: List<Evaluation> =
+                listOf(*evaluations.toTypedArray(), thirdEvaluation)
+
+            every { evaluationRepository.findAll() } returns evaluationsWithDuplicatedBeforeEvaluationId
+            every { evaluationRepository.deleteById(any()) } just Runs
+
+            evaluationService.deleteById(2L)
+
+            assertSoftly {
+                evaluationsWithDuplicatedBeforeEvaluationId[2].beforeEvaluationId shouldBe 0L
+                evaluationsWithDuplicatedBeforeEvaluationId[3].beforeEvaluationId shouldBe 0L
+            }
+        }
     }
-
-    @Test
-    fun `평가와 모집 정보를 함께 제공한다`() {
-        every { evaluationRepository.findAll() } returns evaluations
-        every { recruitmentRepository.getOne(any()) } returns recruitments[0]
-        every { evaluationRepository.findById(1L) } returns Optional.of(evaluations[0])
-        every { evaluationRepository.findById(2L) } returns Optional.of(evaluations[1])
-
-        val findAllWithRecruitment = evaluationService.findAllWithRecruitment()
-
-        assertAll(
-            { assertThat(2L).isEqualTo(findAllWithRecruitment[1].id) },
-            { assertThat(firstEvaluation.title).isEqualTo(findAllWithRecruitment[1].title) },
-            { assertThat(firstEvaluation.description).isEqualTo(findAllWithRecruitment[1].description) },
-            { assertThat(recruitments[0].title).isEqualTo(findAllWithRecruitment[1].recruitmentTitle) },
-            { assertThat(firstEvaluation.recruitmentId).isEqualTo(findAllWithRecruitment[1].recruitmentId) },
-            { assertThat(preCourseEvaluation.title).isEqualTo(findAllWithRecruitment[1].beforeEvaluationTitle) },
-            { assertThat(preCourseEvaluation.id).isEqualTo(findAllWithRecruitment[1].beforeEvaluationId) }
-        )
-    }
-
-    @Test
-    fun `삭제된 평가를 이전 평가로 가지는 평가의 이전 평가를 초기화한다`() {
-        every { evaluationRepository.findAll() } returns evaluations
-        every { evaluationRepository.deleteById(any()) } just Runs
-
-        evaluationService.deleteById(2L)
-
-        assertThat(0L).isEqualTo(evaluations[2].beforeEvaluationId)
-    }
-
-    @Test
-    fun `삭제된 평가를 이전 평가로 가지는 평가들의 이전 평가를 초기화한다`() {
-        val thirdEvaluation = createEvaluation(beforeEvaluationId = 2L, id = 4L)
-
-        val evaluationsWithDuplicatedBeforeEvaluationId: List<Evaluation> =
-            listOf(*evaluations.toTypedArray(), thirdEvaluation)
-
-        every { evaluationRepository.findAll() } returns evaluationsWithDuplicatedBeforeEvaluationId
-        every { evaluationRepository.deleteById(any()) } just Runs
-
-        evaluationService.deleteById(2L)
-
-        assertThat(0L).isEqualTo(evaluationsWithDuplicatedBeforeEvaluationId[2].beforeEvaluationId)
-        assertThat(0L).isEqualTo(evaluationsWithDuplicatedBeforeEvaluationId[3].beforeEvaluationId)
-    }
-}
+})

--- a/src/test/kotlin/apply/application/EvaluationServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationServiceTest.kt
@@ -1,10 +1,6 @@
 package apply.application
 
-import apply.EVALUATION_TITLE1
-import apply.EVALUATION_TITLE2
-import apply.EVALUATION_TITLE3
-import apply.createEvaluation
-import apply.createRecruitment
+import apply.*
 import apply.domain.evaluation.Evaluation
 import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluationItem.EvaluationItemRepository
@@ -19,7 +15,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import support.test.UnitTest
-import java.util.Optional
+import java.util.*
 
 @UnitTest
 internal class EvaluationServiceTest : DescribeSpec({
@@ -32,7 +28,7 @@ internal class EvaluationServiceTest : DescribeSpec({
     @MockK
     val evaluationItemRepository: EvaluationItemRepository = mockk()
 
-    val evaluationService: EvaluationService =
+    val evaluationService =
         EvaluationService(evaluationRepository, evaluationItemRepository, recruitmentRepository)
     val recruitments: List<Recruitment> = listOf(
         createRecruitment(recruitable = false),

--- a/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
@@ -6,7 +6,7 @@ import apply.domain.evaluationItem.EvaluationItemRepository
 import apply.domain.mission.MissionRepository
 import apply.utils.CsvGenerator
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.Runs
 import io.mockk.every
@@ -75,7 +75,7 @@ class EvaluationTargetCsvServiceTest : DescribeSpec({
                 every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
                 every { evaluationTargetService.gradeAll(any(), any()) } just Runs
 
-                shouldNotThrowAny{ evaluationTargetCsvService.updateTarget(inputStream, 1L) }
+                shouldNotThrowAny { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
                 verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
             }
         }
@@ -108,7 +108,7 @@ class EvaluationTargetCsvServiceTest : DescribeSpec({
 
                 every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
 
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     evaluationTargetCsvService.updateTarget(
                         inputStream,
                         1L
@@ -128,7 +128,7 @@ class EvaluationTargetCsvServiceTest : DescribeSpec({
 
                 every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
 
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     evaluationTargetCsvService.updateTarget(
                         inputStream,
                         1L

--- a/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
@@ -5,39 +5,54 @@ import apply.domain.assignment.AssignmentRepository
 import apply.domain.evaluationItem.EvaluationItemRepository
 import apply.domain.mission.MissionRepository
 import apply.utils.CsvGenerator
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkClass
 import io.mockk.verify
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import support.test.UnitTest
 import java.io.InputStream
 
 @UnitTest
-class EvaluationTargetCsvServiceTest {
-    @MockK
-    private lateinit var evaluationTargetService: EvaluationTargetService
+class EvaluationTargetCsvServiceTest : DescribeSpec({
+    fun getInputStream(fileName: String): InputStream {
+        return javaClass.classLoader.getResource(fileName)!!.openStream()
+    }
 
     @MockK
-    private lateinit var evaluationItemRepository: EvaluationItemRepository
+    var evaluationTargetService: EvaluationTargetService = mockk()
 
     @MockK
-    private lateinit var missionRepository: MissionRepository
+    var evaluationItemRepository: EvaluationItemRepository = mockk()
 
     @MockK
-    private lateinit var assignmentRepository: AssignmentRepository
+    var missionRepository: MissionRepository = mockk()
 
     @MockK
-    private lateinit var csvGenerator: CsvGenerator
+    var assignmentRepository: AssignmentRepository = mockk()
 
-    private lateinit var evaluationTargetCsvService: EvaluationTargetCsvService
+    @MockK
+    var csvGenerator: CsvGenerator = mockk()
 
-    @BeforeEach
-    internal fun setUp() {
+    var evaluationTargetCsvService: EvaluationTargetCsvService = EvaluationTargetCsvService(
+        evaluationTargetService,
+        evaluationItemRepository,
+        missionRepository,
+        assignmentRepository,
+        csvGenerator
+    )
+
+    beforeEach {
+        evaluationTargetService = mockkClass(EvaluationTargetService::class)
+        evaluationItemRepository = mockk()
+        missionRepository = mockk()
+        assignmentRepository = mockk()
+        csvGenerator = mockk()
         evaluationTargetCsvService = EvaluationTargetCsvService(
             evaluationTargetService,
             evaluationItemRepository,
@@ -47,67 +62,79 @@ class EvaluationTargetCsvServiceTest {
         )
     }
 
-    @Test
-    fun `평가지 양식에 맞는 평가지 업로드 시 csv 읽기에 성공한다`() {
-        val inputStream = getInputStream("evaluation.csv")
-        val evaluationItems = listOf(
-            createEvaluationItem(maximumScore = 1, position = 1),
-            createEvaluationItem(maximumScore = 2, position = 2),
-            createEvaluationItem(maximumScore = 3, position = 3)
-        )
+    describe("EvaluationTargetCsvService") {
+        context("평가지 양식에 맞는 평가지 업로드 시") {
+            it("csv 읽기에 성공한다") {
+                val inputStream = getInputStream("evaluation.csv")
+                val evaluationItems = listOf(
+                    createEvaluationItem(maximumScore = 1, position = 1),
+                    createEvaluationItem(maximumScore = 2, position = 2),
+                    createEvaluationItem(maximumScore = 3, position = 3)
+                )
 
-        every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
-        every { evaluationTargetService.gradeAll(any(), any()) } just Runs
+                every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
+                every { evaluationTargetService.gradeAll(any(), any()) } just Runs
 
-        assertDoesNotThrow { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
-        verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
+                shouldNotThrow<Exception> { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
+                verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
+            }
+        }
+
+        context("상태에 대해 대소문자 구분을 하지 않고 평가지 업로드 시") {
+            it("csv 읽기에 성공한다") {
+                val inputStream = getInputStream("status_ignore_case_evaluation.csv")
+                val evaluationItems = listOf(
+                    createEvaluationItem(maximumScore = 1, position = 1),
+                    createEvaluationItem(maximumScore = 2, position = 2),
+                    createEvaluationItem(maximumScore = 3, position = 3)
+                )
+
+                every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
+                every { evaluationTargetService.gradeAll(any(), any()) } just Runs
+
+                shouldNotThrow<Exception> { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
+                verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
+            }
+        }
+
+        context("해당 평가에 맞지 않는 평가지 업로드 시") {
+            it("예외가 발생한다") {
+                val inputStream = getInputStream("another_evaluation.csv")
+                val evaluationItems = listOf(
+                    createEvaluationItem(position = 1),
+                    createEvaluationItem(position = 2),
+                    createEvaluationItem(position = 3)
+                )
+
+                every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
+
+                shouldThrowExactly<IllegalArgumentException> {
+                    evaluationTargetCsvService.updateTarget(
+                        inputStream,
+                        1L
+                    )
+                }
+            }
+        }
+
+        context("평가 항목의 최대 점수보다 높은 점수가 평가지에 포함될 시") {
+            it("예외가 발생한다") {
+                val inputStream = getInputStream("evaluation_with_over_maximum_score.csv")
+                val evaluationItems = listOf(
+                    createEvaluationItem(maximumScore = 1, position = 1),
+                    createEvaluationItem(maximumScore = 2, position = 2),
+                    createEvaluationItem(maximumScore = 3, position = 3)
+                )
+
+                every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
+
+                shouldThrowExactly<IllegalArgumentException> {
+                    evaluationTargetCsvService.updateTarget(
+                        inputStream,
+                        1L
+                    )
+                }
+            }
+        }
     }
-
-    @Test
-    fun `상태에 대해 대소문자 구분을 하지 않고 평가지 업로드 시 csv 읽기에 성공한다`() {
-        val inputStream = getInputStream("status_ignore_case_evaluation.csv")
-        val evaluationItems = listOf(
-            createEvaluationItem(maximumScore = 1, position = 1),
-            createEvaluationItem(maximumScore = 2, position = 2),
-            createEvaluationItem(maximumScore = 3, position = 3)
-        )
-
-        every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
-        every { evaluationTargetService.gradeAll(any(), any()) } just Runs
-
-        assertDoesNotThrow { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
-        verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
-    }
-
-    @Test
-    fun `해당 평가에 맞지 않는 평가지 업로드 시 예외가 발생한다`() {
-        val inputStream = getInputStream("another_evaluation.csv")
-        val evaluationItems = listOf(
-            createEvaluationItem(position = 1),
-            createEvaluationItem(position = 2),
-            createEvaluationItem(position = 3)
-        )
-
-        every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
-
-        assertThrows<IllegalArgumentException> { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
-    }
-
-    @Test
-    fun `평가 항목의 최대 점수보다 높은 점수가 평가지에 포함될 시 예외가 발생한다`() {
-        val inputStream = getInputStream("evaluation_with_over_maximum_score.csv")
-        val evaluationItems = listOf(
-            createEvaluationItem(maximumScore = 1, position = 1),
-            createEvaluationItem(maximumScore = 2, position = 2),
-            createEvaluationItem(maximumScore = 3, position = 3)
-        )
-
-        every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
-
-        assertThrows<IllegalArgumentException> { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
-    }
-
-    private fun getInputStream(fileName: String): InputStream {
-        return javaClass.classLoader.getResource(fileName)!!.openStream()
-    }
-}
+})

--- a/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
@@ -5,7 +5,7 @@ import apply.domain.assignment.AssignmentRepository
 import apply.domain.evaluationItem.EvaluationItemRepository
 import apply.domain.mission.MissionRepository
 import apply.utils.CsvGenerator
-import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.Runs
@@ -75,7 +75,7 @@ class EvaluationTargetCsvServiceTest : DescribeSpec({
                 every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
                 every { evaluationTargetService.gradeAll(any(), any()) } just Runs
 
-                shouldNotThrow<Exception> { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
+                shouldNotThrowAny{ evaluationTargetCsvService.updateTarget(inputStream, 1L) }
                 verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
             }
         }
@@ -92,7 +92,7 @@ class EvaluationTargetCsvServiceTest : DescribeSpec({
                 every { evaluationItemRepository.findByEvaluationIdOrderByPosition(any()) } returns evaluationItems
                 every { evaluationTargetService.gradeAll(any(), any()) } just Runs
 
-                shouldNotThrow<Exception> { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
+                shouldNotThrowAny { evaluationTargetCsvService.updateTarget(inputStream, 1L) }
                 verify(exactly = 1) { evaluationTargetService.gradeAll(any(), any()) }
             }
         }

--- a/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetCsvServiceTest.kt
@@ -8,13 +8,8 @@ import apply.utils.CsvGenerator
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
-import io.mockk.Runs
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.mockkClass
-import io.mockk.verify
 import support.test.UnitTest
 import java.io.InputStream
 
@@ -39,7 +34,7 @@ class EvaluationTargetCsvServiceTest : DescribeSpec({
     @MockK
     var csvGenerator: CsvGenerator = mockk()
 
-    var evaluationTargetCsvService: EvaluationTargetCsvService = EvaluationTargetCsvService(
+    var evaluationTargetCsvService = EvaluationTargetCsvService(
         evaluationTargetService,
         evaluationItemRepository,
         missionRepository,

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -28,12 +28,16 @@ import apply.domain.user.Password
 import apply.domain.user.User
 import apply.domain.user.UserRepository
 import apply.domain.user.findAllByEmailIn
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeBlank
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.mockk.mockk
 import org.springframework.data.repository.findByIdOrNull
 import support.createLocalDate
 import support.createLocalDateTime
@@ -42,374 +46,32 @@ import support.test.RepositoryTest
 @RepositoryTest
 class EvaluationTargetServiceTest(
     private val evaluationTargetRepository: EvaluationTargetRepository
-) {
+) : DescribeSpec({
     @MockK
-    private lateinit var evaluationRepository: EvaluationRepository
-
-    @MockK
-    private lateinit var applicationFormRepository: ApplicationFormRepository
+    val evaluationRepository: EvaluationRepository = mockk()
 
     @MockK
-    private lateinit var userRepository: UserRepository
+    val applicationFormRepository: ApplicationFormRepository = mockk()
 
     @MockK
-    private lateinit var cheaterRepository: CheaterRepository
+    val userRepository: UserRepository = mockk()
 
     @MockK
-    private lateinit var evaluationItemRepository: EvaluationItemRepository
-
-    private lateinit var evaluationTargetService: EvaluationTargetService
-
-    @BeforeEach
-    fun setUp() {
-        evaluationTargetService = EvaluationTargetService(
-            evaluationRepository,
-            evaluationTargetRepository,
-            evaluationItemRepository,
-            applicationFormRepository,
-            userRepository,
-            cheaterRepository
-        )
-    }
-
-    @Test
-    fun `이전 평가가 없고 저장 된 평가 대상자가 없을 경우 저장하고 불러온다`() {
-        // given
-        val firstEvaluation = createEvaluation()
-
-        val applicationForms = listOf(
-            createApplicationForm(id = 1L, recruitmentId = 1L, userId = 1L),
-            createApplicationForm(id = 2L, recruitmentId = 1L, userId = 2L),
-            createApplicationForm(id = 3L, recruitmentId = 1L, userId = 3L)
-        )
-
-        val firstUser = createUser(1L)
-        val secondUser = createUser(2L)
-        val thirdUser = createUser(3L)
-
-        val newUsers = listOf(firstUser, secondUser, thirdUser)
-
-        val additionalUsers = listOf(firstUser, secondUser)
-
-        // when
-        every { evaluationRepository.findByIdOrNull(any()) } returns firstEvaluation
-        every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
-        every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
-        every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(any()) } returns applicationForms
-        every { userRepository.findAllById(listOf(1L, 2L, 3L)) } returns newUsers
-        every { userRepository.findAllById(setOf(3L)) } returns listOf(createUser(3L))
-        every { userRepository.findAllById(setOf(1L, 2L)) } returns additionalUsers
-
-        evaluationTargetService.load(firstEvaluation.id)
-
-        val actual = evaluationTargetRepository.findAllByEvaluationId(firstEvaluation.id)
-
-        // then
-        assertAll(
-            { assertThat(actual).hasSize(3) },
-            { assertThat(actual[0].userId).isEqualTo(1L) },
-            { assertThat(actual[0].evaluationStatus).isEqualTo(WAITING) },
-            { assertThat(actual[1].userId).isEqualTo(2L) },
-            { assertThat(actual[1].evaluationStatus).isEqualTo(WAITING) },
-            { assertThat(actual[2].userId).isEqualTo(3L) },
-            { assertThat(actual[2].evaluationStatus).isEqualTo(FAIL) }
-        )
-    }
-
-    @Test
-    fun `이전 평가가 있고 저장 된 평가 대상자가 없을 경우 저장하고 불러온다`() {
-        // given
-        val savedEvaluationTargets = listOf(
-            createEvaluationTarget(1L, 1L, WAITING),
-            createEvaluationTarget(1L, 2L, PASS),
-            createEvaluationTarget(1L, 3L, PASS)
-        )
-
-        evaluationTargetRepository.saveAll(savedEvaluationTargets)
-
-        // when
-        val secondEvaluation = createEvaluation(id = 2L, beforeEvaluationId = 1L)
-
-        every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
-        every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
-        every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
-        every { userRepository.findAllById(setOf(3L)) } returns listOf(createUser(3L))
-        every { userRepository.findAllById(setOf(2L)) } returns listOf(createUser(2L))
-
-        evaluationTargetService.load(secondEvaluation.id)
-
-        val actual = evaluationTargetRepository.findAllByEvaluationId(secondEvaluation.id)
-
-        // then
-        assertAll(
-            { assertThat(actual).hasSize(2) },
-            { assertThat(actual[0].userId).isEqualTo(2L) },
-            { assertThat(actual[0].evaluationStatus).isEqualTo(WAITING) },
-            { assertThat(actual[1].userId).isEqualTo(3L) },
-            { assertThat(actual[1].evaluationStatus).isEqualTo(FAIL) }
-        )
-    }
-
-    @Test
-    fun `이전 평가가 없고 저장 된 평가 대상자가 있을 경우 갱신하여 불러온다, 새로 등록된 지원자를 평가 대상자에 추가한다`() {
-        // given
-        val savedEvaluationTargets = listOf(
-            createEvaluationTarget(1L, 1L, FAIL),
-            createEvaluationTarget(1L, 2L, PASS),
-            createEvaluationTarget(1L, 3L, PASS)
-        )
-
-        evaluationTargetRepository.saveAll(savedEvaluationTargets)
-
-        // when
-        val firstEvaluation = createEvaluation(id = 1L, beforeEvaluationId = 0L)
-
-        val allApplicationForms = listOf(
-            createApplicationForm(id = 1L, recruitmentId = 1L, userId = 1L),
-            createApplicationForm(id = 2L, recruitmentId = 1L, userId = 2L),
-            createApplicationForm(id = 3L, recruitmentId = 1L, userId = 3L),
-            createApplicationForm(id = 4L, recruitmentId = 1L, userId = 4L)
-        )
-
-        val addingUser = createUser(id = 4L)
-
-        val allUsers = listOf(
-            createUser(1L),
-            createUser(2L),
-            createUser(3L),
-            addingUser
-        )
-
-        every { evaluationRepository.findByIdOrNull(any()) } returns firstEvaluation
-        every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
-        every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
-        every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(any()) } returns allApplicationForms
-        every { userRepository.findAllById(listOf(1L, 2L, 3L, 4L)) } returns allUsers
-        every { userRepository.findAllById(setOf(4L)) } returns listOf(addingUser)
-        every { userRepository.findAllById(setOf()) } returns listOf()
-
-        evaluationTargetService.load(firstEvaluation.id)
-
-        val actual = evaluationTargetRepository.findAllByEvaluationId(firstEvaluation.id)
-
-        // then
-        assertAll(
-            { assertThat(actual).hasSize(4) },
-            { assertThat(actual[0].userId).isEqualTo(1L) },
-            { assertThat(actual[0].evaluationStatus).isEqualTo(FAIL) },
-            { assertThat(actual[1].userId).isEqualTo(2L) },
-            { assertThat(actual[1].evaluationStatus).isEqualTo(PASS) },
-            { assertThat(actual[2].userId).isEqualTo(3L) },
-            { assertThat(actual[2].evaluationStatus).isEqualTo(FAIL) },
-            { assertThat(actual[3].userId).isEqualTo(4L) },
-            { assertThat(actual[3].evaluationStatus).isEqualTo(WAITING) }
-        )
-    }
-
-    @Test
-    fun `이전 평가가 있고 저장 된 평가 대상자가 있을 경우 갱신하고 불러온다, 이전 평가의 평가 대상자의 평가가 FAIL로 바뀌면 제거한다`() {
-        // given
-        val savedCurrentEvaluationTargets = listOf(
-            createEvaluationTarget(2L, 1L, WAITING),
-            createEvaluationTarget(2L, 2L, PASS),
-            createEvaluationTarget(2L, 3L, PASS)
-        )
-
-        evaluationTargetRepository.saveAll(savedCurrentEvaluationTargets)
-
-        val loadingEvaluationTargetsFromBeforeEvaluation = listOf(
-            createEvaluationTarget(1L, 1L, WAITING),
-            createEvaluationTarget(1L, 2L, PASS),
-            createEvaluationTarget(1L, 3L, PASS),
-            createEvaluationTarget(1L, 4L, PASS)
-        )
-
-        evaluationTargetRepository.saveAll(loadingEvaluationTargetsFromBeforeEvaluation)
-
-        // when
-        val secondEvaluation = createEvaluation(id = 2L, beforeEvaluationId = 1L)
-
-        val addingUser = createUser(4L)
-
-        every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
-        every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
-        every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
-        every { userRepository.findAllById(setOf(4L)) } returns listOf(addingUser)
-        every { userRepository.findAllById(setOf()) } returns listOf()
-
-        evaluationTargetService.load(secondEvaluation.id)
-
-        val actual = evaluationTargetRepository.findAllByEvaluationId(secondEvaluation.id)
-
-        // then
-        assertAll(
-            { assertThat(actual).hasSize(3) },
-            { assertThat(actual[0].userId).isEqualTo(2L) },
-            { assertThat(actual[0].evaluationStatus).isEqualTo(PASS) },
-            { assertThat(actual[1].userId).isEqualTo(3L) },
-            { assertThat(actual[1].evaluationStatus).isEqualTo(FAIL) },
-            { assertThat(actual[2].userId).isEqualTo(4L) },
-            { assertThat(actual[2].evaluationStatus).isEqualTo(WAITING) }
-        )
-    }
-
-    @Test
-    fun `평가자 불러오기 시 부정행위자는 불합격 상태로 불러온다`() {
-        // given
-        val savedEvaluationTargets = listOf(
-            createEvaluationTarget(1L, 1L, FAIL),
-            createEvaluationTarget(1L, 2L, PASS),
-            createEvaluationTarget(1L, 3L, PASS),
-            createEvaluationTarget(1L, 4L, WAITING)
-        )
-
-        evaluationTargetRepository.saveAll(savedEvaluationTargets)
-
-        // when
-        val evaluation = createEvaluation(id = 1L, beforeEvaluationId = 0L)
-
-        val allApplicationForms = listOf(
-            createApplicationForm(id = 1L, recruitmentId = 1L, userId = 1L),
-            createApplicationForm(id = 2L, recruitmentId = 1L, userId = 2L),
-            createApplicationForm(id = 3L, recruitmentId = 1L, userId = 3L),
-            createApplicationForm(id = 4L, recruitmentId = 1L, userId = 4L)
-        )
-
-        val cheater = createUser(3L)
-
-        val allUsers = listOf(
-            createUser(1L),
-            createUser(2L),
-            cheater,
-            createUser(4L)
-        )
-
-        every { evaluationRepository.findByIdOrNull(any()) } returns evaluation
-        every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(any()) } returns allApplicationForms
-        every { cheaterRepository.findAll() } returns listOf(Cheater(cheater.email))
-        every { userRepository.findAllByEmailIn(listOf(cheater.email)) } returns listOf(cheater)
-        every { userRepository.findAllById(listOf(1L, 2L, 3L, 4L)) } returns allUsers
-        every { userRepository.findAllById(setOf(3L)) } returns listOf(cheater)
-        every { userRepository.findAllById(setOf()) } returns listOf()
-
-        evaluationTargetService.load(evaluation.id)
-
-        val actual = evaluationTargetRepository.findAllByEvaluationId(evaluation.id)
-        val cheaterEvaluationTargets = actual.filter { it.userId == cheater.id }
-
-        // then
-        assertAll(
-            { assertThat(actual).hasSize(4) },
-            { assertThat(cheaterEvaluationTargets.all { it.evaluationStatus == FAIL }).isTrue() }
-        )
-    }
-
-    @Test
-    fun `현재 평가를 불러올 때, 평가 대상자가 부정행위자로 지정되어 탈락 처리되는 경우, 현재 평가에만 영향이 가는지 확인한다`() {
-        // given
-        val beforeEvaluationTarget = createEvaluationTarget(1L, 1L, PASS)
-        val currentEvaluationTarget = createEvaluationTarget(2L, 1L, PASS)
-        val nextEvaluationTarget = createEvaluationTarget(3L, 1L, PASS)
-        evaluationTargetRepository.saveAll(
-            listOf(
-                beforeEvaluationTarget,
-                currentEvaluationTarget,
-                nextEvaluationTarget
-            )
-        )
-
-        // when
-        val currentEvaluation = createEvaluation(id = 2L, beforeEvaluationId = 1L)
-
-        every { evaluationRepository.findByIdOrNull(2L) } returns currentEvaluation
-        every { cheaterRepository.findAll() } returns listOf(Cheater("1@email.com"))
-        every { userRepository.findAllByEmailIn(listOf("1@email.com")) } returns listOf(createUser(1L))
-        every { userRepository.findAllById(setOf(1L)) } returns listOf(createUser(1L))
-        every { userRepository.findAllById(emptySet()) } returns emptyList()
-
-        evaluationTargetService.load(2L)
-
-        // then
-        assertAll(
-            { assertThat(evaluationTargetRepository.findAllByEvaluationId(1L)[0].evaluationStatus).isEqualTo(PASS) },
-            { assertThat(evaluationTargetRepository.findAllByEvaluationId(2L)[0].evaluationStatus).isEqualTo(FAIL) },
-            { assertThat(evaluationTargetRepository.findAllByEvaluationId(3L)[0].evaluationStatus).isEqualTo(PASS) }
-        )
-    }
-
-    @Test
-    fun `평가 대상을 평가(채점)한 적이 없을 때, 채점 정보를 불러온다`() {
-        val evaluation = createEvaluation(id = EVALUATION_ID, beforeEvaluationId = 1L)
-        val evaluationItem = createEvaluationItem(id = 1L)
-        val evaluationTarget =
-            evaluationTargetRepository.save(EvaluationTarget(evaluationId = EVALUATION_ID, userId = 1L))
-
-        every { evaluationRepository.findByIdOrNull(EVALUATION_ID) } returns evaluation
-        every {
-            evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
-        } returns listOf(evaluationItem)
-
-        val result = evaluationTargetService.getGradeEvaluation(evaluationTarget.id)
-        assertAll(
-            { assertThat(result.title).isEqualTo(evaluation.title) },
-            { assertThat(result.description).isEqualTo(evaluation.description) },
-            { assertThat(result.evaluationItems).hasSize(1) },
-            { assertThat(result.evaluationTarget.evaluationItemScores[0].score).isEqualTo(0) },
-            { assertThat(result.evaluationTarget.evaluationStatus).isEqualTo(WAITING) },
-            { assertThat(result.evaluationTarget.note).isBlank() }
-        )
-    }
-
-    @Test
-    fun `평가 대상을 평가(채점)한 적이 있을 때, 채점 정보를 불러온다`() {
-        val evaluation = createEvaluation(id = EVALUATION_ID, beforeEvaluationId = 1L)
-        val evaluationItem = createEvaluationItem(id = EVALUATION_ITEM_ID)
-        val answers = EvaluationAnswers(mutableListOf(createEvaluationAnswer()))
-        val evaluationTarget = evaluationTargetRepository.save(
-            createEvaluationTarget(EVALUATION_ID, 1L, PASS, EVALUATION_TARGET_NOTE, answers)
-        )
-
-        every { evaluationRepository.findByIdOrNull(EVALUATION_ID) } returns evaluation
-        every {
-            evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
-        } returns listOf(evaluationItem)
-
-        val result = evaluationTargetService.getGradeEvaluation(evaluationTarget.id)
-        assertAll(
-            { assertThat(result.title).isEqualTo(evaluation.title) },
-            { assertThat(result.description).isEqualTo(evaluation.description) },
-            { assertThat(result.evaluationItems).hasSize(1) },
-            { assertThat(result.evaluationTarget.evaluationItemScores[0].score).isEqualTo(EVALUATION_ANSWER_SCORE) },
-            { assertThat(result.evaluationTarget.evaluationStatus).isEqualTo(PASS) },
-            { assertThat(result.evaluationTarget.note).isEqualTo(EVALUATION_TARGET_NOTE) }
-        )
-    }
-
-    @Test
-    fun `평가 대상 지원자를 평가하면 평가 상태, 특이사항, 평가 항목에 대한 점수들이 변경된다`() {
-        val evaluationTarget = evaluationTargetRepository.save(createEvaluationTarget(1L, 2L, WAITING))
-
-        val updatedScore = 5
-        val updatedStatus = PASS
-        val updatedNote = "특이 사항(수정)"
-        val answers = listOf(EvaluationItemScoreData(score = updatedScore, id = 3L))
-        val gradeEvaluationRequest = EvaluationTargetData(answers, updatedNote, updatedStatus)
-
-        evaluationTargetService.grade(evaluationTarget.id, gradeEvaluationRequest)
-
-        val updatedEvaluationTarget = evaluationTargetRepository.findByIdOrNull(evaluationTarget.id)!!
-        val expectedAnswers = EvaluationAnswers(mutableListOf(EvaluationAnswer(updatedScore, 3L)))
-        assertAll(
-            { assertThat(updatedEvaluationTarget.evaluationStatus).isEqualTo(updatedStatus) },
-            { assertThat(updatedEvaluationTarget.note).isEqualTo(updatedNote) },
-            {
-                assertThat(updatedEvaluationTarget.evaluationAnswers).usingRecursiveComparison()
-                    .isEqualTo(expectedAnswers)
-            }
-        )
-    }
-
-    private fun createApplicationForm(id: Long, recruitmentId: Long = 1L, userId: Long): ApplicationForm {
+    val cheaterRepository: CheaterRepository = mockk()
+
+    @MockK
+    val evaluationItemRepository: EvaluationItemRepository = mockk()
+
+    val evaluationTargetService: EvaluationTargetService = EvaluationTargetService(
+        evaluationRepository,
+        evaluationTargetRepository,
+        evaluationItemRepository,
+        applicationFormRepository,
+        userRepository,
+        cheaterRepository
+    )
+
+    fun createApplicationForm(id: Long, recruitmentId: Long = 1L, userId: Long): ApplicationForm {
         return ApplicationForm(
             userId = userId,
             recruitmentId = recruitmentId,
@@ -428,7 +90,7 @@ class EvaluationTargetServiceTest(
         )
     }
 
-    private fun createUser(id: Long): User {
+    fun createUser(id: Long): User {
         return User(
             id = id,
             name = "홍길동$id",
@@ -439,4 +101,351 @@ class EvaluationTargetServiceTest(
             password = Password("password")
         )
     }
-}
+
+
+
+    describe("EvaluationTargetService") {
+        context("이전 평가가 없고 저장 된 평가 대상자가 없을 경우") {
+            it("저장하고 불러온다") {
+                // given
+                val firstEvaluation = createEvaluation()
+
+                val applicationForms = listOf(
+                    createApplicationForm(id = 1L, recruitmentId = 1L, userId = 1L),
+                    createApplicationForm(id = 2L, recruitmentId = 1L, userId = 2L),
+                    createApplicationForm(id = 3L, recruitmentId = 1L, userId = 3L)
+                )
+
+                val firstUser = createUser(1L)
+                val secondUser = createUser(2L)
+                val thirdUser = createUser(3L)
+
+                val newUsers = listOf(firstUser, secondUser, thirdUser)
+
+                val additionalUsers = listOf(firstUser, secondUser)
+
+                // when
+                every { evaluationRepository.findByIdOrNull(any()) } returns firstEvaluation
+                every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
+                every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
+                every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(any()) } returns applicationForms
+                every { userRepository.findAllById(listOf(1L, 2L, 3L)) } returns newUsers
+                every { userRepository.findAllById(setOf(3L)) } returns listOf(createUser(3L))
+                every { userRepository.findAllById(setOf(1L, 2L)) } returns additionalUsers
+
+                evaluationTargetService.load(firstEvaluation.id)
+
+                val actual = evaluationTargetRepository.findAllByEvaluationId(firstEvaluation.id)
+
+                // then
+                assertSoftly {
+                    actual shouldHaveSize 3
+                    actual[0].userId shouldBe 1L
+                    actual[0].evaluationStatus shouldBe WAITING
+                    actual[1].userId shouldBe 2L
+                    actual[1].evaluationStatus shouldBe WAITING
+                    actual[2].userId shouldBe 3L
+                    actual[2].evaluationStatus shouldBe FAIL
+                }
+            }
+        }
+
+        context("이전 평가가 있고 저장 된 평가 대상자가 없을 경우") {
+            it("저장하고 불러온다") {
+                // given
+                val savedEvaluationTargets = listOf(
+                    createEvaluationTarget(1L, 1L, WAITING),
+                    createEvaluationTarget(1L, 2L, PASS),
+                    createEvaluationTarget(1L, 3L, PASS)
+                )
+
+                evaluationTargetRepository.saveAll(savedEvaluationTargets)
+
+                // when
+                val secondEvaluation = createEvaluation(id = 2L, beforeEvaluationId = 1L)
+
+                every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
+                every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
+                every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
+                every { userRepository.findAllById(setOf(3L)) } returns listOf(createUser(3L))
+                every { userRepository.findAllById(setOf(2L)) } returns listOf(createUser(2L))
+
+                evaluationTargetService.load(secondEvaluation.id)
+
+                val actual = evaluationTargetRepository.findAllByEvaluationId(secondEvaluation.id)
+
+                // then
+                assertSoftly {
+                    actual shouldHaveSize 2
+                    actual[0].userId shouldBe 2L
+                    actual[0].evaluationStatus shouldBe WAITING
+                    actual[1].userId shouldBe 3L
+                    actual[1].evaluationStatus shouldBe FAIL
+                }
+            }
+        }
+
+        context("이전 평가가 없고 저장 된 평가 대상자가 있을 경우") {
+            it("갱신하여 불러온다, 새로 등록된 지원자를 평가 대상자에 추가한다") {
+                // given
+                val savedEvaluationTargets = listOf(
+                    createEvaluationTarget(1L, 1L, FAIL),
+                    createEvaluationTarget(1L, 2L, PASS),
+                    createEvaluationTarget(1L, 3L, PASS)
+                )
+
+                evaluationTargetRepository.saveAll(savedEvaluationTargets)
+
+                // when
+                val firstEvaluation = createEvaluation(id = 1L, beforeEvaluationId = 0L)
+
+                val allApplicationForms = listOf(
+                    createApplicationForm(id = 1L, recruitmentId = 1L, userId = 1L),
+                    createApplicationForm(id = 2L, recruitmentId = 1L, userId = 2L),
+                    createApplicationForm(id = 3L, recruitmentId = 1L, userId = 3L),
+                    createApplicationForm(id = 4L, recruitmentId = 1L, userId = 4L)
+                )
+
+                val addingUser = createUser(id = 4L)
+
+                val allUsers = listOf(
+                    createUser(1L),
+                    createUser(2L),
+                    createUser(3L),
+                    addingUser
+                )
+
+                every { evaluationRepository.findByIdOrNull(any()) } returns firstEvaluation
+                every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
+                every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
+                every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(any()) } returns allApplicationForms
+                every { userRepository.findAllById(listOf(1L, 2L, 3L, 4L)) } returns allUsers
+                every { userRepository.findAllById(setOf(4L)) } returns listOf(addingUser)
+                every { userRepository.findAllById(setOf()) } returns listOf()
+
+                evaluationTargetService.load(firstEvaluation.id)
+
+                val actual = evaluationTargetRepository.findAllByEvaluationId(firstEvaluation.id)
+
+                // then
+                assertSoftly {
+                    actual shouldHaveSize 4
+                    actual[0].userId shouldBe 1L
+                    actual[0].evaluationStatus shouldBe FAIL
+                    actual[1].userId shouldBe 2L
+                    actual[1].evaluationStatus shouldBe PASS
+                    actual[2].userId shouldBe 3L
+                    actual[2].evaluationStatus shouldBe FAIL
+                    actual[3].userId shouldBe 4L
+                    actual[3].evaluationStatus shouldBe WAITING
+                }
+            }
+        }
+
+        context("이전 평가가 있고 저장 된 평가 대상자가 있을 경우") {
+            it("갱신하고 불러온다, 이전 평가의 평가 대상자의 평가가 FAIL로 바뀌면 제거한다") {
+                // given
+                val savedCurrentEvaluationTargets = listOf(
+                    createEvaluationTarget(2L, 1L, WAITING),
+                    createEvaluationTarget(2L, 2L, PASS),
+                    createEvaluationTarget(2L, 3L, PASS)
+                )
+
+                evaluationTargetRepository.saveAll(savedCurrentEvaluationTargets)
+
+                val loadingEvaluationTargetsFromBeforeEvaluation = listOf(
+                    createEvaluationTarget(1L, 1L, WAITING),
+                    createEvaluationTarget(1L, 2L, PASS),
+                    createEvaluationTarget(1L, 3L, PASS),
+                    createEvaluationTarget(1L, 4L, PASS)
+                )
+
+                evaluationTargetRepository.saveAll(loadingEvaluationTargetsFromBeforeEvaluation)
+
+                // when
+                val secondEvaluation = createEvaluation(id = 2L, beforeEvaluationId = 1L)
+
+                val addingUser = createUser(4L)
+
+                every { evaluationRepository.findByIdOrNull(any()) } returns secondEvaluation
+                every { cheaterRepository.findAll() } returns listOf(Cheater("3@email.com"))
+                every { userRepository.findAllByEmailIn(listOf("3@email.com")) } returns listOf(createUser(3L))
+                every { userRepository.findAllById(setOf(4L)) } returns listOf(addingUser)
+                every { userRepository.findAllById(setOf()) } returns listOf()
+
+                evaluationTargetService.load(secondEvaluation.id)
+
+                val actual = evaluationTargetRepository.findAllByEvaluationId(secondEvaluation.id)
+
+                // then
+                assertSoftly {
+                    actual shouldHaveSize 3
+                    actual[0].userId shouldBe 2L
+                    actual[0].evaluationStatus shouldBe PASS
+                    actual[1].userId shouldBe 3L
+                    actual[1].evaluationStatus shouldBe FAIL
+                    actual[2].userId shouldBe 4L
+                    actual[2].evaluationStatus shouldBe WAITING
+                }
+            }
+        }
+
+        context("평가자 불러오기 시") {
+            it("부정행위자는 불합격 상태로 불러온다") {
+                // given
+                val savedEvaluationTargets = listOf(
+                    createEvaluationTarget(1L, 1L, FAIL),
+                    createEvaluationTarget(1L, 2L, PASS),
+                    createEvaluationTarget(1L, 3L, PASS),
+                    createEvaluationTarget(1L, 4L, WAITING)
+                )
+
+                evaluationTargetRepository.saveAll(savedEvaluationTargets)
+
+                // when
+                val evaluation = createEvaluation(id = 1L, beforeEvaluationId = 0L)
+
+                val allApplicationForms = listOf(
+                    createApplicationForm(id = 1L, recruitmentId = 1L, userId = 1L),
+                    createApplicationForm(id = 2L, recruitmentId = 1L, userId = 2L),
+                    createApplicationForm(id = 3L, recruitmentId = 1L, userId = 3L),
+                    createApplicationForm(id = 4L, recruitmentId = 1L, userId = 4L)
+                )
+
+                val cheater = createUser(3L)
+
+                val allUsers = listOf(
+                    createUser(1L),
+                    createUser(2L),
+                    cheater,
+                    createUser(4L)
+                )
+
+                every { evaluationRepository.findByIdOrNull(any()) } returns evaluation
+                every { applicationFormRepository.findByRecruitmentIdAndSubmittedTrue(any()) } returns allApplicationForms
+                every { cheaterRepository.findAll() } returns listOf(Cheater(cheater.email))
+                every { userRepository.findAllByEmailIn(listOf(cheater.email)) } returns listOf(cheater)
+                every { userRepository.findAllById(listOf(1L, 2L, 3L, 4L)) } returns allUsers
+                every { userRepository.findAllById(setOf(3L)) } returns listOf(cheater)
+                every { userRepository.findAllById(setOf()) } returns listOf()
+
+                evaluationTargetService.load(evaluation.id)
+
+                val actual = evaluationTargetRepository.findAllByEvaluationId(evaluation.id)
+                val cheaterEvaluationTargets = actual.filter { it.userId == cheater.id }
+
+                // then
+                assertSoftly {
+                    actual shouldHaveSize 4
+                    cheaterEvaluationTargets.all { it.evaluationStatus == FAIL }.shouldBeTrue()
+                }
+            }
+        }
+
+        context("현재 평가를 불러올 때, 평가 대상자가 부정행위자로 지정되어 탈락 처리되는 경우") {
+            it("현재 평가에만 영향이 가는지 확인한다") {
+                // given
+                val beforeEvaluationTarget = createEvaluationTarget(1L, 1L, PASS)
+                val currentEvaluationTarget = createEvaluationTarget(2L, 1L, PASS)
+                val nextEvaluationTarget = createEvaluationTarget(3L, 1L, PASS)
+                evaluationTargetRepository.saveAll(
+                    listOf(
+                        beforeEvaluationTarget,
+                        currentEvaluationTarget,
+                        nextEvaluationTarget
+                    )
+                )
+
+                // when
+                val currentEvaluation = createEvaluation(id = 2L, beforeEvaluationId = 1L)
+
+                every { evaluationRepository.findByIdOrNull(2L) } returns currentEvaluation
+                every { cheaterRepository.findAll() } returns listOf(Cheater("1@email.com"))
+                every { userRepository.findAllByEmailIn(listOf("1@email.com")) } returns listOf(createUser(1L))
+                every { userRepository.findAllById(setOf(1L)) } returns listOf(createUser(1L))
+                every { userRepository.findAllById(emptySet()) } returns emptyList()
+
+                evaluationTargetService.load(2L)
+
+                // then
+                assertSoftly {
+                    evaluationTargetRepository.findAllByEvaluationId(1L)[0].evaluationStatus shouldBe PASS
+                    evaluationTargetRepository.findAllByEvaluationId(2L)[0].evaluationStatus shouldBe FAIL
+                    evaluationTargetRepository.findAllByEvaluationId(3L)[0].evaluationStatus shouldBe PASS
+                }
+            }
+        }
+
+        context("평가 대상을 평가(채점)한 적이 없을 때") {
+            it("채점 정보를 불러온다") {
+                val evaluation = createEvaluation(id = EVALUATION_ID, beforeEvaluationId = 1L)
+                val evaluationItem = createEvaluationItem(id = 1L)
+                val evaluationTarget =
+                    evaluationTargetRepository.save(EvaluationTarget(evaluationId = EVALUATION_ID, userId = 1L))
+
+                every { evaluationRepository.findByIdOrNull(EVALUATION_ID) } returns evaluation
+                every {
+                    evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
+                } returns listOf(evaluationItem)
+
+                val result = evaluationTargetService.getGradeEvaluation(evaluationTarget.id)
+                assertSoftly {
+                    result.title shouldBe evaluation.title
+                    result.description shouldBe evaluation.description
+                    result.evaluationItems shouldHaveSize 1
+                    result.evaluationTarget.evaluationItemScores[0].score shouldBe 0
+                    result.evaluationTarget.evaluationStatus shouldBe WAITING
+                    result.evaluationTarget.note.shouldBeBlank()
+                }
+            }
+        }
+
+        context("평가 대상을 평가(채점)한 적이 있을 때") {
+            it("채점 정보를 불러온다") {
+                val evaluation = createEvaluation(id = EVALUATION_ID, beforeEvaluationId = 1L)
+                val evaluationItem = createEvaluationItem(id = EVALUATION_ITEM_ID)
+                val answers = EvaluationAnswers(mutableListOf(createEvaluationAnswer()))
+                val evaluationTarget = evaluationTargetRepository.save(
+                    createEvaluationTarget(EVALUATION_ID, 1L, PASS, EVALUATION_TARGET_NOTE, answers)
+                )
+
+                every { evaluationRepository.findByIdOrNull(EVALUATION_ID) } returns evaluation
+                every {
+                    evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
+                } returns listOf(evaluationItem)
+
+                val result = evaluationTargetService.getGradeEvaluation(evaluationTarget.id)
+                assertSoftly {
+                    result.title shouldBe evaluation.title
+                    result.description shouldBe evaluation.description
+                    result.evaluationItems shouldHaveSize 1
+                    result.evaluationTarget.evaluationItemScores[0].score shouldBe EVALUATION_ANSWER_SCORE
+                    result.evaluationTarget.evaluationStatus shouldBe PASS
+                    result.evaluationTarget.note shouldBe EVALUATION_TARGET_NOTE
+                }
+            }
+        }
+
+        context("평가 대상 지원자를 평가하면") {
+            it("평가 상태, 특이사항, 평가 항목에 대한 점수들이 변경된다") {
+                val evaluationTarget = evaluationTargetRepository.save(createEvaluationTarget(1L, 2L, WAITING))
+
+                val updatedScore = 5
+                val updatedStatus = PASS
+                val updatedNote = "특이 사항(수정)"
+                val answers = listOf(EvaluationItemScoreData(score = updatedScore, id = 3L))
+                val gradeEvaluationRequest = EvaluationTargetData(answers, updatedNote, updatedStatus)
+
+                evaluationTargetService.grade(evaluationTarget.id, gradeEvaluationRequest)
+
+                val updatedEvaluationTarget = evaluationTargetRepository.findByIdOrNull(evaluationTarget.id)!!
+                val expectedAnswers = EvaluationAnswers(mutableListOf(EvaluationAnswer(updatedScore, 3L)))
+                assertSoftly {
+                    updatedEvaluationTarget.evaluationStatus shouldBe updatedStatus
+                    updatedEvaluationTarget.note shouldBe updatedNote
+                    updatedEvaluationTarget.evaluationAnswers shouldBeEqualToComparingFields expectedAnswers
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -30,7 +30,6 @@ import apply.domain.user.UserRepository
 import apply.domain.user.findAllByEmailIn
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import io.kotest.matchers.shouldBe
@@ -138,7 +137,7 @@ class EvaluationTargetServiceTest(
                 val actual = evaluationTargetRepository.findAllByEvaluationId(firstEvaluation.id)
 
                 // then
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 3
                     actual[0].userId shouldBe 1L
                     actual[0].evaluationStatus shouldBe WAITING
@@ -175,7 +174,7 @@ class EvaluationTargetServiceTest(
                 val actual = evaluationTargetRepository.findAllByEvaluationId(secondEvaluation.id)
 
                 // then
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 2
                     actual[0].userId shouldBe 2L
                     actual[0].evaluationStatus shouldBe WAITING
@@ -228,7 +227,7 @@ class EvaluationTargetServiceTest(
                 val actual = evaluationTargetRepository.findAllByEvaluationId(firstEvaluation.id)
 
                 // then
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 4
                     actual[0].userId shouldBe 1L
                     actual[0].evaluationStatus shouldBe FAIL
@@ -278,7 +277,7 @@ class EvaluationTargetServiceTest(
                 val actual = evaluationTargetRepository.findAllByEvaluationId(secondEvaluation.id)
 
                 // then
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 3
                     actual[0].userId shouldBe 2L
                     actual[0].evaluationStatus shouldBe PASS
@@ -337,7 +336,7 @@ class EvaluationTargetServiceTest(
                 // then
                 assertSoftly {
                     actual shouldHaveSize 4
-                    cheaterEvaluationTargets.all { it.evaluationStatus == FAIL }.shouldBeTrue()
+                    cheaterEvaluationTargets.all { it.evaluationStatus == FAIL } shouldBe true
                 }
             }
         }
@@ -368,7 +367,7 @@ class EvaluationTargetServiceTest(
                 evaluationTargetService.load(2L)
 
                 // then
-                assertSoftly {
+                assertSoftly(evaluationTargetRepository) {
                     evaluationTargetRepository.findAllByEvaluationId(1L)[0].evaluationStatus shouldBe PASS
                     evaluationTargetRepository.findAllByEvaluationId(2L)[0].evaluationStatus shouldBe FAIL
                     evaluationTargetRepository.findAllByEvaluationId(3L)[0].evaluationStatus shouldBe PASS
@@ -389,7 +388,7 @@ class EvaluationTargetServiceTest(
                 } returns listOf(evaluationItem)
 
                 val result = evaluationTargetService.getGradeEvaluation(evaluationTarget.id)
-                assertSoftly {
+                assertSoftly(result) {
                     result.title shouldBe evaluation.title
                     result.description shouldBe evaluation.description
                     result.evaluationItems shouldHaveSize 1
@@ -415,7 +414,7 @@ class EvaluationTargetServiceTest(
                 } returns listOf(evaluationItem)
 
                 val result = evaluationTargetService.getGradeEvaluation(evaluationTarget.id)
-                assertSoftly {
+                assertSoftly(result) {
                     result.title shouldBe evaluation.title
                     result.description shouldBe evaluation.description
                     result.evaluationItems shouldHaveSize 1
@@ -440,7 +439,7 @@ class EvaluationTargetServiceTest(
 
                 val updatedEvaluationTarget = evaluationTargetRepository.findByIdOrNull(evaluationTarget.id)!!
                 val expectedAnswers = EvaluationAnswers(mutableListOf(EvaluationAnswer(updatedScore, 3L)))
-                assertSoftly {
+                assertSoftly(updatedEvaluationTarget) {
                     updatedEvaluationTarget.evaluationStatus shouldBe updatedStatus
                     updatedEvaluationTarget.note shouldBe updatedNote
                     updatedEvaluationTarget.evaluationAnswers shouldBeEqualToComparingFields expectedAnswers

--- a/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetServiceTest.kt
@@ -1,13 +1,6 @@
 package apply.application
 
-import apply.EVALUATION_ANSWER_SCORE
-import apply.EVALUATION_ID
-import apply.EVALUATION_ITEM_ID
-import apply.EVALUATION_TARGET_NOTE
-import apply.createEvaluation
-import apply.createEvaluationAnswer
-import apply.createEvaluationItem
-import apply.createEvaluationTarget
+import apply.*
 import apply.domain.applicationform.ApplicationForm
 import apply.domain.applicationform.ApplicationFormAnswer
 import apply.domain.applicationform.ApplicationFormAnswers
@@ -18,16 +11,10 @@ import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluationItem.EvaluationItemRepository
 import apply.domain.evaluationtarget.EvaluationAnswer
 import apply.domain.evaluationtarget.EvaluationAnswers
-import apply.domain.evaluationtarget.EvaluationStatus.FAIL
-import apply.domain.evaluationtarget.EvaluationStatus.PASS
-import apply.domain.evaluationtarget.EvaluationStatus.WAITING
+import apply.domain.evaluationtarget.EvaluationStatus.*
 import apply.domain.evaluationtarget.EvaluationTarget
 import apply.domain.evaluationtarget.EvaluationTargetRepository
-import apply.domain.user.Gender
-import apply.domain.user.Password
-import apply.domain.user.User
-import apply.domain.user.UserRepository
-import apply.domain.user.findAllByEmailIn
+import apply.domain.user.*
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -61,7 +48,7 @@ class EvaluationTargetServiceTest(
     @MockK
     val evaluationItemRepository: EvaluationItemRepository = mockk()
 
-    val evaluationTargetService: EvaluationTargetService = EvaluationTargetService(
+    val evaluationTargetService = EvaluationTargetService(
         evaluationRepository,
         evaluationTargetRepository,
         evaluationItemRepository,

--- a/src/test/kotlin/apply/application/MailHistoryServiceTest.kt
+++ b/src/test/kotlin/apply/application/MailHistoryServiceTest.kt
@@ -3,42 +3,37 @@ package apply.application
 import apply.createMailData
 import apply.createMailHistory
 import apply.domain.mail.MailHistoryRepository
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
+import io.mockk.mockk
 import support.test.UnitTest
 import java.time.LocalDateTime
 
 @UnitTest
-class MailHistoryServiceTest {
+class MailHistoryServiceTest : DescribeSpec({
     @MockK
-    private lateinit var mailHistoryRepository: MailHistoryRepository
+    val mailHistoryRepository: MailHistoryRepository = mockk()
 
-    private lateinit var mailHistoryService: MailHistoryService
+    val mailHistoryService: MailHistoryService = MailHistoryService(mailHistoryRepository)
 
-    @BeforeEach
-    internal fun setUp() {
-        mailHistoryService = MailHistoryService(mailHistoryRepository)
+    describe("MailHistoryService") {
+        it("메일 이력을 저장한다") {
+            val mailData = createMailData()
+            every { mailHistoryRepository.save(any()) } returns createMailHistory()
+            shouldNotThrow<Exception> { mailHistoryService.save(mailData) }
+        }
+
+        it("저장된 메일 이력을 모두 조회한다") {
+            val now = LocalDateTime.now()
+            val mailData1 = createMailData(subject = "제목1", sentTime = now)
+            val mailData2 = createMailData(subject = "제목2", sentTime = now.plusSeconds(1))
+            val emailHistory1 = createMailHistory(subject = "제목1", sentTime = now)
+            val emailHistory2 = createMailHistory(subject = "제목2", sentTime = now.plusSeconds(1))
+            every { mailHistoryRepository.findAll() } returns listOf(emailHistory1, emailHistory2)
+            mailHistoryService.findAll().shouldContainExactly(mailData1, mailData2)
+        }
     }
-
-    @Test
-    fun `메일 이력을 저장한다`() {
-        val mailData = createMailData()
-        every { mailHistoryRepository.save(any()) } returns createMailHistory()
-        assertDoesNotThrow { mailHistoryService.save(mailData) }
-    }
-
-    @Test
-    fun `저장된 메일 이력을 모두 조회한다`() {
-        val now = LocalDateTime.now()
-        val mailData1 = createMailData(subject = "제목1", sentTime = now)
-        val mailData2 = createMailData(subject = "제목2", sentTime = now.plusSeconds(1))
-        val emailHistory1 = createMailHistory(subject = "제목1", sentTime = now)
-        val emailHistory2 = createMailHistory(subject = "제목2", sentTime = now.plusSeconds(1))
-        every { mailHistoryRepository.findAll() } returns listOf(emailHistory1, emailHistory2)
-        assertThat(mailHistoryService.findAll()).containsExactly(mailData1, mailData2)
-    }
-}
+})

--- a/src/test/kotlin/apply/application/MailHistoryServiceTest.kt
+++ b/src/test/kotlin/apply/application/MailHistoryServiceTest.kt
@@ -3,7 +3,7 @@ package apply.application
 import apply.createMailData
 import apply.createMailHistory
 import apply.domain.mail.MailHistoryRepository
-import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.mockk.every
@@ -23,7 +23,7 @@ class MailHistoryServiceTest : DescribeSpec({
         it("메일 이력을 저장한다") {
             val mailData = createMailData()
             every { mailHistoryRepository.save(any()) } returns createMailHistory()
-            shouldNotThrow<Exception> { mailHistoryService.save(mailData) }
+            shouldNotThrowAny { mailHistoryService.save(mailData) }
         }
 
         it("저장된 메일 이력을 모두 조회한다") {
@@ -33,7 +33,7 @@ class MailHistoryServiceTest : DescribeSpec({
             val emailHistory1 = createMailHistory(subject = "제목1", sentTime = now)
             val emailHistory2 = createMailHistory(subject = "제목2", sentTime = now.plusSeconds(1))
             every { mailHistoryRepository.findAll() } returns listOf(emailHistory1, emailHistory2)
-            mailHistoryService.findAll().shouldContainExactly(mailData1, mailData2)
+            mailHistoryService.findAll() shouldContainExactly listOf(mailData1, mailData2)
         }
     }
 })

--- a/src/test/kotlin/apply/application/MailHistoryServiceTest.kt
+++ b/src/test/kotlin/apply/application/MailHistoryServiceTest.kt
@@ -17,7 +17,7 @@ class MailHistoryServiceTest : DescribeSpec({
     @MockK
     val mailHistoryRepository: MailHistoryRepository = mockk()
 
-    val mailHistoryService: MailHistoryService = MailHistoryService(mailHistoryRepository)
+    val mailHistoryService = MailHistoryService(mailHistoryRepository)
 
     describe("MailHistoryService") {
         it("메일 이력을 저장한다") {

--- a/src/test/kotlin/apply/application/MailTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/MailTargetServiceTest.kt
@@ -66,7 +66,7 @@ class MailTargetServiceTest : DescribeSpec({
                     createUser(id = 3L, email = "pass@email.com")
                 )
                 val actual = mailTargetService.findMailTargets(EVALUATION_ID, PASS)
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 1
                     actual[0].email shouldBe "pass@email.com"
                 }
@@ -87,7 +87,7 @@ class MailTargetServiceTest : DescribeSpec({
                     createUser(id = 2L, email = "fail@email.com")
                 )
                 val actual = mailTargetService.findMailTargets(EVALUATION_ID, FAIL)
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 1
                     actual[0].email shouldBe "fail@email.com"
                 }
@@ -131,7 +131,7 @@ class MailTargetServiceTest : DescribeSpec({
                     createUser(id = 1L, email = "waiting@email.com")
                 )
                 val actual = mailTargetService.findMailTargets(EVALUATION_ID, WAITING)
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 1
                     actual[0].email shouldBe "waiting@email.com"
                 }

--- a/src/test/kotlin/apply/application/MailTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/MailTargetServiceTest.kt
@@ -12,119 +12,146 @@ import apply.domain.evaluationtarget.EvaluationStatus.WAITING
 import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.user.UserRepository
 import apply.domain.user.findAllByEmailIn
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.verify
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import support.test.UnitTest
 
 @UnitTest
-class MailTargetServiceTest {
+class MailTargetServiceTest : DescribeSpec({
     @MockK
-    private lateinit var evaluationTargetRepository: EvaluationTargetRepository
+    val evaluationTargetRepository: EvaluationTargetRepository = mockk()
 
     @MockK
-    private lateinit var userRepository: UserRepository
+    val userRepository: UserRepository = mockk()
 
-    private lateinit var mailTargetService: MailTargetService
+    val mailTargetService: MailTargetService = MailTargetService(evaluationTargetRepository, userRepository)
 
-    @BeforeEach
-    internal fun setUp() {
-        mailTargetService = MailTargetService(evaluationTargetRepository, userRepository)
-    }
+    describe("MailTargetService") {
+        context("평가 상태에 따라 (null, 전체)") {
+            it("메일 발송 대상들의 이메일 정보를 불러온다") {
+                every { evaluationTargetRepository.findAllByEvaluationId(any()) } returns listOf(
+                    createEvaluationTarget(userId = 1L, evaluationStatus = WAITING),
+                    createEvaluationTarget(userId = 2L, evaluationStatus = PENDING),
+                    createEvaluationTarget(userId = 3L, evaluationStatus = PASS),
+                    createEvaluationTarget(userId = 4L, evaluationStatus = FAIL)
+                )
+                every { userRepository.findAllById(any()) } returns listOf(
+                    createUser(id = 1L, email = "waiting@email.com"),
+                    createUser(id = 2L, email = "pending@email.com"),
+                    createUser(id = 3L, email = "pass@email.com"),
+                    createUser(id = 4L, email = "fail@email.com")
+                )
+                val actual = mailTargetService.findMailTargets(EVALUATION_ID)
+                actual shouldHaveSize 4
+            }
+        }
 
-    @Test
-    fun `평가 상태에 따라 (null, 전체) 메일 발송 대상들의 이메일 정보를 불러온다`() {
-        every { evaluationTargetRepository.findAllByEvaluationId(any()) } returns listOf(
-            createEvaluationTarget(userId = 1L, evaluationStatus = WAITING),
-            createEvaluationTarget(userId = 2L, evaluationStatus = PENDING),
-            createEvaluationTarget(userId = 3L, evaluationStatus = PASS),
-            createEvaluationTarget(userId = 4L, evaluationStatus = FAIL)
-        )
-        every { userRepository.findAllById(any()) } returns listOf(
-            createUser(id = 1L, email = "waiting@email.com"),
-            createUser(id = 2L, email = "pending@email.com"),
-            createUser(id = 3L, email = "pass@email.com"),
-            createUser(id = 4L, email = "fail@email.com")
-        )
-        val actual = mailTargetService.findMailTargets(EVALUATION_ID)
-        assertThat(actual).hasSize(4)
-    }
+        context("평가 상태에 따라 (PASS)") {
+            it("메일 발송 대상들의 이메일 정보를 불러온다") {
+                every {
+                    evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(
+                        any(),
+                        any()
+                    )
+                } returns listOf(
+                    createEvaluationTarget(userId = 3L, evaluationStatus = PASS)
+                )
+                every { userRepository.findAllById(any()) } returns listOf(
+                    createUser(id = 3L, email = "pass@email.com")
+                )
+                val actual = mailTargetService.findMailTargets(EVALUATION_ID, PASS)
+                assertSoftly {
+                    actual shouldHaveSize 1
+                    actual[0].email shouldBe "pass@email.com"
+                }
+            }
+        }
 
-    @Test
-    fun `평가 상태에 따라 (PASS) 메일 발송 대상들의 이메일 정보를 불러온다`() {
-        every { evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(any(), any()) } returns listOf(
-            createEvaluationTarget(userId = 3L, evaluationStatus = PASS)
-        )
-        every { userRepository.findAllById(any()) } returns listOf(
-            createUser(id = 3L, email = "pass@email.com")
-        )
-        val actual = mailTargetService.findMailTargets(EVALUATION_ID, PASS)
-        assertThat(actual).hasSize(1)
-        assertThat(actual[0].email).isEqualTo("pass@email.com")
-    }
+        context("평가 상태에 따라 (FAIL)") {
+            it("메일 발송 대상들의 이메일 정보를 불러온다") {
+                every {
+                    evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(
+                        any(),
+                        any()
+                    )
+                } returns listOf(
+                    createEvaluationTarget(userId = 2L, evaluationStatus = FAIL)
+                )
+                every { userRepository.findAllById(any()) } returns listOf(
+                    createUser(id = 2L, email = "fail@email.com")
+                )
+                val actual = mailTargetService.findMailTargets(EVALUATION_ID, FAIL)
+                assertSoftly {
+                    actual shouldHaveSize 1
+                    actual[0].email shouldBe "fail@email.com"
+                }
+            }
 
-    @Test
-    fun `평가 상태에 따라 (FAIL) 메일 발송 대상들의 이메일 정보를 불러온다`() {
-        every { evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(any(), any()) } returns listOf(
-            createEvaluationTarget(userId = 2L, evaluationStatus = FAIL)
-        )
-        every { userRepository.findAllById(any()) } returns listOf(
-            createUser(id = 2L, email = "fail@email.com")
-        )
-        val actual = mailTargetService.findMailTargets(EVALUATION_ID, FAIL)
-        assertThat(actual).hasSize(1)
-        assertThat(actual[0].email).isEqualTo("fail@email.com")
-    }
+            it("메일 발송 시 과제 미제출자는 대상이 되지 않는다") {
+                every {
+                    evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(
+                        any(),
+                        any()
+                    )
+                } returns listOf(
+                    createEvaluationTarget(
+                        userId = 1L,
+                        evaluationStatus = FAIL,
+                        evaluationAnswers = EvaluationAnswers(emptyList())
+                    ),
+                    createEvaluationTarget(
+                        userId = 2L,
+                        evaluationStatus = FAIL,
+                        evaluationAnswers = EvaluationAnswers(listOf(createEvaluationAnswer(score = 0)))
+                    )
+                )
+                every { userRepository.findAllById(any()) } returns emptyList()
+                mailTargetService.findMailTargets(EVALUATION_ID, FAIL)
+                verify { userRepository.findAllById(emptyList()) }
+            }
+        }
 
-    @Test
-    fun `평가 상태에 따라 (FAIL) 메일 발송 시 과제 미제출자는 대상이 되지 않는다`() {
-        every { evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(any(), any()) } returns listOf(
-            createEvaluationTarget(
-                userId = 1L,
-                evaluationStatus = FAIL,
-                evaluationAnswers = EvaluationAnswers(emptyList())
-            ),
-            createEvaluationTarget(
-                userId = 2L,
-                evaluationStatus = FAIL,
-                evaluationAnswers = EvaluationAnswers(listOf(createEvaluationAnswer(score = 0)))
+        context("평가 상태에 따라 (WAITING)") {
+            it("메일 발송 대상들의 이메일 정보를 불러온다") {
+                every {
+                    evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(
+                        any(),
+                        any()
+                    )
+                } returns listOf(
+                    createEvaluationTarget(userId = 1L, evaluationStatus = WAITING)
+                )
+                every { userRepository.findAllById(any()) } returns listOf(
+                    createUser(id = 1L, email = "waiting@email.com")
+                )
+                val actual = mailTargetService.findMailTargets(EVALUATION_ID, WAITING)
+                assertSoftly {
+                    actual shouldHaveSize 1
+                    actual[0].email shouldBe "waiting@email.com"
+                }
+            }
+        }
+
+        it("이메일 중에서 회원에 해당하는 이메일이 있으면 (회원이름, 이메일)을, 회원에 해당하는 이메일이 없으면 (공백, 이메일)을 반환한다") {
+            val users = listOf(
+                createUser(name = "회원1", email = "test1@email.com"),
+                createUser(name = "회원3", email = "test3@email.com")
             )
-        )
-        every { userRepository.findAllById(any()) } returns emptyList()
-        mailTargetService.findMailTargets(EVALUATION_ID, FAIL)
-        verify { userRepository.findAllById(emptyList()) }
+            val emails = listOf("test1@email.com", "test2@email.com", "test3@email.com")
+            val mailTargetResponses = listOf(
+                MailTargetResponse("test1@email.com", "회원1"),
+                MailTargetResponse("test3@email.com", "회원3"),
+                MailTargetResponse("test2@email.com")
+            )
+            every { userRepository.findAllByEmailIn(emails) } returns users
+            val actual = mailTargetService.findAllByEmails(emails)
+            actual shouldBe mailTargetResponses
+        }
     }
-
-    @Test
-    fun `평가 상태에 따라 (WAITING) 메일 발송 대상들의 이메일 정보를 불러온다`() {
-        every { evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(any(), any()) } returns listOf(
-            createEvaluationTarget(userId = 1L, evaluationStatus = WAITING)
-        )
-        every { userRepository.findAllById(any()) } returns listOf(
-            createUser(id = 1L, email = "waiting@email.com")
-        )
-        val actual = mailTargetService.findMailTargets(EVALUATION_ID, WAITING)
-        assertThat(actual).hasSize(1)
-        assertThat(actual[0].email).isEqualTo("waiting@email.com")
-    }
-
-    @Test
-    fun `이메일 중에서 회원에 해당하는 이메일이 있으면 (회원이름, 이메일)을, 회원에 해당하는 이메일이 없으면 (공백, 이메일)을 반환한다`() {
-        val users = listOf(
-            createUser(name = "회원1", email = "test1@email.com"),
-            createUser(name = "회원3", email = "test3@email.com")
-        )
-        val emails = listOf("test1@email.com", "test2@email.com", "test3@email.com")
-        val mailTargetResponses = listOf(
-            MailTargetResponse("test1@email.com", "회원1"),
-            MailTargetResponse("test3@email.com", "회원3"),
-            MailTargetResponse("test2@email.com")
-        )
-        every { userRepository.findAllByEmailIn(emails) } returns users
-        val actual = mailTargetService.findAllByEmails(emails)
-        assertThat(actual).isEqualTo(mailTargetResponses)
-    }
-}
+})

--- a/src/test/kotlin/apply/application/MailTargetServiceTest.kt
+++ b/src/test/kotlin/apply/application/MailTargetServiceTest.kt
@@ -5,10 +5,7 @@ import apply.createEvaluationAnswer
 import apply.createEvaluationTarget
 import apply.createUser
 import apply.domain.evaluationtarget.EvaluationAnswers
-import apply.domain.evaluationtarget.EvaluationStatus.FAIL
-import apply.domain.evaluationtarget.EvaluationStatus.PASS
-import apply.domain.evaluationtarget.EvaluationStatus.PENDING
-import apply.domain.evaluationtarget.EvaluationStatus.WAITING
+import apply.domain.evaluationtarget.EvaluationStatus.*
 import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.user.UserRepository
 import apply.domain.user.findAllByEmailIn

--- a/src/test/kotlin/apply/application/MissionServiceTest.kt
+++ b/src/test/kotlin/apply/application/MissionServiceTest.kt
@@ -8,158 +8,152 @@ import apply.domain.assignment.AssignmentRepository
 import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.mission.MissionRepository
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainAnyOf
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.mockk.Runs
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.just
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
+import io.mockk.mockk
 import org.springframework.data.repository.findByIdOrNull
 import support.test.UnitTest
 
 @UnitTest
-class MissionServiceTest {
-    @MockK
-    lateinit var missionRepository: MissionRepository
+class MissionServiceTest : DescribeSpec({
+    val missionRepository: MissionRepository = mockk()
+    val evaluationRepository: EvaluationRepository = mockk()
+    val evaluationTargetRepository: EvaluationTargetRepository = mockk()
+    val assignmentRepository: AssignmentRepository = mockk()
+    val missionService = MissionService(
+        missionRepository, evaluationRepository, evaluationTargetRepository, assignmentRepository
+    )
+    val recruitmentId = 1L
+    val userId = 1L
 
-    @MockK
-    lateinit var evaluationRepository: EvaluationRepository
+    describe("MissionService") {
+        it("과제를 추가한다") {
+            val missionData = createMissionData()
+            every { evaluationRepository.existsById(any()) } returns true
+            every { missionRepository.existsByEvaluationId(any()) } returns false
+            every { missionRepository.save(any()) } returns createMission()
+            shouldNotThrow<Exception> { missionService.save(missionData) }
+        }
 
-    @MockK
-    lateinit var evaluationTargetRepository: EvaluationTargetRepository
-
-    @MockK
-    lateinit var assignmentRepository: AssignmentRepository
-
-    private lateinit var missionService: MissionService
-
-    private val recruitmentId = 1L
-    private val userId = 1L
-
-    @BeforeEach
-    internal fun setUp() {
-        missionService = MissionService(
-            missionRepository, evaluationRepository, evaluationTargetRepository, assignmentRepository
-        )
-    }
-
-    @Test
-    fun `과제를 추가한다`() {
-        val missionData = createMissionData()
-        every { evaluationRepository.existsById(any()) } returns true
-        every { missionRepository.existsByEvaluationId(any()) } returns false
-        every { missionRepository.save(any()) } returns createMission()
-        assertDoesNotThrow { missionService.save(missionData) }
-    }
-
-    @Test
-    fun `존재하지 않는 평가 id인 경우 예외를 던진다`() {
-        val missionData = createMissionData()
-        every { evaluationRepository.existsById(any()) } returns false
-        assertThrows<IllegalArgumentException> { missionService.save(missionData) }
-    }
-
-    @Test
-    fun `해당 평가에 이미 등록된 과제가 있는 경우 예외를 던진다`() {
-        val missionData = createMissionData()
-        every { evaluationRepository.existsById(any()) } returns true
-        every { missionRepository.existsByEvaluationId(any()) } returns true
-        assertThrows<IllegalStateException> { missionService.save(missionData) }
-    }
-
-    @Test
-    fun `특정 모집의 모든 과제를 찾는다`() {
-        val recruitmentId = 1L
-        val firstEvaluation = createEvaluation(id = 1L, title = "평가1", recruitmentId = recruitmentId)
-        val secondEvaluation = createEvaluation(id = 2L, title = "평가2", recruitmentId = recruitmentId)
-        every { evaluationRepository.findAllByRecruitmentId(any()) } returns listOf(firstEvaluation, secondEvaluation)
-
-        val firstMission = createMission(title = "과제1", evaluationId = 1L)
-        val secondMission = createMission(title = "과제1", evaluationId = 2L)
-        every { missionRepository.findAllByEvaluationIdIn(any()) } returns listOf(firstMission, secondMission)
-
-        val actual = missionService.findAllByRecruitmentId(recruitmentId)
-        assertAll(
-            { assertThat(actual).hasSize(2) },
-            {
-                assertThat(actual).containsAnyOf(
-                    MissionAndEvaluationResponse(firstMission, firstEvaluation),
-                    MissionAndEvaluationResponse(secondMission, secondEvaluation)
-                )
+        context("존재하지 않는 평가 id인 경우") {
+            it("예외를 던진다") {
+                val missionData = createMissionData()
+                every { evaluationRepository.existsById(any()) } returns false
+                shouldThrowExactly<IllegalArgumentException> { missionService.save(missionData) }
             }
-        )
-    }
+        }
 
-    @Test
-    fun `특정 모집에 해당하는 나의 숨겨지지 않은 과제들을 조회한다`() {
-        val missions = listOf(createMission(id = 1L), createMission(id = 2L))
-        every { evaluationRepository.findAllByRecruitmentId(any()) } returns
-            listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
-        every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
-        every { missionRepository.findAllByEvaluationIdIn(any()) } returns missions
-        every { assignmentRepository.findAllByUserId(any()) } returns listOf(
-            createAssignment(userId = userId, missionId = 1L),
-            createAssignment(userId = userId, missionId = 2L)
-        )
-
-        val responses = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
-
-        assertAll(
-            { assertThat(responses).hasSize(2) },
-            {
-                assertThat(responses).containsExactlyInAnyOrder(
-                    MissionResponse(missions[0], true),
-                    MissionResponse(missions[1], true)
-                )
+        context("해당 평가에 이미 등록된 과제가 있는 경우") {
+            it("예외를 던진다") {
+                val missionData = createMissionData()
+                every { evaluationRepository.existsById(any()) } returns true
+                every { missionRepository.existsByEvaluationId(any()) } returns true
+                shouldThrowExactly<IllegalStateException> { missionService.save(missionData) }
             }
-        )
+        }
+
+        context("특정 모집의") {
+            it("모든 과제를 찾는다") {
+                val recruitmentId = 1L
+                val firstEvaluation = createEvaluation(id = 1L, title = "평가1", recruitmentId = recruitmentId)
+                val secondEvaluation = createEvaluation(id = 2L, title = "평가2", recruitmentId = recruitmentId)
+                every { evaluationRepository.findAllByRecruitmentId(any()) } returns listOf(
+                    firstEvaluation,
+                    secondEvaluation
+                )
+
+                val firstMission = createMission(title = "과제1", evaluationId = 1L)
+                val secondMission = createMission(title = "과제1", evaluationId = 2L)
+                every { missionRepository.findAllByEvaluationIdIn(any()) } returns listOf(firstMission, secondMission)
+
+                val actual = missionService.findAllByRecruitmentId(recruitmentId)
+                assertSoftly {
+                    actual shouldHaveSize 2
+                    actual shouldContainAnyOf listOf(
+                        MissionAndEvaluationResponse(firstMission, firstEvaluation),
+                        MissionAndEvaluationResponse(secondMission, secondEvaluation)
+                    )
+                }
+            }
+        }
+
+        context("특정 모집에 해당하는") {
+            it("나의 숨겨지지 않은 과제들을 조회한다") {
+                val missions = listOf(createMission(id = 1L), createMission(id = 2L))
+                every { evaluationRepository.findAllByRecruitmentId(any()) } returns
+                    listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
+                every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
+                every { missionRepository.findAllByEvaluationIdIn(any()) } returns missions
+                every { assignmentRepository.findAllByUserId(any()) } returns listOf(
+                    createAssignment(userId = userId, missionId = 1L),
+                    createAssignment(userId = userId, missionId = 2L)
+                )
+
+                val responses = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
+
+                assertSoftly {
+                    responses shouldHaveSize 2
+                    responses shouldContainExactlyInAnyOrder listOf(
+                        MissionResponse(missions[0], true),
+                        MissionResponse(missions[1], true)
+                    )
+                }
+            }
+        }
+
+        context("과제의 상태가 hidden인 경우") {
+            it("조회할 수 없다") {
+                val missions = listOf(createMission(id = 1L, hidden = true), createMission(id = 2L, hidden = true))
+                every { evaluationRepository.findAllByRecruitmentId(any()) } returns
+                    listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
+                every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
+                every { missionRepository.findAllByEvaluationIdIn(any()) } returns missions
+                every { assignmentRepository.findAllByUserId(any()) } returns listOf(
+                    createAssignment(userId = userId, missionId = 1L),
+                    createAssignment(userId = userId, missionId = 2L)
+                )
+
+                val responses = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
+
+                responses.shouldBeEmpty()
+            }
+        }
+
+        it("과제를 삭제한다") {
+            val mission = createMission(submittable = false)
+            every { missionRepository.findByIdOrNull(mission.id) } returns mission
+            every { missionRepository.deleteById(any()) } just Runs
+
+            shouldNotThrow<Exception> { missionService.deleteById(mission.id) }
+        }
+
+        context("제출 가능한 상태의 과제를 삭제하면") {
+            it("예외가 발생한다") {
+                val mission = createMission(submittable = true)
+                every { missionRepository.findByIdOrNull(mission.id) } returns mission
+                every { missionRepository.deleteById(any()) } just Runs
+
+                shouldThrowExactly<IllegalStateException> { missionService.deleteById(mission.id) }
+            }
+        }
+
+        context("존재하지 않는 과제를 삭제하면") {
+            it("예외가 발생한다") {
+                val missionId = 1L
+                every { missionRepository.findByIdOrNull(missionId) } returns null
+                every { missionRepository.deleteById(any()) } just Runs
+
+                shouldThrowExactly<NoSuchElementException> { missionService.deleteById(missionId) }
+            }
+        }
     }
-
-    @Test
-    fun `과제의 상태가 hidden인 경우 조회할 수 없다`() {
-        val missions = listOf(createMission(id = 1L, hidden = true), createMission(id = 2L, hidden = true))
-        every { evaluationRepository.findAllByRecruitmentId(any()) } returns
-            listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
-        every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
-        every { missionRepository.findAllByEvaluationIdIn(any()) } returns missions
-        every { assignmentRepository.findAllByUserId(any()) } returns listOf(
-            createAssignment(userId = userId, missionId = 1L),
-            createAssignment(userId = userId, missionId = 2L)
-        )
-
-        val responses = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
-
-        assertThat(responses).isEmpty()
-    }
-
-    @Test
-    fun `과제를 삭제한다`() {
-        val mission = createMission(submittable = false)
-        every { missionRepository.findByIdOrNull(mission.id) } returns mission
-        every { missionRepository.deleteById(any()) } just Runs
-
-        assertDoesNotThrow { missionService.deleteById(mission.id) }
-    }
-
-    @Test
-    fun `제출 가능한 상태의 과제를 삭제하면 예외가 발생한다`() {
-        val mission = createMission(submittable = true)
-        every { missionRepository.findByIdOrNull(mission.id) } returns mission
-        every { missionRepository.deleteById(any()) } just Runs
-
-        assertThrows<IllegalStateException> { missionService.deleteById(mission.id) }
-    }
-
-    @Test
-    fun `존재하지 않는 과제를 삭제하면 예외가 발생한다`() {
-        val missionId = 1L
-        every { missionRepository.findByIdOrNull(missionId) } returns null
-        every { missionRepository.deleteById(any()) } just Runs
-
-        assertThrows<NoSuchElementException> { missionService.deleteById(missionId) }
-    }
-}
+})

--- a/src/test/kotlin/apply/application/MissionServiceTest.kt
+++ b/src/test/kotlin/apply/application/MissionServiceTest.kt
@@ -11,7 +11,7 @@ import apply.domain.mission.MissionRepository
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainAnyOf
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -49,7 +49,7 @@ class MissionServiceTest : DescribeSpec({
             it("예외를 던진다") {
                 val missionData = createMissionData()
                 every { evaluationRepository.existsById(any()) } returns false
-                shouldThrowExactly<IllegalArgumentException> { missionService.save(missionData) }
+                shouldThrow<IllegalArgumentException> { missionService.save(missionData) }
             }
         }
 
@@ -58,7 +58,7 @@ class MissionServiceTest : DescribeSpec({
                 val missionData = createMissionData()
                 every { evaluationRepository.existsById(any()) } returns true
                 every { missionRepository.existsByEvaluationId(any()) } returns true
-                shouldThrowExactly<IllegalStateException> { missionService.save(missionData) }
+                shouldThrow<IllegalStateException> { missionService.save(missionData) }
             }
         }
 
@@ -143,7 +143,7 @@ class MissionServiceTest : DescribeSpec({
                 every { missionRepository.findByIdOrNull(mission.id) } returns mission
                 every { missionRepository.deleteById(any()) } just Runs
 
-                shouldThrowExactly<IllegalStateException> { missionService.deleteById(mission.id) }
+                shouldThrow<IllegalStateException> { missionService.deleteById(mission.id) }
             }
         }
 
@@ -153,7 +153,7 @@ class MissionServiceTest : DescribeSpec({
                 every { missionRepository.findByIdOrNull(missionId) } returns null
                 every { missionRepository.deleteById(any()) } just Runs
 
-                shouldThrowExactly<NoSuchElementException> { missionService.deleteById(missionId) }
+                shouldThrow<NoSuchElementException> { missionService.deleteById(missionId) }
             }
         }
     }

--- a/src/test/kotlin/apply/application/MissionServiceTest.kt
+++ b/src/test/kotlin/apply/application/MissionServiceTest.kt
@@ -10,12 +10,13 @@ import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.mission.MissionRepository
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAnyOf
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -76,7 +77,7 @@ class MissionServiceTest : DescribeSpec({
                 every { missionRepository.findAllByEvaluationIdIn(any()) } returns listOf(firstMission, secondMission)
 
                 val actual = missionService.findAllByRecruitmentId(recruitmentId)
-                assertSoftly {
+                assertSoftly(actual) {
                     actual shouldHaveSize 2
                     actual shouldContainAnyOf listOf(
                         MissionAndEvaluationResponse(firstMission, firstEvaluation),
@@ -100,7 +101,7 @@ class MissionServiceTest : DescribeSpec({
 
                 val responses = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
 
-                assertSoftly {
+                assertSoftly(responses) {
                     responses shouldHaveSize 2
                     responses shouldContainExactlyInAnyOrder listOf(
                         MissionResponse(missions[0], true),
@@ -124,7 +125,7 @@ class MissionServiceTest : DescribeSpec({
 
                 val responses = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
 
-                responses.shouldBeEmpty()
+                responses shouldBe emptyList()
             }
         }
 
@@ -133,7 +134,7 @@ class MissionServiceTest : DescribeSpec({
             every { missionRepository.findByIdOrNull(mission.id) } returns mission
             every { missionRepository.deleteById(any()) } just Runs
 
-            shouldNotThrow<Exception> { missionService.deleteById(mission.id) }
+            shouldNotThrowAny { missionService.deleteById(mission.id) }
         }
 
         context("제출 가능한 상태의 과제를 삭제하면") {

--- a/src/test/kotlin/apply/application/MissionServiceTest.kt
+++ b/src/test/kotlin/apply/application/MissionServiceTest.kt
@@ -91,7 +91,7 @@ class MissionServiceTest : DescribeSpec({
             it("나의 숨겨지지 않은 과제들을 조회한다") {
                 val missions = listOf(createMission(id = 1L), createMission(id = 2L))
                 every { evaluationRepository.findAllByRecruitmentId(any()) } returns
-                    listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
+                        listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
                 every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
                 every { missionRepository.findAllByEvaluationIdIn(any()) } returns missions
                 every { assignmentRepository.findAllByUserId(any()) } returns listOf(
@@ -115,7 +115,7 @@ class MissionServiceTest : DescribeSpec({
             it("조회할 수 없다") {
                 val missions = listOf(createMission(id = 1L, hidden = true), createMission(id = 2L, hidden = true))
                 every { evaluationRepository.findAllByRecruitmentId(any()) } returns
-                    listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
+                        listOf(createEvaluation(id = 1L), createEvaluation(id = 2L))
                 every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
                 every { missionRepository.findAllByEvaluationIdIn(any()) } returns missions
                 every { assignmentRepository.findAllByUserId(any()) } returns listOf(

--- a/src/test/kotlin/apply/application/RecruitmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/RecruitmentServiceTest.kt
@@ -9,7 +9,7 @@ import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.recruitmentitem.RecruitmentItem
 import apply.domain.recruitmentitem.RecruitmentItemRepository
 import apply.domain.term.TermRepository
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.Runs
 import io.mockk.every
@@ -127,7 +127,7 @@ internal class RecruitmentServiceTest : DescribeSpec({
             it("삭제할 수 없다") {
                 val recruitment = createRecruitment(recruitable = true)
                 every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-                shouldThrowExactly<IllegalStateException> { recruitmentService.deleteById(recruitment.id) }
+                shouldThrow<IllegalStateException> { recruitmentService.deleteById(recruitment.id) }
             }
         }
     }

--- a/src/test/kotlin/apply/application/RecruitmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/RecruitmentServiceTest.kt
@@ -9,137 +9,126 @@ import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.recruitmentitem.RecruitmentItem
 import apply.domain.recruitmentitem.RecruitmentItemRepository
 import apply.domain.term.TermRepository
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.Runs
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import support.test.UnitTest
 
 @UnitTest
-internal class RecruitmentServiceTest {
-    @MockK
-    lateinit var recruitmentRepository: RecruitmentRepository
+internal class RecruitmentServiceTest : DescribeSpec({
+    val recruitmentRepository: RecruitmentRepository = mockk()
+    val recruitmentItemRepository: RecruitmentItemRepository = mockk()
+    val termRepository: TermRepository = mockk()
+    val recruitmentService = RecruitmentService(recruitmentRepository, recruitmentItemRepository, termRepository)
 
-    @MockK
-    private lateinit var recruitmentItemRepository: RecruitmentItemRepository
-
-    @MockK
-    private lateinit var termRepository: TermRepository
-
-    private lateinit var recruitmentService: RecruitmentService
-
-    @BeforeEach
-    internal fun setUp() {
-        recruitmentService = RecruitmentService(recruitmentRepository, recruitmentItemRepository, termRepository)
+    slot<Recruitment>().also { slot ->
+        every { recruitmentRepository.save(capture(slot)) } answers {
+            slot.captured.run {
+                Recruitment(title, period, 0L, recruitable, hidden, id)
+            }
+        }
+    }
+    every { recruitmentItemRepository.deleteAll(any()) } just Runs
+    slot<List<RecruitmentItem>>().also { slot ->
+        every { recruitmentItemRepository.saveAll(capture(slot)) } answers {
+            slot.captured.run {
+                map {
+                    RecruitmentItem(
+                        it.recruitmentId,
+                        it.title,
+                        it.position,
+                        it.maximumLength,
+                        it.description,
+                        it.id
+                    )
+                }
+            }
+        }
     }
 
-    @Nested
-    inner class Save {
-        @BeforeEach
-        internal fun setUp() {
-            slot<Recruitment>().also { slot ->
-                every { recruitmentRepository.save(capture(slot)) } answers {
-                    slot.captured.run {
-                        Recruitment(title, period, 0L, recruitable, hidden, id)
-                    }
-                }
-            }
-            every { recruitmentItemRepository.deleteAll(any()) } just Runs
-            slot<List<RecruitmentItem>>().also { slot ->
-                every { recruitmentItemRepository.saveAll(capture(slot)) } answers {
-                    slot.captured.run {
-                        map {
-                            RecruitmentItem(
-                                it.recruitmentId,
-                                it.title,
-                                it.position,
-                                it.maximumLength,
-                                it.description,
-                                it.id
-                            )
-                        }
-                    }
-                }
+    describe("RecruitmentService") {
+        context("지원 항목 없이 새 지원을 생성하면") {
+            it("지원만 저장한다") {
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns emptyList()
+
+                recruitmentService.save(createRecruitmentData())
+
+                verify { recruitmentRepository.save(any<Recruitment>()) }
+                verify { recruitmentItemRepository.deleteAll(mutableListOf()) }
+                verify { recruitmentItemRepository.saveAll(mutableListOf()) }
             }
         }
 
-        @Test
-        fun `지원 항목 없이 새 지원을 생성하면 지원만 저장한다`() {
-            every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns emptyList()
+        context("지원 항목이 있는 경우") {
+            it("새 지원을 생성하면 지원 및 지원 항목을 저장한다") {
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns emptyList()
 
-            recruitmentService.save(createRecruitmentData())
+                recruitmentService.save(createRecruitmentData(recruitmentItems = listOf(createRecruitmentItemData())))
 
-            verify { recruitmentRepository.save(any<Recruitment>()) }
-            verify { recruitmentItemRepository.deleteAll(mutableListOf()) }
-            verify { recruitmentItemRepository.saveAll(mutableListOf()) }
+                verify { recruitmentRepository.save(any<Recruitment>()) }
+                verify { recruitmentItemRepository.deleteAll(mutableListOf()) }
+                verify { recruitmentItemRepository.saveAll(any<List<RecruitmentItem>>()) }
+            }
         }
 
-        @Test
-        fun `지원 항목이 있는 경우 새 지원을 생성하면 지원 및 지원 항목을 저장한다`() {
-            every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns emptyList()
+        context("지원 항목이 없는 지원을 수정하면") {
+            it("지원만 수정한다") {
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns emptyList()
 
-            recruitmentService.save(createRecruitmentData(recruitmentItems = listOf(createRecruitmentItemData())))
+                recruitmentService.save(createRecruitmentData(id = 1L))
 
-            verify { recruitmentRepository.save(any<Recruitment>()) }
-            verify { recruitmentItemRepository.deleteAll(mutableListOf()) }
-            verify { recruitmentItemRepository.saveAll(any<List<RecruitmentItem>>()) }
+                verify { recruitmentRepository.save(createRecruitment(id = 1L)) }
+                verify { recruitmentItemRepository.deleteAll(mutableListOf()) }
+                verify { recruitmentItemRepository.saveAll(mutableListOf()) }
+            }
         }
 
-        @Test
-        fun `지원 항목이 없는 지원을 수정하면 지원만 수정한다`() {
-            every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(any()) } returns emptyList()
-
-            recruitmentService.save(createRecruitmentData(id = 1L))
-
-            verify { recruitmentRepository.save(createRecruitment(id = 1L)) }
-            verify { recruitmentItemRepository.deleteAll(mutableListOf()) }
-            verify { recruitmentItemRepository.saveAll(mutableListOf()) }
-        }
-
-        @Test
-        fun `지원 항목이 있는 지원에 대한 일부 지원 항목을 삭제하면 나머지 지원 항목만 수정한다`() {
-            every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(1L) } returns listOf(
-                createRecruitmentItem(id = 1L),
-                createRecruitmentItem(id = 2L)
-            )
-
-            recruitmentService.save(
-                createRecruitmentData(
-                    id = 1L,
-                    recruitmentItems = listOf(createRecruitmentItemData(id = 2L))
+        context("지원 항목이 있는 지원에 대한 일부 지원 항목을 삭제하면") {
+            it("나머지 지원 항목만 수정한다") {
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(1L) } returns listOf(
+                    createRecruitmentItem(id = 1L),
+                    createRecruitmentItem(id = 2L)
                 )
-            )
 
-            verify { recruitmentRepository.save(createRecruitment(id = 1L)) }
-            verify { recruitmentItemRepository.deleteAll(listOf(createRecruitmentItem(id = 1L))) }
-            verify { recruitmentItemRepository.saveAll(listOf(createRecruitmentItem(id = 2L))) }
+                recruitmentService.save(
+                    createRecruitmentData(
+                        id = 1L,
+                        recruitmentItems = listOf(createRecruitmentItemData(id = 2L))
+                    )
+                )
+
+                verify { recruitmentRepository.save(createRecruitment(id = 1L)) }
+                verify { recruitmentItemRepository.deleteAll(listOf(createRecruitmentItem(id = 1L))) }
+                verify { recruitmentItemRepository.saveAll(listOf(createRecruitmentItem(id = 2L))) }
+            }
         }
 
-        @Test
-        fun `지원 항목이 있는 지원에 대한 모든 지원 항목을 삭제하면 모든 지원 항목을 삭제한다`() {
-            every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(1L) } returns listOf(
-                createRecruitmentItem(id = 1L)
-            )
+        context("지원 항목이 있는 지원에 대한 모든 지원 항목을 삭제하면") {
+            it("모든 지원 항목을 삭제한다") {
+                every { recruitmentItemRepository.findByRecruitmentIdOrderByPosition(1L) } returns listOf(
+                    createRecruitmentItem(id = 1L)
+                )
 
-            recruitmentService.save(createRecruitmentData(id = 1L))
+                recruitmentService.save(createRecruitmentData(id = 1L))
 
-            verify { recruitmentRepository.save(createRecruitment(id = 1L)) }
-            verify { recruitmentItemRepository.deleteAll(listOf(createRecruitmentItem(id = 1L))) }
-            verify { recruitmentItemRepository.saveAll(mutableListOf()) }
+                verify { recruitmentRepository.save(createRecruitment(id = 1L)) }
+                verify { recruitmentItemRepository.deleteAll(listOf(createRecruitmentItem(id = 1L))) }
+                verify { recruitmentItemRepository.saveAll(mutableListOf()) }
+            }
+        }
+
+        context("모집 중인 모집은") {
+            it("삭제할 수 없다") {
+                val recruitment = createRecruitment(recruitable = true)
+                every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
+                shouldThrowExactly<IllegalStateException> { recruitmentService.deleteById(recruitment.id) }
+            }
         }
     }
-
-    @Test
-    fun `모집 중인 모집은 삭제할 수 없다`() {
-        val recruitment = createRecruitment(recruitable = true)
-        every { recruitmentRepository.findByIdOrNull(any()) } returns recruitment
-        assertThrows<IllegalStateException> { recruitmentService.deleteById(recruitment.id) }
-    }
-}
+})

--- a/src/test/kotlin/apply/application/RecruitmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/RecruitmentServiceTest.kt
@@ -11,12 +11,7 @@ import apply.domain.recruitmentitem.RecruitmentItemRepository
 import apply.domain.term.TermRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
-import io.mockk.Runs
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+import io.mockk.*
 import org.springframework.data.repository.findByIdOrNull
 import support.test.UnitTest
 

--- a/src/test/kotlin/apply/application/TermServiceTest.kt
+++ b/src/test/kotlin/apply/application/TermServiceTest.kt
@@ -3,88 +3,158 @@ package apply.application
 import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.term.Term
 import apply.domain.term.TermRepository
+import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.Runs
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import support.test.UnitTest
 
 @UnitTest
-internal class TermServiceTest {
-    @MockK
-    lateinit var termRepository: TermRepository
+internal class TermServiceTest : DescribeSpec({
+    var termRepository: TermRepository = mockk()
+    var recruitmentRepository: RecruitmentRepository = mockk()
+    lateinit var termService: TermService
 
-    @MockK
-    lateinit var recruitmentRepository: RecruitmentRepository
-
-    private lateinit var termService: TermService
-
-    @BeforeEach
-    internal fun setUp() {
+    beforeEach {
         termService = TermService(termRepository, recruitmentRepository)
     }
 
-    @Test
-    fun `기수를 생성한다`() {
-        every { termRepository.save(any()) } returns Term("3기")
-        every { termRepository.existsByName(any()) } returns false
-        assertDoesNotThrow { termService.save(TermData("3기")) }
-    }
+    describe("TermService") {
+        it("기수를 생성한다") {
+            every { termRepository.save(any()) } returns Term("3기")
+            every { termRepository.existsByName(any()) } returns false
+            assertDoesNotThrow { termService.save(TermData("3기")) }
+        }
 
-    @Test
-    fun `기본 기수명으로 기수를 생성할 수 없다`() {
-        val request = TermData(Term.SINGLE.name)
-        assertThrows<IllegalStateException> { termService.save(request) }
-    }
+        context("기본 기수명으로") {
+            it("기수를 생성할 수 없다") {
+                val request = TermData(Term.SINGLE.name)
+                assertThrows<IllegalStateException> { termService.save(request) }
+            }
+        }
 
-    @Test
-    fun `중복된 기수명으로 기수를 생성할 수 없다`() {
-        every { termRepository.existsByName(any()) } returns true
-        assertThrows<IllegalStateException> { termService.save(TermData("3기")) }
-    }
+        context("중복된 기수명으로") {
+            it("기수를 생성할 수 없다") {
+                every { termRepository.existsByName(any()) } returns true
+                assertThrows<IllegalStateException> { termService.save(TermData("3기")) }
+            }
+        }
 
-    @Test
-    fun `기수를 조회한다`() {
-        val terms = listOf(Term("3기"), Term("4기"))
-        every { termRepository.findAll() } returns terms
-        val responses = termService.findAll()
-        assertThat(responses).containsExactlyInAnyOrder(
-            TermResponse(Term.SINGLE),
-            TermResponse(terms[0]),
-            TermResponse(terms[1])
-        )
-    }
+        it("기수를 조회한다") {
+            val terms = listOf(Term("3기"), Term("4기"))
+            every { termRepository.findAll() } returns terms
+            val responses = termService.findAll()
+            assertThat(responses).containsExactlyInAnyOrder(
+                TermResponse(Term.SINGLE),
+                TermResponse(terms[0]),
+                TermResponse(terms[1])
+            )
+        }
 
-    @Test
-    fun `기수 조회시 단독 모집을 포함한다`() {
-        every { termRepository.findAll() } returns emptyList()
-        val responses = termService.findAll()
-        assertThat(responses).contains(TermResponse(Term.SINGLE))
-    }
+        context("기수 조회시") {
+            it("단독 모집을 포함한다") {
+                every { termRepository.findAll() } returns emptyList()
+                val responses = termService.findAll()
+                assertThat(responses).contains(TermResponse(Term.SINGLE))
+            }
+        }
 
-    @Test
-    fun `기수를 삭제한다`() {
-        every { recruitmentRepository.existsByTermId(any()) } returns false
-        every { termRepository.existsById(any()) } returns true
-        every { termRepository.deleteById(any()) } just Runs
-        assertDoesNotThrow { termService.deleteById(1L) }
-    }
+        it("기수를 삭제한다") {
+            every { recruitmentRepository.existsByTermId(any()) } returns false
+            every { termRepository.existsById(any()) } returns true
+            every { termRepository.deleteById(any()) } just Runs
+            assertDoesNotThrow { termService.deleteById(1L) }
+        }
 
-    @Test
-    fun `모집이 존재하는 기수는 삭제할 수 없다`() {
-        every { recruitmentRepository.existsByTermId(any()) } returns true
-        assertThrows<IllegalStateException> { termService.deleteById(1L) }
-    }
+        context("모집이 존재하는 기수는") {
+            it("삭제할 수 없다") {
+                every { recruitmentRepository.existsByTermId(any()) } returns true
+                assertThrows<IllegalStateException> { termService.deleteById(1L) }
+            }
+        }
 
-    @Test
-    fun `존재하지 않는 기수를 삭제하면 예외가 발생한다`() {
-        every { recruitmentRepository.existsByTermId(any()) } returns false
-        every { termRepository.existsById(any()) } returns false
-        assertThrows<IllegalArgumentException> { termService.deleteById(1L) }
+        context("존재하지 않는 기수를 삭제하면") {
+            it("예외가 발생한다") {
+                every { recruitmentRepository.existsByTermId(any()) } returns false
+                every { termRepository.existsById(any()) } returns false
+                assertThrows<IllegalArgumentException> { termService.deleteById(1L) }
+            }
+        }
     }
+}) {
+    // @MockK
+    // lateinit var termRepository: TermRepository
+    //
+    // @MockK
+    // lateinit var recruitmentRepository: RecruitmentRepository
+    //
+    // private lateinit var termService: TermService
+    //
+    // @BeforeEach
+    // internal fun setUp() {
+    //     termService = TermService(termRepository, recruitmentRepository)
+    // }
+
+    // @Test
+    // fun `기수를 생성한다`() {
+    //     every { termRepository.save(any()) } returns Term("3기")
+    //     every { termRepository.existsByName(any()) } returns false
+    //     assertDoesNotThrow { termService.save(TermData("3기")) }
+    // }
+    //
+    // @Test
+    // fun `기본 기수명으로 기수를 생성할 수 없다`() {
+    //     val request = TermData(Term.SINGLE.name)
+    //     assertThrows<IllegalStateException> { termService.save(request) }
+    // }
+    //
+    // @Test
+    // fun `중복된 기수명으로 기수를 생성할 수 없다`() {
+    //     every { termRepository.existsByName(any()) } returns true
+    //     assertThrows<IllegalStateException> { termService.save(TermData("3기")) }
+    // }
+    //
+    // @Test
+    // fun `기수를 조회한다`() {
+    //     val terms = listOf(Term("3기"), Term("4기"))
+    //     every { termRepository.findAll() } returns terms
+    //     val responses = termService.findAll()
+    //     assertThat(responses).containsExactlyInAnyOrder(
+    //         TermResponse(Term.SINGLE),
+    //         TermResponse(terms[0]),
+    //         TermResponse(terms[1])
+    //     )
+    // }
+    //
+    // @Test
+    // fun `기수 조회시 단독 모집을 포함한다`() {
+    //     every { termRepository.findAll() } returns emptyList()
+    //     val responses = termService.findAll()
+    //     assertThat(responses).contains(TermResponse(Term.SINGLE))
+    // }
+    //
+    // @Test
+    // fun `기수를 삭제한다`() {
+    //     every { recruitmentRepository.existsByTermId(any()) } returns false
+    //     every { termRepository.existsById(any()) } returns true
+    //     every { termRepository.deleteById(any()) } just Runs
+    //     assertDoesNotThrow { termService.deleteById(1L) }
+    // }
+    //
+    // @Test
+    // fun `모집이 존재하는 기수는 삭제할 수 없다`() {
+    //     every { recruitmentRepository.existsByTermId(any()) } returns true
+    //     assertThrows<IllegalStateException> { termService.deleteById(1L) }
+    // }
+    //
+    // @Test
+    // fun `존재하지 않는 기수를 삭제하면 예외가 발생한다`() {
+    //     every { recruitmentRepository.existsByTermId(any()) } returns false
+    //     every { termRepository.existsById(any()) } returns false
+    //     assertThrows<IllegalArgumentException> { termService.deleteById(1L) }
+    // }
 }

--- a/src/test/kotlin/apply/application/TermServiceTest.kt
+++ b/src/test/kotlin/apply/application/TermServiceTest.kt
@@ -4,7 +4,7 @@ import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.term.Term
 import apply.domain.term.TermRepository
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
@@ -34,14 +34,14 @@ internal class TermServiceTest : DescribeSpec({
         context("기본 기수명으로") {
             it("기수를 생성할 수 없다") {
                 val request = TermData(Term.SINGLE.name)
-                shouldThrowExactly<IllegalStateException> { termService.save(request) }
+                shouldThrow<IllegalStateException> { termService.save(request) }
             }
         }
 
         context("중복된 기수명으로") {
             it("기수를 생성할 수 없다") {
                 every { termRepository.existsByName(any()) } returns true
-                shouldThrowExactly<IllegalStateException> { termService.save(TermData("3기")) }
+                shouldThrow<IllegalStateException> { termService.save(TermData("3기")) }
             }
         }
 
@@ -74,7 +74,7 @@ internal class TermServiceTest : DescribeSpec({
         context("모집이 존재하는 기수는") {
             it("삭제할 수 없다") {
                 every { recruitmentRepository.existsByTermId(any()) } returns true
-                shouldThrowExactly<IllegalStateException> { termService.deleteById(1L) }
+                shouldThrow<IllegalStateException> { termService.deleteById(1L) }
             }
         }
 
@@ -82,7 +82,7 @@ internal class TermServiceTest : DescribeSpec({
             it("예외가 발생한다") {
                 every { recruitmentRepository.existsByTermId(any()) } returns false
                 every { termRepository.existsById(any()) } returns false
-                shouldThrowExactly<IllegalArgumentException> { termService.deleteById(1L) }
+                shouldThrow<IllegalArgumentException> { termService.deleteById(1L) }
             }
         }
     }

--- a/src/test/kotlin/apply/application/TermServiceTest.kt
+++ b/src/test/kotlin/apply/application/TermServiceTest.kt
@@ -3,14 +3,15 @@ package apply.application
 import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.term.Term
 import apply.domain.term.TermRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import support.test.UnitTest
 
 @UnitTest
@@ -27,20 +28,20 @@ internal class TermServiceTest : DescribeSpec({
         it("기수를 생성한다") {
             every { termRepository.save(any()) } returns Term("3기")
             every { termRepository.existsByName(any()) } returns false
-            assertDoesNotThrow { termService.save(TermData("3기")) }
+            shouldNotThrowAny { termService.save(TermData("3기")) }
         }
 
         context("기본 기수명으로") {
             it("기수를 생성할 수 없다") {
                 val request = TermData(Term.SINGLE.name)
-                assertThrows<IllegalStateException> { termService.save(request) }
+                shouldThrowExactly<IllegalStateException> { termService.save(request) }
             }
         }
 
         context("중복된 기수명으로") {
             it("기수를 생성할 수 없다") {
                 every { termRepository.existsByName(any()) } returns true
-                assertThrows<IllegalStateException> { termService.save(TermData("3기")) }
+                shouldThrowExactly<IllegalStateException> { termService.save(TermData("3기")) }
             }
         }
 
@@ -48,7 +49,7 @@ internal class TermServiceTest : DescribeSpec({
             val terms = listOf(Term("3기"), Term("4기"))
             every { termRepository.findAll() } returns terms
             val responses = termService.findAll()
-            assertThat(responses).containsExactlyInAnyOrder(
+            responses shouldContainExactly listOf(
                 TermResponse(Term.SINGLE),
                 TermResponse(terms[0]),
                 TermResponse(terms[1])
@@ -59,7 +60,7 @@ internal class TermServiceTest : DescribeSpec({
             it("단독 모집을 포함한다") {
                 every { termRepository.findAll() } returns emptyList()
                 val responses = termService.findAll()
-                assertThat(responses).contains(TermResponse(Term.SINGLE))
+                responses shouldContain TermResponse(Term.SINGLE)
             }
         }
 
@@ -67,13 +68,13 @@ internal class TermServiceTest : DescribeSpec({
             every { recruitmentRepository.existsByTermId(any()) } returns false
             every { termRepository.existsById(any()) } returns true
             every { termRepository.deleteById(any()) } just Runs
-            assertDoesNotThrow { termService.deleteById(1L) }
+            shouldNotThrowAny { termService.deleteById(1L) }
         }
 
         context("모집이 존재하는 기수는") {
             it("삭제할 수 없다") {
                 every { recruitmentRepository.existsByTermId(any()) } returns true
-                assertThrows<IllegalStateException> { termService.deleteById(1L) }
+                shouldThrowExactly<IllegalStateException> { termService.deleteById(1L) }
             }
         }
 
@@ -81,80 +82,8 @@ internal class TermServiceTest : DescribeSpec({
             it("예외가 발생한다") {
                 every { recruitmentRepository.existsByTermId(any()) } returns false
                 every { termRepository.existsById(any()) } returns false
-                assertThrows<IllegalArgumentException> { termService.deleteById(1L) }
+                shouldThrowExactly<IllegalArgumentException> { termService.deleteById(1L) }
             }
         }
     }
-}) {
-    // @MockK
-    // lateinit var termRepository: TermRepository
-    //
-    // @MockK
-    // lateinit var recruitmentRepository: RecruitmentRepository
-    //
-    // private lateinit var termService: TermService
-    //
-    // @BeforeEach
-    // internal fun setUp() {
-    //     termService = TermService(termRepository, recruitmentRepository)
-    // }
-
-    // @Test
-    // fun `기수를 생성한다`() {
-    //     every { termRepository.save(any()) } returns Term("3기")
-    //     every { termRepository.existsByName(any()) } returns false
-    //     assertDoesNotThrow { termService.save(TermData("3기")) }
-    // }
-    //
-    // @Test
-    // fun `기본 기수명으로 기수를 생성할 수 없다`() {
-    //     val request = TermData(Term.SINGLE.name)
-    //     assertThrows<IllegalStateException> { termService.save(request) }
-    // }
-    //
-    // @Test
-    // fun `중복된 기수명으로 기수를 생성할 수 없다`() {
-    //     every { termRepository.existsByName(any()) } returns true
-    //     assertThrows<IllegalStateException> { termService.save(TermData("3기")) }
-    // }
-    //
-    // @Test
-    // fun `기수를 조회한다`() {
-    //     val terms = listOf(Term("3기"), Term("4기"))
-    //     every { termRepository.findAll() } returns terms
-    //     val responses = termService.findAll()
-    //     assertThat(responses).containsExactlyInAnyOrder(
-    //         TermResponse(Term.SINGLE),
-    //         TermResponse(terms[0]),
-    //         TermResponse(terms[1])
-    //     )
-    // }
-    //
-    // @Test
-    // fun `기수 조회시 단독 모집을 포함한다`() {
-    //     every { termRepository.findAll() } returns emptyList()
-    //     val responses = termService.findAll()
-    //     assertThat(responses).contains(TermResponse(Term.SINGLE))
-    // }
-    //
-    // @Test
-    // fun `기수를 삭제한다`() {
-    //     every { recruitmentRepository.existsByTermId(any()) } returns false
-    //     every { termRepository.existsById(any()) } returns true
-    //     every { termRepository.deleteById(any()) } just Runs
-    //     assertDoesNotThrow { termService.deleteById(1L) }
-    // }
-    //
-    // @Test
-    // fun `모집이 존재하는 기수는 삭제할 수 없다`() {
-    //     every { recruitmentRepository.existsByTermId(any()) } returns true
-    //     assertThrows<IllegalStateException> { termService.deleteById(1L) }
-    // }
-    //
-    // @Test
-    // fun `존재하지 않는 기수를 삭제하면 예외가 발생한다`() {
-    //     every { recruitmentRepository.existsByTermId(any()) } returns false
-    //     every { termRepository.existsById(any()) } returns false
-    //     assertThrows<IllegalArgumentException> { termService.deleteById(1L) }
-    // }
-}
+})

--- a/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
@@ -22,7 +22,6 @@ import apply.domain.user.findByEmail
 import apply.security.JwtTokenProvider
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -125,7 +124,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
             it("인증 코드가 일치한다면 인증된 회원으로 변경한다") {
                 every { authenticationCodeRepository.getLastByEmail(any()) } returns authenticationCode
                 userAuthenticationService.authenticateEmail(authenticationCode.email, authenticationCode.code)
-                authenticationCode.authenticated.shouldBeTrue()
+                authenticationCode.authenticated shouldBe true
             }
 
             it("인증 코드가 일치하지 않는다면 예외가 발생한다") {

--- a/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
@@ -20,164 +20,134 @@ import apply.domain.user.UserRepository
 import apply.domain.user.existsByEmail
 import apply.domain.user.findByEmail
 import apply.security.JwtTokenProvider
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import io.mockk.mockk
 import support.test.UnitTest
 
 @UnitTest
-internal class UserAuthenticationServiceTest {
-    @MockK
-    private lateinit var userRepository: UserRepository
+internal class UserAuthenticationServiceTest : DescribeSpec({
+    val userRepository: UserRepository = mockk()
+    val authenticationCodeRepository: AuthenticationCodeRepository = mockk()
+    val jwtTokenProvider: JwtTokenProvider = mockk()
+    val userAuthenticationService = UserAuthenticationService(
+        userRepository, authenticationCodeRepository, jwtTokenProvider
+    )
 
-    @MockK
-    private lateinit var authenticationCodeRepository: AuthenticationCodeRepository
+    every { jwtTokenProvider.createToken(any()) } returns VALID_TOKEN
 
-    @MockK
-    private lateinit var jwtTokenProvider: JwtTokenProvider
+    describe("UserAuthenticationService") {
+        context("(회원 가입) 토큰 생성은") {
+            var request: RegisterUserRequest = mockk()
+            fun subject(): String {
+                return userAuthenticationService.generateTokenByRegister(request)
+            }
 
-    private lateinit var userAuthenticationService: UserAuthenticationService
+            it("가입된 이메일이라면 예외가 발생한다") {
+                every { userRepository.existsByEmail(any()) } returns true
+                request = RegisterUserRequest(
+                    NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
+                )
+                shouldThrowExactly<IllegalStateException> { subject() }
+            }
 
-    @BeforeEach
-    internal fun setUp() {
-        every { jwtTokenProvider.createToken(any()) } returns VALID_TOKEN
-        userAuthenticationService = UserAuthenticationService(
-            userRepository, authenticationCodeRepository, jwtTokenProvider
-        )
-    }
+            it("인증된 인증 코드와 일치하지 않는다면 예외가 발생한다") {
+                every { userRepository.existsByEmail(any()) } returns false
+                every { authenticationCodeRepository.getLastByEmail(any()) } returns
+                    createAuthenticationCode(EMAIL, INVALID_CODE)
+                request = RegisterUserRequest(
+                    NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
+                )
+                shouldThrowExactly<IllegalStateException> { subject() }
+            }
 
-    @DisplayName("(회원 가입) 토큰 생성은")
-    @Nested
-    inner class GenerateTokenByRegister {
-        private lateinit var request: RegisterUserRequest
+            it("인증된 이메일이 아니라면 예외가 발생한다") {
+                every { userRepository.existsByEmail(any()) } returns false
+                every { authenticationCodeRepository.getLastByEmail(any()) } returns
+                    createAuthenticationCode(EMAIL, INVALID_CODE)
+                request = RegisterUserRequest(
+                    NAME, "not@email.com", PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
+                )
+                shouldThrowExactly<IllegalStateException> { subject() }
+            }
 
-        fun subject(): String {
-            return userAuthenticationService.generateTokenByRegister(request)
-        }
+            it("가입되지 않고 인증된 이메일이라면 회원을 저장하고 토큰을 반환한다") {
+                every { userRepository.existsByEmail(any()) } returns false
+                every { authenticationCodeRepository.getLastByEmail(any()) } returns
+                    createAuthenticationCode(EMAIL, VALID_CODE, true)
 
-        @Test
-        fun `가입된 이메일이라면 예외가 발생한다`() {
-            every { userRepository.existsByEmail(any()) } returns true
-            request = RegisterUserRequest(
-                NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
-            )
-            assertThrows<IllegalStateException> { subject() }
-        }
+                every { userRepository.save(any()) } returns createUser()
+                request = RegisterUserRequest(
+                    NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
+                )
+                subject() shouldBe VALID_TOKEN
+            }
 
-        @Test
-        fun `인증된 인증 코드와 일치하지 않는다면 예외가 발생한다`() {
-            every { userRepository.existsByEmail(any()) } returns false
-            every { authenticationCodeRepository.getLastByEmail(any()) } returns
-                createAuthenticationCode(EMAIL, INVALID_CODE)
-            request = RegisterUserRequest(
-                NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
-            )
-            assertThrows<IllegalStateException> { subject() }
-        }
-
-        @Test
-        fun `인증된 이메일이 아니라면 예외가 발생한다`() {
-            every { userRepository.existsByEmail(any()) } returns false
-            every { authenticationCodeRepository.getLastByEmail(any()) } returns
-                createAuthenticationCode(EMAIL, INVALID_CODE)
-            request = RegisterUserRequest(
-                NAME, "not@email.com", PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
-            )
-            assertThrows<IllegalStateException> { subject() }
-        }
-
-        @Test
-        fun `가입되지 않고 인증된 이메일이라면 회원을 저장하고 토큰을 반환한다`() {
-            every { userRepository.existsByEmail(any()) } returns false
-            every { authenticationCodeRepository.getLastByEmail(any()) } returns
-                createAuthenticationCode(EMAIL, VALID_CODE, true)
-
-            every { userRepository.save(any()) } returns createUser()
-            request = RegisterUserRequest(
-                NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
-            )
-            assertThat(subject()).isEqualTo(VALID_TOKEN)
-        }
-
-        @Test
-        fun `확인용 비밀번호가 일치하지 않으면 예외가 발생한다`() {
-            request = RegisterUserRequest(
-                NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, WRONG_PASSWORD, VALID_CODE
-            )
-            assertThrows<IllegalArgumentException> { subject() }
-        }
-    }
-
-    @DisplayName("(로그인) 토큰 생성은")
-    @Nested
-    inner class GenerateTokenByLogin {
-        private lateinit var request: AuthenticateUserRequest
-
-        fun subject(): String {
-            return userAuthenticationService.generateTokenByLogin(request)
-        }
-
-        @Test
-        fun `회원이 존재하고 인증에 성공하면 유효한 토큰을 반환한다`() {
-            every { userRepository.findByEmail(any()) } returns createUser()
-            request = AuthenticateUserRequest(EMAIL, PASSWORD)
-            assertThat(subject()).isEqualTo(VALID_TOKEN)
-        }
-
-        @Test
-        fun `회원이 존재하지만 인증에 실패하면 예외가 발생한다`() {
-            every { userRepository.findByEmail(any()) } returns createUser()
-            request = AuthenticateUserRequest(EMAIL, WRONG_PASSWORD)
-            assertThrows<UnidentifiedUserException> { subject() }
-        }
-
-        @Test
-        fun `회원이 존재하지 않다면 예외가 발생한다`() {
-            every { userRepository.findByEmail(any()) } returns null
-            request = AuthenticateUserRequest(EMAIL, PASSWORD)
-            assertThrows<UnidentifiedUserException> { subject() }
-        }
-    }
-
-    @DisplayName("이메일 사용자 인증 시")
-    @Nested
-    inner class AuthenticateEmail {
-        private val authenticationCode = createAuthenticationCode()
-
-        @Test
-        fun `인증 코드가 일치한다면 인증된 회원으로 변경한다`() {
-            every { authenticationCodeRepository.getLastByEmail(any()) } returns authenticationCode
-            userAuthenticationService.authenticateEmail(authenticationCode.email, authenticationCode.code)
-            assertThat(authenticationCode.authenticated).isTrue()
-        }
-
-        @Test
-        fun `인증 코드가 일치하지 않는다면 예외가 발생한다`() {
-            every { authenticationCodeRepository.getLastByEmail(any()) } returns authenticationCode
-            assertThrows<IllegalArgumentException> {
-                userAuthenticationService.authenticateEmail(authenticationCode.email, INVALID_CODE)
+            it("확인용 비밀번호가 일치하지 않으면 예외가 발생한다") {
+                request = RegisterUserRequest(
+                    NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, WRONG_PASSWORD, VALID_CODE
+                )
+                shouldThrowExactly<IllegalArgumentException> { subject() }
             }
         }
 
-        @Test
-        fun `인증 코드를 생성한다`() {
-            every { userRepository.existsByEmail(any()) } returns false
-            every { authenticationCodeRepository.save(any()) } returns authenticationCode
-            val actual = userAuthenticationService.generateAuthenticationCode(authenticationCode.email)
-            assertThat(actual).isEqualTo(authenticationCode.code)
+        context("(로그인) 토큰 생성은") {
+            var request: AuthenticateUserRequest = mockk()
+            fun subject(): String {
+                return userAuthenticationService.generateTokenByLogin(request)
+            }
+
+            it("회원이 존재하고 인증에 성공하면 유효한 토큰을 반환한다") {
+                every { userRepository.findByEmail(any()) } returns createUser()
+                request = AuthenticateUserRequest(EMAIL, PASSWORD)
+                subject() shouldBe VALID_TOKEN
+            }
+
+            it("회원이 존재하지만 인증에 실패하면 예외가 발생한다") {
+                every { userRepository.findByEmail(any()) } returns createUser()
+                request = AuthenticateUserRequest(EMAIL, WRONG_PASSWORD)
+                shouldThrowExactly<UnidentifiedUserException> { subject() }
+            }
+
+            it("회원이 존재하지 않다면 예외가 발생한다") {
+                every { userRepository.findByEmail(any()) } returns null
+                request = AuthenticateUserRequest(EMAIL, PASSWORD)
+                shouldThrowExactly<UnidentifiedUserException> { subject() }
+            }
         }
 
-        @Test
-        fun `인증 코드 요청시 이미 가입된 이메일이라면 예외가 발생한다`() {
-            every { userRepository.existsByEmail(any()) } returns true
-            assertThrows<IllegalStateException> {
-                userAuthenticationService.generateAuthenticationCode(authenticationCode.email)
+        context("이메일 사용자 인증 시") {
+            var authenticationCode = createAuthenticationCode()
+
+            it("인증 코드가 일치한다면 인증된 회원으로 변경한다") {
+                every { authenticationCodeRepository.getLastByEmail(any()) } returns authenticationCode
+                userAuthenticationService.authenticateEmail(authenticationCode.email, authenticationCode.code)
+                authenticationCode.authenticated.shouldBeTrue()
+            }
+
+            it("인증 코드가 일치하지 않는다면 예외가 발생한다") {
+                every { authenticationCodeRepository.getLastByEmail(any()) } returns authenticationCode
+                shouldThrowExactly<IllegalArgumentException> {
+                    userAuthenticationService.authenticateEmail(authenticationCode.email, INVALID_CODE)
+                }
+            }
+
+            it("인증 코드를 생성한다") {
+                every { userRepository.existsByEmail(any()) } returns false
+                every { authenticationCodeRepository.save(any()) } returns authenticationCode
+                val actual = userAuthenticationService.generateAuthenticationCode(authenticationCode.email)
+                authenticationCode.code shouldBe actual
+            }
+
+            it("인증 코드 요청시 이미 가입된 이메일이라면 예외가 발생한다") {
+                every { userRepository.existsByEmail(any()) } returns true
+                shouldThrowExactly<IllegalStateException> {
+                    userAuthenticationService.generateAuthenticationCode(authenticationCode.email)
+                }
             }
         }
     }
-}
+})

--- a/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserAuthenticationServiceTest.kt
@@ -20,7 +20,7 @@ import apply.domain.user.UserRepository
 import apply.domain.user.existsByEmail
 import apply.domain.user.findByEmail
 import apply.security.JwtTokenProvider
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -50,7 +50,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
                 request = RegisterUserRequest(
                     NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
                 )
-                shouldThrowExactly<IllegalStateException> { subject() }
+                shouldThrow<IllegalStateException> { subject() }
             }
 
             it("인증된 인증 코드와 일치하지 않는다면 예외가 발생한다") {
@@ -60,7 +60,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
                 request = RegisterUserRequest(
                     NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
                 )
-                shouldThrowExactly<IllegalStateException> { subject() }
+                shouldThrow<IllegalStateException> { subject() }
             }
 
             it("인증된 이메일이 아니라면 예외가 발생한다") {
@@ -70,7 +70,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
                 request = RegisterUserRequest(
                     NAME, "not@email.com", PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, CONFIRM_PASSWORD, VALID_CODE
                 )
-                shouldThrowExactly<IllegalStateException> { subject() }
+                shouldThrow<IllegalStateException> { subject() }
             }
 
             it("가입되지 않고 인증된 이메일이라면 회원을 저장하고 토큰을 반환한다") {
@@ -89,7 +89,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
                 request = RegisterUserRequest(
                     NAME, EMAIL, PHONE_NUMBER, GENDER, BIRTHDAY, PASSWORD, WRONG_PASSWORD, VALID_CODE
                 )
-                shouldThrowExactly<IllegalArgumentException> { subject() }
+                shouldThrow<IllegalArgumentException> { subject() }
             }
         }
 
@@ -108,13 +108,13 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
             it("회원이 존재하지만 인증에 실패하면 예외가 발생한다") {
                 every { userRepository.findByEmail(any()) } returns createUser()
                 request = AuthenticateUserRequest(EMAIL, WRONG_PASSWORD)
-                shouldThrowExactly<UnidentifiedUserException> { subject() }
+                shouldThrow<UnidentifiedUserException> { subject() }
             }
 
             it("회원이 존재하지 않다면 예외가 발생한다") {
                 every { userRepository.findByEmail(any()) } returns null
                 request = AuthenticateUserRequest(EMAIL, PASSWORD)
-                shouldThrowExactly<UnidentifiedUserException> { subject() }
+                shouldThrow<UnidentifiedUserException> { subject() }
             }
         }
 
@@ -129,7 +129,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
 
             it("인증 코드가 일치하지 않는다면 예외가 발생한다") {
                 every { authenticationCodeRepository.getLastByEmail(any()) } returns authenticationCode
-                shouldThrowExactly<IllegalArgumentException> {
+                shouldThrow<IllegalArgumentException> {
                     userAuthenticationService.authenticateEmail(authenticationCode.email, INVALID_CODE)
                 }
             }
@@ -143,7 +143,7 @@ internal class UserAuthenticationServiceTest : DescribeSpec({
 
             it("인증 코드 요청시 이미 가입된 이메일이라면 예외가 발생한다") {
                 every { userRepository.existsByEmail(any()) } returns true
-                shouldThrowExactly<IllegalStateException> {
+                shouldThrow<IllegalStateException> {
                     userAuthenticationService.generateAuthenticationCode(authenticationCode.email)
                 }
             }

--- a/src/test/kotlin/apply/application/UserServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserServiceTest.kt
@@ -13,124 +13,98 @@ import apply.domain.user.User
 import apply.domain.user.UserRepository
 import apply.domain.user.findByEmail
 import apply.domain.user.getById
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.slot
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import support.test.UnitTest
 
 @UnitTest
-internal class UserServiceTest {
-    @MockK
-    private lateinit var userRepository: UserRepository
+internal class UserServiceTest : DescribeSpec({
+    val userRepository: UserRepository = mockk()
+    val passwordGenerator: PasswordGenerator = mockk()
+    val userService = UserService(userRepository, passwordGenerator)
 
-    @MockK
-    private lateinit var passwordGenerator: PasswordGenerator
+    describe("UserService") {
+        var user: User = createUser()
+        var request: ResetPasswordRequest = mockk()
 
-    private lateinit var userService: UserService
-
-    @BeforeEach
-    internal fun setUp() {
-        userService = UserService(userRepository, passwordGenerator)
-    }
-
-    @DisplayName("비밀번호 초기화는")
-    @Nested
-    inner class ResetPassword {
-        private lateinit var user: User
-        private lateinit var request: ResetPasswordRequest
-
-        @BeforeEach
-        internal fun setUp() {
-            user = createUser()
-            every { userRepository.findByEmail(EMAIL) } returns user
-            every { passwordGenerator.generate() } returns RANDOM_PASSWORD_TEXT
-        }
+        every { userRepository.findByEmail(EMAIL) } returns user
+        every { passwordGenerator.generate() } returns RANDOM_PASSWORD_TEXT
 
         fun subject() {
             userService.resetPassword(request)
         }
 
-        @Test
-        fun `만약 개인정보가 일치한다면 초기화한다`() {
-            every { userRepository.save(any()) } returns user
-            request = ResetPasswordRequest(NAME, EMAIL, BIRTHDAY)
-            subject()
-            assertThat(user.password).isEqualTo(Password(RANDOM_PASSWORD_TEXT))
-        }
+        context("개인정보를 비교할 때") {
+            it("일치한다면 초기화한다") {
+                every { userRepository.save(any()) } returns user
+                request = ResetPasswordRequest(NAME, EMAIL, BIRTHDAY)
+                subject()
+                user.password shouldBe Password(RANDOM_PASSWORD_TEXT)
+            }
 
-        @Test
-        fun `만약 개인정보가 일치하지 않는다면 예외가 발생한다`() {
-            request = ResetPasswordRequest("가짜 이름", EMAIL, BIRTHDAY)
-            assertThrows<UnidentifiedUserException> { subject() }
-        }
-    }
-
-    @DisplayName("비밀번호 변경은")
-    @Nested
-    inner class EditPassword {
-        private lateinit var request: EditPasswordRequest
-
-        @BeforeEach
-        internal fun setUp() {
-            slot<Long>().also { slot ->
-                every { userRepository.getById(capture(slot)) } answers { createUser(id = slot.captured) }
+            it("일치하지 않는다면 예외가 발생한다") {
+                request = ResetPasswordRequest("가짜 이름", EMAIL, BIRTHDAY)
+                shouldThrowExactly<UnidentifiedUserException> { subject() }
             }
         }
 
-        fun subject() {
-            userService.editPassword(1L, request)
+        context("비밀번호를 비교할 때") {
+            var request: EditPasswordRequest = mockk()
+            fun subject() {
+                userService.editPassword(1L, request)
+            }
+            slot<Long>().also { slot ->
+                every { userRepository.getById(capture(slot)) } answers { createUser(id = slot.captured) }
+            }
+
+            it("일치한다면 변경한다") {
+                request = EditPasswordRequest(PASSWORD, Password("new_password"), Password("new_password"))
+                shouldNotThrow<Exception> { subject() }
+            }
+
+            it("일치하지 않다면 예외가 발생한다") {
+                request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"), Password("new_password"))
+                shouldThrowExactly<UnidentifiedUserException> { subject() }
+            }
+
+            it("확인용 비밀번호가 일치하지 않으면 예외가 발생한다") {
+                request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"), Password("wrong_password"))
+                shouldThrowExactly<IllegalArgumentException> { subject() }
+            }
         }
 
-        @Test
-        fun `만약 기존 비밀번호가 일치한다면 변경한다`() {
-            request = EditPasswordRequest(PASSWORD, Password("new_password"), Password("new_password"))
-            assertDoesNotThrow { subject() }
-        }
+        context("회원정보를") {
+            it("조회한다") {
+                val user = createUser()
+                every { userRepository.getById(any()) } returns user
 
-        @Test
-        fun `만약 기존 비밀번호가 일치하지 않다면 예외가 발생한다`() {
-            request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"), Password("new_password"))
-            assertThrows<UnidentifiedUserException> { subject() }
-        }
+                val expected = userService.getInformation(user.id)
 
-        @Test
-        fun `확인용 비밀번호가 일치하지 않으면 예외가 발생한다`() {
-            request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"), Password("wrong_password"))
-            assertThrows<IllegalArgumentException> { subject() }
+                assertSoftly {
+                    expected.id.shouldNotBeNull()
+                    expected.name.shouldNotBeNull()
+                    expected.email.shouldNotBeNull()
+                    expected.phoneNumber.shouldNotBeNull()
+                    expected.gender.shouldNotBeNull()
+                    expected.birthday.shouldNotBeNull()
+                }
+            }
+
+            it("변경한다") {
+                val request = EditInformationRequest("010-9999-9999")
+                val user = createUser(phoneNumber = "010-0000-0000")
+                every { userRepository.getById(any()) } returns user
+
+                shouldNotThrow<Exception> { userService.editInformation(user.id, request) }
+                user.phoneNumber shouldBe request.phoneNumber
+            }
         }
     }
-
-    @Test
-    fun `회원이 정보를 조회한다`() {
-        val user = createUser()
-        every { userRepository.getById(any()) } returns user
-
-        val expected = userService.getInformation(user.id)
-
-        assertAll(
-            { assertThat(expected.id).isNotNull },
-            { assertThat(expected.name).isNotNull },
-            { assertThat(expected.email).isNotNull },
-            { assertThat(expected.phoneNumber).isNotNull },
-            { assertThat(expected.gender).isNotNull },
-            { assertThat(expected.birthday).isNotNull }
-        )
-    }
-
-    @Test
-    fun `회원이 정보(전화번호)를 변경한다`() {
-        val request = EditInformationRequest("010-9999-9999")
-        val user = createUser(phoneNumber = "010-0000-0000")
-        every { userRepository.getById(any()) } returns user
-        assertDoesNotThrow { userService.editInformation(user.id, request) }
-        assertThat(user.phoneNumber).isEqualTo(request.phoneNumber)
-    }
-}
+})

--- a/src/test/kotlin/apply/application/UserServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserServiceTest.kt
@@ -16,7 +16,7 @@ import apply.domain.user.getById
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -52,7 +52,7 @@ internal class UserServiceTest : DescribeSpec({
 
             it("일치하지 않는다면 예외가 발생한다") {
                 request = ResetPasswordRequest("가짜 이름", EMAIL, BIRTHDAY)
-                shouldThrowExactly<UnidentifiedUserException> { subject() }
+                shouldThrow<UnidentifiedUserException> { subject() }
             }
         }
 
@@ -72,12 +72,12 @@ internal class UserServiceTest : DescribeSpec({
 
             it("일치하지 않다면 예외가 발생한다") {
                 request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"), Password("new_password"))
-                shouldThrowExactly<UnidentifiedUserException> { subject() }
+                shouldThrow<UnidentifiedUserException> { subject() }
             }
 
             it("확인용 비밀번호가 일치하지 않으면 예외가 발생한다") {
                 request = EditPasswordRequest(WRONG_PASSWORD, Password("new_password"), Password("wrong_password"))
-                shouldThrowExactly<IllegalArgumentException> { subject() }
+                shouldThrow<IllegalArgumentException> { subject() }
             }
         }
 

--- a/src/test/kotlin/apply/application/UserServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserServiceTest.kt
@@ -15,6 +15,7 @@ import apply.domain.user.findByEmail
 import apply.domain.user.getById
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -66,7 +67,7 @@ internal class UserServiceTest : DescribeSpec({
 
             it("일치한다면 변경한다") {
                 request = EditPasswordRequest(PASSWORD, Password("new_password"), Password("new_password"))
-                shouldNotThrow<Exception> { subject() }
+                shouldNotThrowAny { subject() }
             }
 
             it("일치하지 않다면 예외가 발생한다") {
@@ -87,7 +88,7 @@ internal class UserServiceTest : DescribeSpec({
 
                 val expected = userService.getInformation(user.id)
 
-                assertSoftly {
+                assertSoftly(expected) {
                     expected.id.shouldNotBeNull()
                     expected.name.shouldNotBeNull()
                     expected.email.shouldNotBeNull()

--- a/src/test/kotlin/apply/application/UserServiceTest.kt
+++ b/src/test/kotlin/apply/application/UserServiceTest.kt
@@ -1,18 +1,7 @@
 package apply.application
 
-import apply.BIRTHDAY
-import apply.EMAIL
-import apply.NAME
-import apply.PASSWORD
-import apply.RANDOM_PASSWORD_TEXT
-import apply.WRONG_PASSWORD
-import apply.createUser
-import apply.domain.user.Password
-import apply.domain.user.UnidentifiedUserException
-import apply.domain.user.User
-import apply.domain.user.UserRepository
-import apply.domain.user.findByEmail
-import apply.domain.user.getById
+import apply.*
+import apply.domain.user.*
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny

--- a/src/test/kotlin/apply/domain/applicationform/ApplicationFormRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/applicationform/ApplicationFormRepositoryTest.kt
@@ -3,12 +3,9 @@ package apply.domain.applicationform
 import apply.createApplicationForm
 import apply.pass
 import io.kotest.assertions.assertSoftly
-import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.assertAll
 import support.test.RepositoryTest
 
 @RepositoryTest

--- a/src/test/kotlin/apply/domain/applicationform/ApplicationFormRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/applicationform/ApplicationFormRepositoryTest.kt
@@ -2,38 +2,39 @@ package apply.domain.applicationform
 
 import apply.createApplicationForm
 import apply.pass
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import support.test.RepositoryTest
 
 @RepositoryTest
-class ApplicationFormRepositoryTest(
+internal class ApplicationFormRepositoryTest(
     private val applicationFormRepository: ApplicationFormRepository
-) {
-    @BeforeEach
-    internal fun setUp() {
-        val applicationForm = createApplicationForm()
-        val submittedApplicationForm = createApplicationForm(recruitmentId = 2L).apply { submit(pass) }
+) : DescribeSpec({
+    describe("ApplicationFormRepositoryT") {
+        context("지원자가 지원서를 제출하면") {
+            val applicationForm = createApplicationForm()
+            val submittedApplicationForm = createApplicationForm(recruitmentId = 2L).apply { submit(pass) }
+            applicationFormRepository.saveAll(listOf(applicationForm, submittedApplicationForm))
 
-        applicationFormRepository.saveAll(listOf(applicationForm, submittedApplicationForm))
+            it("지원한 모집의 지원서를 가져올 수 있다") {
+                val form = applicationFormRepository.findByRecruitmentIdAndUserId(1L, 1L)!!
+
+                assertSoftly(form) {
+                    referenceUrl.shouldBe("https://example.com")
+                    id.shouldBe(1L)
+                    answers.items[0].contents.shouldBe("스타트업을 하고 싶습니다.")
+                    answers.items[1].contents.shouldBe("책임감")
+                }
+            }
+
+            it("제출한 이력을 확인할 수 있다") {
+                applicationFormRepository.existsByUserIdAndSubmittedTrue(1L).shouldBeTrue()
+            }
+        }
     }
-
-    @Test
-    fun `지원자가 지원한 모집의 지원서를 가져온다`() {
-        val form = applicationFormRepository.findByRecruitmentIdAndUserId(1L, 1L)!!
-
-        assertAll(
-            { assertThat(form.referenceUrl).isEqualTo("https://example.com") },
-            { assertThat(form.id).isEqualTo(1L) },
-            { assertThat(form.answers.items[0].contents).isEqualTo("스타트업을 하고 싶습니다.") },
-            { assertThat(form.answers.items[1].contents).isEqualTo("책임감") }
-        )
-    }
-
-    @Test
-    fun `지원자가 지원서를 제출한 이력이 있는지 확인한다`() {
-        assertThat(applicationFormRepository.existsByUserIdAndSubmittedTrue(1L)).isTrue()
-    }
-}
+})

--- a/src/test/kotlin/apply/domain/assignment/AssignmentRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/assignment/AssignmentRepositoryTest.kt
@@ -1,40 +1,39 @@
 package apply.domain.assignment
 
 import apply.createAssignment
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import support.test.RepositoryTest
 
 @RepositoryTest
-class AssignmentRepositoryTest(
+internal class AssignmentRepositoryTest(
     private val assignmentRepository: AssignmentRepository
-) {
-    private val assignment = createAssignment(userId = 1L, missionId = 1L)
+) : DescribeSpec({
+    val assignment = createAssignment(userId = 1L, missionId = 1L)
 
-    @BeforeEach
-    fun setUp() {
-        assignmentRepository.save(assignment)
-    }
+    describe("AssignmentRepository") {
+        context("지원자가 과제물을 제출하면") {
+            assignmentRepository.save(assignment)
 
-    @Test
-    fun `지원자와 과제에 해당하는 제출물의 존재 여부를 조회힌다`() {
-        assertThat(assignmentRepository.existsByUserIdAndMissionId(assignment.userId, assignment.missionId)).isTrue
-    }
+            it("지원자와 과제에 해당하는 제출물의 존재 여부를 조회할 수 있다") {
+                assignmentRepository.existsByUserIdAndMissionId(assignment.userId, assignment.missionId).shouldBeTrue()
+            }
 
-    @Test
-    fun `지원자와 과제에 해당하는 제출물을 반환한다`() {
-        assertThat(assignmentRepository.findByUserIdAndMissionId(assignment.userId, assignment.missionId)).isNotNull
-    }
+            it("지원자와 과제에 해당하는 제출물을 반환할 수 있다") {
+                assignmentRepository.findByUserIdAndMissionId(assignment.userId, assignment.missionId).shouldNotBeNull()
+            }
 
-    @Test
-    fun `지원자의 모든 제출물을 조회한다`() {
-        assignmentRepository.saveAll(
-            listOf(
-                createAssignment(userId = 1L, missionId = 2L),
-                createAssignment(userId = 1L, missionId = 3L)
-            )
-        )
-        assertThat(assignmentRepository.findAllByUserId(1L)).hasSize(3)
+            it("지원자의 모든 제출물을 조회할 수 있다") {
+                assignmentRepository.saveAll(
+                    listOf(
+                        createAssignment(userId = 1L, missionId = 2L),
+                        createAssignment(userId = 1L, missionId = 3L)
+                    )
+                )
+                assignmentRepository.findAllByUserId(1L).shouldHaveSize(3)
+            }
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/domain/authenticationcode/AuthenticationCodeRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/authenticationcode/AuthenticationCodeRepositoryTest.kt
@@ -2,26 +2,29 @@ package apply.domain.authenticationcode
 
 import apply.EMAIL
 import apply.createAuthenticationCode
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import support.test.RepositoryTest
 import java.time.LocalDateTime
 
 @RepositoryTest
-class AuthenticationCodeRepositoryTest(
+internal class AuthenticationCodeRepositoryTest(
     private val authenticationCodeRepository: AuthenticationCodeRepository
-) {
-    @Test
-    fun `가장 최근에 생성된 인증 코드를 조회한다`() {
-        val now = LocalDateTime.now()
-        val authenticationCodes = authenticationCodeRepository.saveAll(
-            listOf(
-                createAuthenticationCode(EMAIL),
-                createAuthenticationCode(EMAIL, createdDateTime = now.plusSeconds(1L)),
-                createAuthenticationCode(EMAIL, createdDateTime = now.plusSeconds(2L))
+) : DescribeSpec({
+    extension(SpringExtension)
+    describe("AuthenticationCodeRepository") {
+        it("가장 최근에 생성된 인증 코드를 조회한다") {
+            val now = LocalDateTime.now()
+            val authenticationCodes = authenticationCodeRepository.saveAll(
+                listOf(
+                    createAuthenticationCode(EMAIL),
+                    createAuthenticationCode(EMAIL, createdDateTime = now.plusSeconds(1L)),
+                    createAuthenticationCode(EMAIL, createdDateTime = now.plusSeconds(2L))
+                )
             )
-        )
-        val actual = authenticationCodeRepository.findFirstByEmailOrderByCreatedDateTimeDesc(EMAIL)
-        assertThat(actual).isSameAs(authenticationCodes.last())
+            val actual = authenticationCodeRepository.findFirstByEmailOrderByCreatedDateTimeDesc(EMAIL)
+            actual.shouldBeSameInstanceAs(authenticationCodes.last())
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/domain/authenticationcode/AuthenticationCodeRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/authenticationcode/AuthenticationCodeRepositoryTest.kt
@@ -3,7 +3,6 @@ package apply.domain.authenticationcode
 import apply.EMAIL
 import apply.createAuthenticationCode
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import support.test.RepositoryTest
 import java.time.LocalDateTime
@@ -12,7 +11,6 @@ import java.time.LocalDateTime
 internal class AuthenticationCodeRepositoryTest(
     private val authenticationCodeRepository: AuthenticationCodeRepository
 ) : DescribeSpec({
-    extension(SpringExtension)
     describe("AuthenticationCodeRepository") {
         it("가장 최근에 생성된 인증 코드를 조회한다") {
             val now = LocalDateTime.now()

--- a/src/test/kotlin/apply/domain/cheater/CheaterRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/cheater/CheaterRepositoryTest.kt
@@ -3,18 +3,18 @@ package apply.domain.cheater
 import apply.domain.user.Gender
 import apply.domain.user.Password
 import apply.domain.user.User
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import support.createLocalDate
 import support.test.RepositoryTest
 
 @RepositoryTest
 internal class CheaterRepositoryTest(
     private val cheaterRepository: CheaterRepository
-) {
-    private val cheater = User(
+) : DescribeSpec({
+    val cheater = User(
         id = 1L,
         name = "홍길동1",
         email = "a@email.com",
@@ -24,7 +24,7 @@ internal class CheaterRepositoryTest(
         password = Password("password")
     )
 
-    private val user = User(
+    val user = User(
         id = 2L,
         name = "홍길동2",
         email = "b@email.com",
@@ -34,16 +34,16 @@ internal class CheaterRepositoryTest(
         password = Password("password")
     )
 
-    @BeforeEach
-    internal fun setUp() {
-        cheaterRepository.save(Cheater(cheater.email))
-    }
+    describe("CheaterRepository") {
+        context("지원자의 부정행위 정보가 저장되면") {
+            cheaterRepository.save(Cheater(cheater.email))
 
-    @Test
-    fun `지원자의 부정 행위 여부를 확인한다`() {
-        assertAll(
-            { assertThat(cheaterRepository.existsByEmail(cheater.email)).isTrue() },
-            { assertThat(cheaterRepository.existsByEmail(user.email)).isFalse() }
-        )
+            it("부정 행위 여부를 확인한다") {
+                assertSoftly(cheaterRepository) {
+                    existsByEmail(cheater.email).shouldBeTrue()
+                    existsByEmail(user.email).shouldBeFalse()
+                }
+            }
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/domain/evaluationitem/EvaluationItemRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationitem/EvaluationItemRepositoryTest.kt
@@ -3,27 +3,28 @@ package apply.domain.evaluationitem
 import apply.EVALUATION_ID
 import apply.createEvaluationItem
 import apply.domain.evaluationItem.EvaluationItemRepository
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import support.test.RepositoryTest
 
 @RepositoryTest
 internal class EvaluationItemRepositoryTest(
     private val evaluationItemRepository: EvaluationItemRepository
-) {
-    @Test
-    fun `평가의 id로 평가 항목들을 Position의 오름차순으로 조회한다`() {
-        val evaluationItems = listOf(
-            createEvaluationItem(position = 2),
-            createEvaluationItem(position = 1),
-            createEvaluationItem(position = 3),
-            createEvaluationItem(position = 0)
-        )
+) : DescribeSpec({
+    describe("EvaluationItemRepository") {
+        it("평가의 id로 평가 항목들을 Position의 오름차순으로 조회한다") {
+            val evaluationItems = listOf(
+                createEvaluationItem(position = 2),
+                createEvaluationItem(position = 1),
+                createEvaluationItem(position = 3),
+                createEvaluationItem(position = 0)
+            )
 
-        evaluationItemRepository.saveAll(evaluationItems)
-        val results = evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
+            evaluationItemRepository.saveAll(evaluationItems)
+            val results = evaluationItemRepository.findByEvaluationIdOrderByPosition(EVALUATION_ID)
 
-        val expected = listOf(evaluationItems[3], evaluationItems[1], evaluationItems[0], evaluationItems[2])
-        assertThat(results).isEqualTo(expected)
+            val expected = listOf(evaluationItems[3], evaluationItems[1], evaluationItems[0], evaluationItems[2])
+            results.shouldBe(expected)
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -1,22 +1,21 @@
 package apply.domain.evaluationtarget
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
-import org.junit.jupiter.params.provider.ValueSource
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualToUsingFields
+import io.kotest.matchers.shouldBe
 import support.test.RepositoryTest
 
 @RepositoryTest
-class EvaluationTargetRepositoryTest(
+internal class EvaluationTargetRepositoryTest(
     private val evaluationTargetRepository: EvaluationTargetRepository
-) {
-    companion object {
-        private const val EVALUATION_ID = 1L
-    }
+) : DescribeSpec({
+    extension(SpringExtension)
 
-    private val evaluationTargets: List<EvaluationTarget> = listOf(
+    val evaluationTargets: List<EvaluationTarget> = listOf(
         EvaluationTarget(
             EVALUATION_ID,
             userId = 1L
@@ -27,69 +26,79 @@ class EvaluationTargetRepositoryTest(
         )
     )
 
-    @BeforeEach
-    fun setUp() {
+    beforeTest {
         evaluationTargetRepository.saveAll(evaluationTargets)
     }
 
-    @Test
-    fun `평가의 id로 평가 대상자를 찾는다`() {
-        val results = evaluationTargetRepository.findAllByEvaluationId(EVALUATION_ID)
+    describe("EvaluationTargetRepository") {
+        it("평가의 id로 평가 대상자를 찾는다") {
+            val results = evaluationTargetRepository.findAllByEvaluationId(EVALUATION_ID)
 
-        assertThat(results).usingElementComparatorOnFields("userId").isEqualTo(evaluationTargets)
-    }
+            results.zip(evaluationTargets)
+                .forEach { evaluationTarget ->
+                    evaluationTarget.first.shouldBeEqualToUsingFields(
+                        evaluationTarget.second,
+                        EvaluationTarget::evaluationId
+                    )
+                }
+        }
 
-    @CsvSource(value = ["1,true", "2,false"])
-    @ParameterizedTest
-    fun `평가의 id를 가지고 있는 평가 대상자의 존재 여부를 확인한다`(evaluationId: Long, expected: Boolean) {
-        val actual = evaluationTargetRepository.existsByEvaluationId(evaluationId)
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `지원자의 id들에 해당되는 평가 대상자를 제거한다`() {
-        evaluationTargetRepository.deleteByUserIdIn(setOf(1L, 2L))
-
-        assertThat(evaluationTargetRepository.count()).isEqualTo(0)
-    }
-
-    @Test
-    fun `지정한 평가에 해당되고 지원자의 id들에 해당되는 평가 대상자를 제거한다`() {
-        evaluationTargetRepository.save(
-            EvaluationTarget(
-                evaluationId = 2L,
-                userId = 1L
-            )
-        )
-
-        evaluationTargetRepository.deleteByEvaluationIdAndUserIdIn(1L, setOf(1L, 2L))
-
-        assertThat(evaluationTargetRepository.count()).isEqualTo(1)
-    }
-
-    @ParameterizedTest
-    @CsvSource(value = ["PASS,2", "FAIL,1"])
-    fun `지정한 평가에 해당되고 평가대상자들의 평가 상태가 특정 평가 상태와 일치하는 평가 대상자를 찾는다`(
-        evaluationStatus: EvaluationStatus,
-        expectedSize: Int
-    ) {
-        evaluationTargetRepository.saveAll(
+        it("평가의 id를 가지고 있는 평가 대상자의 존재 여부를 확인한다") {
             listOf(
-                EvaluationTarget(EVALUATION_ID, userId = 1L, evaluationStatus = EvaluationStatus.PASS),
-                EvaluationTarget(EVALUATION_ID, userId = 2L, evaluationStatus = EvaluationStatus.PASS),
-                EvaluationTarget(EVALUATION_ID, userId = 3L, evaluationStatus = EvaluationStatus.FAIL)
-            )
-        )
-        val actual =
-            evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(EVALUATION_ID, evaluationStatus)
-        assertThat(actual).hasSize(expectedSize)
-    }
+                1L to true,
+                2L to false
+            ).forAll { (evaluationId: Long, expected: Boolean) ->
+                val actual = evaluationTargetRepository.existsByEvaluationId(evaluationId)
+                actual.shouldBe(expected)
+            }
+        }
 
-    @ParameterizedTest
-    @ValueSource(ints = [1, 2])
-    fun `지정한 평가와 회원에 해당하는 대상자의 존재 여부를 확인한다`(userId: Long) {
-        val isExists = evaluationTargetRepository.existsByUserIdAndEvaluationId(userId, EVALUATION_ID)
-        assertThat(isExists).isTrue
+        it("지원자의 id들에 해당되는 평가 대상자를 제거한다") {
+            evaluationTargetRepository.deleteByUserIdIn(setOf(1L, 2L))
+
+            evaluationTargetRepository.count().shouldBe(0)
+        }
+
+        it("지정한 평가에 해당되고 지원자의 id들에 해당되는 평가 대상자를 제거한다") {
+            evaluationTargetRepository.save(
+                EvaluationTarget(
+                    evaluationId = 2L,
+                    userId = 1L
+                )
+            )
+
+            evaluationTargetRepository.deleteByEvaluationIdAndUserIdIn(1L, setOf(1L, 2L))
+
+            evaluationTargetRepository.count().shouldBe(1)
+        }
+
+        it("지정한 평가에 해당되고 평가대상자들의 평가 상태가 특정 평가 상태와 일치하는 평가 대상자를 찾는다") {
+            evaluationTargetRepository.saveAll(
+                listOf(
+                    EvaluationTarget(EVALUATION_ID, userId = 1L, evaluationStatus = EvaluationStatus.PASS),
+                    EvaluationTarget(EVALUATION_ID, userId = 2L, evaluationStatus = EvaluationStatus.PASS),
+                    EvaluationTarget(EVALUATION_ID, userId = 3L, evaluationStatus = EvaluationStatus.FAIL)
+                )
+            )
+            listOf(
+                EvaluationStatus.PASS to 2,
+                EvaluationStatus.FAIL to 1
+            ).forAll { (evaluationStatus: EvaluationStatus, expectedSize: Int) ->
+                val actual =
+                    evaluationTargetRepository.findAllByEvaluationIdAndEvaluationStatus(EVALUATION_ID, evaluationStatus)
+                actual.shouldHaveSize(expectedSize)
+            }
+        }
+
+        it("지정한 평가와 회원에 해당하는 대상자의 존재 여부를 확인한다") {
+            listOf(1L, 2L).forAll { userId: Long ->
+                val isExists = evaluationTargetRepository.existsByUserIdAndEvaluationId(userId, EVALUATION_ID)
+                isExists.shouldBeTrue()
+            }
+        }
+    }
+}) {
+    companion object {
+        private const val EVALUATION_ID = 1L
     }
 }

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -1,7 +1,6 @@
 package apply.domain.evaluationtarget
 
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldHaveSize
@@ -13,7 +12,6 @@ import support.test.RepositoryTest
 internal class EvaluationTargetRepositoryTest(
     private val evaluationTargetRepository: EvaluationTargetRepository
 ) : DescribeSpec({
-    extension(SpringExtension)
 
     val evaluationTargets: List<EvaluationTarget> = listOf(
         EvaluationTarget(

--- a/src/test/kotlin/apply/domain/mission/MissionRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/mission/MissionRepositoryTest.kt
@@ -3,7 +3,6 @@ package apply.domain.mission
 import apply.createMission
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldHaveSize
@@ -17,7 +16,6 @@ internal class MissionRepositoryTest(
     private val missionRepository: MissionRepository,
     private val entityManager: TestEntityManager
 ) : DescribeSpec({
-    extension(SpringExtension)
     fun flushAndClear() {
         entityManager.flush()
         entityManager.clear()

--- a/src/test/kotlin/apply/domain/recruitment/RecruitmentRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/recruitment/RecruitmentRepositoryTest.kt
@@ -3,7 +3,6 @@ package apply.domain.recruitment
 import apply.createRecruitment
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
 import org.springframework.boot.autoconfigure.domain.EntityScan
@@ -19,11 +18,12 @@ internal class RecruitmentRepositoryTest(
     private val recruitmentRepository: RecruitmentRepository,
     private val entityManager: TestEntityManager
 ) : DescribeSpec({
-    extension(SpringExtension)
+
     fun flushAndClear() {
         entityManager.flush()
         entityManager.clear()
     }
+
     describe("RecruitmentRepository") {
         it("삭제 시 논리적 삭제가 적용된다") {
             val recruitment = recruitmentRepository.save(createRecruitment())

--- a/src/test/kotlin/apply/domain/recruitment/RecruitmentRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/recruitment/RecruitmentRepositoryTest.kt
@@ -1,9 +1,11 @@
 package apply.domain.recruitment
 
 import apply.createRecruitment
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
@@ -13,23 +15,24 @@ import support.test.RepositoryTest
 @EnableJpaRepositories("apply.domain.recruitment")
 @EntityScan("apply.domain.recruitment")
 @RepositoryTest
-class RecruitmentRepositoryTest(
+internal class RecruitmentRepositoryTest(
     private val recruitmentRepository: RecruitmentRepository,
     private val entityManager: TestEntityManager
-) {
-    @Test
-    fun `삭제 시 논리적 삭제가 적용된다`() {
-        val recruitment = recruitmentRepository.save(createRecruitment())
-        flushAndClear()
-        recruitmentRepository.deleteById(recruitment.id)
-        assertAll(
-            { assertThat(recruitmentRepository.findAll()).hasSize(0) },
-            { assertThat(recruitmentRepository.findByIdOrNull(recruitment.id)).isNull() }
-        )
-    }
-
-    private fun flushAndClear() {
+) : DescribeSpec({
+    extension(SpringExtension)
+    fun flushAndClear() {
         entityManager.flush()
         entityManager.clear()
     }
-}
+    describe("RecruitmentRepository") {
+        it("삭제 시 논리적 삭제가 적용된다") {
+            val recruitment = recruitmentRepository.save(createRecruitment())
+            flushAndClear()
+            recruitmentRepository.deleteById(recruitment.id)
+            assertSoftly(recruitmentRepository) {
+                findAll().shouldHaveSize(0)
+                findByIdOrNull(recruitment.id).shouldBeNull()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/apply/domain/recruitmentitem/RecruitmentItemRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/recruitmentitem/RecruitmentItemRepositoryTest.kt
@@ -1,59 +1,69 @@
 package apply.domain.recruitmentitem
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
+import io.kotest.matchers.nulls.shouldNotBeNull
 import support.test.RepositoryTest
 
 @RepositoryTest
 internal class RecruitmentItemRepositoryTest(
     private val recruitmentItemRepository: RecruitmentItemRepository
-) {
+) : DescribeSpec({
+    describe("RecruitmentItemRepository") {
+        context("특정 모집의 모집 항목을") {
+            val recruitmentItems = listOf(
+                RecruitmentItem(
+                    RECRUITMENT_ID,
+                    "모집 항목 제목",
+                    position = 1,
+                    maximumLength = 1,
+                    description = "모집 항목 설명"
+                ),
+                RecruitmentItem(
+                    RECRUITMENT_ID,
+                    "모집 항목 제목2",
+                    position = 3,
+                    maximumLength = 1,
+                    description = "모집 항목 설명2"
+                ),
+                RecruitmentItem(
+                    RECRUITMENT_ID,
+                    "모집 항목 제목3",
+                    position = 2,
+                    maximumLength = 1,
+                    description = "모집 항목 설명3"
+                ),
+                RecruitmentItem(
+                    DIFFERENT_RECRUITMENT_ID,
+                    "모집 항목 제목4",
+                    position = 2,
+                    maximumLength = 1,
+                    description = "모집 항목 설명4"
+                )
+            )
+            recruitmentItemRepository.saveAll(recruitmentItems)
+
+            it("특정 모집의 모집 항목을 순서대로 조회한다") {
+                val results = recruitmentItemRepository.findByRecruitmentIdOrderByPosition(RECRUITMENT_ID)
+                val expected = listOf(recruitmentItems[0], recruitmentItems[2], recruitmentItems[1])
+                val zip = results.zip(expected)
+
+                assertSoftly(zip) {
+                    zip.forEach { recruitmentItems ->
+                        recruitmentItems.first.shouldBeEqualToIgnoringFields(
+                            recruitmentItems.second,
+                            RecruitmentItem::recruitmentId
+                        )
+                    }
+                    zip.forEach { recruitmentItems -> recruitmentItems.first.recruitmentId.shouldNotBeNull() }
+                }
+            }
+        }
+    }
+}) {
     companion object {
         private const val RECRUITMENT_ID = 1L
         private const val DIFFERENT_RECRUITMENT_ID = 2L
-    }
-
-    @Test
-    fun `특정 모집의 모집 항목을 순서대로 조회한다`() {
-        val recruitmentItems = listOf(
-            RecruitmentItem(
-                RECRUITMENT_ID,
-                "모집 항목 제목",
-                position = 1,
-                maximumLength = 1,
-                description = "모집 항목 설명"
-            ),
-            RecruitmentItem(
-                RECRUITMENT_ID,
-                "모집 항목 제목2",
-                position = 3,
-                maximumLength = 1,
-                description = "모집 항목 설명2"
-            ),
-            RecruitmentItem(
-                RECRUITMENT_ID,
-                "모집 항목 제목3",
-                position = 2,
-                maximumLength = 1,
-                description = "모집 항목 설명3"
-            ),
-            RecruitmentItem(
-                DIFFERENT_RECRUITMENT_ID,
-                "모집 항목 제목4",
-                position = 2,
-                maximumLength = 1,
-                description = "모집 항목 설명4"
-            )
-        )
-
-        recruitmentItemRepository.saveAll(recruitmentItems)
-        val results = recruitmentItemRepository.findByRecruitmentIdOrderByPosition(RECRUITMENT_ID)
-
-        val expected = listOf(recruitmentItems[0], recruitmentItems[2], recruitmentItems[1])
-        assertAll(
-            { assertThat(results).usingElementComparatorIgnoringFields("id").isEqualTo(expected) },
-            { assertThat(results).usingElementComparatorOnFields("id").isNotNull() }
-        )
     }
 }

--- a/src/test/kotlin/apply/domain/user/UserRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/user/UserRepositoryTest.kt
@@ -1,18 +1,21 @@
 package apply.domain.user
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import support.createLocalDate
 import support.test.RepositoryTest
 
 @RepositoryTest
-internal class UserRepositoryTest(private val userRepository: UserRepository) {
-    @BeforeEach
-    internal fun setUp() {
+internal class UserRepositoryTest(private val userRepository: UserRepository) : DescribeSpec({
+    extension(SpringExtension)
+    beforeEach {
         val users = listOf(
             User(
                 "홍길동1",
@@ -42,34 +45,37 @@ internal class UserRepositoryTest(private val userRepository: UserRepository) {
         userRepository.saveAll(users)
     }
 
-    @ParameterizedTest
-    @CsvSource("홍,2", "a@,1", "'',3", "4,0")
-    fun `이름 또는 이메일에 검색 키워드가 포함되는 회원들을 모두 조회한다`(keyword: String, expectedSize: Int) {
-        val result = userRepository.findAllByKeyword(keyword)
-        assertThat(result).hasSize(expectedSize)
-    }
+    describe("UserRepository") {
+        it("이름 또는 이메일에 검색 키워드가 포함되는 회원들을 모두 조회한다") {
+            listOf(
+                "홍" to 2,
+                "a@" to 1,
+                "" to 3,
+                "4" to 0
+            ).forAll { (keyword, expectedSize) ->
+                val result = userRepository.findAllByKeyword(keyword)
+                result.shouldHaveSize(expectedSize)
+            }
+        }
 
-    @Test
-    fun `이메일이 일치하는 회원을 조회한다`() {
-        assertThat(userRepository.findByEmail("b@email.com")!!.name).isEqualTo("홍길동2")
-    }
+        it("이메일이 일치하는 회원을 조회한다") {
+            userRepository.findByEmail("b@email.com")!!.name.shouldBe("홍길동2")
+        }
 
-    @Test
-    fun `이메일이 일치하는 회원이 존재하지 않을 때, null을 반환한다`() {
-        assertThat(userRepository.findByEmail("notexist@email.com")).isNull()
-    }
+        it("이메일이 일치하는 회원이 존재하지 않을 때, null을 반환한다") {
+            userRepository.findByEmail("notexist@email.com").shouldBeNull()
+        }
 
-    @Test
-    fun `이메일이 일치하는 회원들을 전부 조회한다`() {
-        val emails = listOf("b@email.com", "c@email.com")
-        assertThat(userRepository.findAllByEmailIn(emails)).hasSize(2)
-    }
+        it("이메일이 일치하는 회원들을 전부 조회한다") {
+            val emails = listOf("b@email.com", "c@email.com")
+            userRepository.findAllByEmailIn(emails).shouldHaveSize(2)
+        }
 
-    @Test
-    fun `이메일이 일치하는 회원이 있는지 확인한다`() {
-        assertAll(
-            { assertThat(userRepository.existsByEmail("a@email.com")).isTrue() },
-            { assertThat(userRepository.existsByEmail("non-exists@email.com")).isFalse() }
-        )
+        it("이메일이 일치하는 회원이 있는지 확인한다") {
+            assertSoftly(userRepository) {
+                existsByEmail("a@email.com").shouldBeTrue()
+                existsByEmail("non-exists@email.com").shouldBeFalse()
+            }
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/domain/user/UserRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/user/UserRepositoryTest.kt
@@ -2,7 +2,6 @@ package apply.domain.user
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -14,7 +13,7 @@ import support.test.RepositoryTest
 
 @RepositoryTest
 internal class UserRepositoryTest(private val userRepository: UserRepository) : DescribeSpec({
-    extension(SpringExtension)
+
     beforeEach {
         val users = listOf(
             User(

--- a/src/test/kotlin/apply/infra/mail/AwsMailSenderTest.kt
+++ b/src/test/kotlin/apply/infra/mail/AwsMailSenderTest.kt
@@ -1,7 +1,6 @@
 package apply.infra.mail
 
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.DescribeSpec
 import support.test.IntegrationTest
 
 private const val ALWAYS_SUCCESSFUL_DELIVERY_ADDRESS: String = "success@simulator.amazonses.com"
@@ -9,13 +8,13 @@ private const val TEST_SUBJECT: String = "테스트"
 private const val TEST_HTML_BODY: String =
     """<img src="https://woowacourse.github.io/img/logo_full_dark.26e30197.png" style="width: 200px" alt="logo" />"""
 
-@Disabled
 @IntegrationTest
 internal class AwsMailSenderTest(
     private val awsMailSender: AwsMailSender
-) {
-    @Test
-    fun `성공적인 전송`() {
-        awsMailSender.send(ALWAYS_SUCCESSFUL_DELIVERY_ADDRESS, TEST_SUBJECT, TEST_HTML_BODY)
+) : DescribeSpec({
+    xdescribe("AwsMailSender") {
+        it("성공적인 전송") {
+            awsMailSender.send(ALWAYS_SUCCESSFUL_DELIVERY_ADDRESS, TEST_SUBJECT, TEST_HTML_BODY)
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/security/LoginUserResolverTest.kt
+++ b/src/test/kotlin/apply/security/LoginUserResolverTest.kt
@@ -4,15 +4,13 @@ import apply.application.UserService
 import apply.domain.user.Gender
 import apply.domain.user.Password
 import apply.domain.user.User
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.core.MethodParameter
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.web.context.request.NativeWebRequest
@@ -22,102 +20,101 @@ import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.primaryConstructor
 
 @UnitTest
-internal class LoginUserResolverTest {
-    @MockK
-    private lateinit var userService: UserService
+internal class LoginUserResolverTest : DescribeSpec({
 
-    @MockK
-    private lateinit var jwtTokenProvider: JwtTokenProvider
-    private lateinit var loginUserResolver: LoginUserResolver
-    private lateinit var methodParameter: MethodParameter
-    private lateinit var nativeWebRequest: NativeWebRequest
+    val userService = mockk<UserService>()
+    val jwtTokenProvider = mockk<JwtTokenProvider>()
+    val methodParameter = mockk<MethodParameter>()
+    val nativeWebRequest = mockk<NativeWebRequest>()
+    val loginUserResolver = LoginUserResolver(jwtTokenProvider, userService)
 
-    @BeforeEach
-    internal fun setUp() {
-        loginUserResolver = LoginUserResolver(jwtTokenProvider, userService)
-        methodParameter = mockk()
-        nativeWebRequest = mockk()
-    }
-
-    @ParameterizedTest
-    @CsvSource("user,true", "administrator,true", "guest,false")
-    fun `@LoginUser 주어진 메서드의 서포트 여부를 확인한다`(methodName: String, expected: Boolean) {
-        val method = TestAuthController::class.java.getDeclaredMethod(methodName, User::class.java)
-        val loginUserParameter: MethodParameter = MethodParameter.forExecutable(method, 0)
-        assertThat(loginUserResolver.supportsParameter(loginUserParameter)).isEqualTo(expected)
-    }
-
-    private class TestAuthController {
+    class TestAuthController {
         fun user(@LoginUser user: User) {}
         fun administrator(@LoginUser(administrator = true) user: User) {}
         fun guest(user: User) {}
     }
 
-    @Test
-    fun `관리 API를 호출하면 실패한다`() {
-        every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createAdministratorAnnotation()
-        assertThrows<LoginFailedException> {
-            loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
+    fun createUserAnnotation(): LoginUser = LoginUser::class.createInstance()
+
+    fun createAdministratorAnnotation(): LoginUser? = LoginUser::class.primaryConstructor?.call(true)
+
+    describe("LoginUserResolver") {
+        context("사용자 API를 호출하면") {
+
+            every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
+
+            it("@LoginUser 주어진 메서드의 서포트 여부를 확인한다") {
+                listOf(
+                    "user" to true,
+                    "administrator" to true,
+                    "guest" to false
+                ).forAll { (methodName, expected) ->
+                    val method = TestAuthController::class.java.getDeclaredMethod(methodName, User::class.java)
+                    val loginUserParameter: MethodParameter = MethodParameter.forExecutable(method, 0)
+                    loginUserResolver.supportsParameter(loginUserParameter) shouldBe expected
+                }
+            }
+
+            it("요청의 Authorization 헤더로 저장된 회원을 불러온다") {
+                every { nativeWebRequest.getHeader(AUTHORIZATION) } returns "Bearer valid_token"
+                every { jwtTokenProvider.isValidToken("valid_token") } returns true
+                every { jwtTokenProvider.getSubject("valid_token") } returns "user_email@email.com"
+                val expectedUser = User(
+                    name = "홍길동1",
+                    email = "user_email@email.com",
+                    phoneNumber = "010-0000-0000",
+                    gender = Gender.MALE,
+                    birthday = createLocalDate(2020, 4, 17),
+                    password = Password("password")
+                )
+                every { userService.getByEmail("user_email@email.com") } returns expectedUser
+
+                val result = loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
+                result shouldBeEqualToComparingFields expectedUser
+            }
+
+            it("요청의 Authorization 헤더의 형식이 올바르지 않을 경우 예외가 발생한다") {
+                listOf(
+                    "Bearertokeninfo",
+                    "''",
+                    "Bearer"
+                ).forAll { header ->
+                    every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
+                    every { nativeWebRequest.getHeader(AUTHORIZATION) } returns header
+
+                    shouldThrowExactly<LoginFailedException> {
+                        loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
+                    }
+                }
+            }
+
+            it("요청의 Authorization 헤더가 존재하지 않을 경우 예외가 발생한다") {
+                every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
+                every { nativeWebRequest.getHeader(AUTHORIZATION) } returns null
+
+                shouldThrowExactly<LoginFailedException> {
+                    loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
+                }
+            }
+
+            it("요청의 토큰이 유효하지 않은 경우 예외가 발생한다") {
+                every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
+                every { nativeWebRequest.getHeader(AUTHORIZATION) } returns "invalid_token"
+                every { jwtTokenProvider.isValidToken("invalid_token") } returns false
+
+                shouldThrowExactly<LoginFailedException> {
+                    loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
+                }
+            }
+        }
+
+        context("관리 API를 호출하면") {
+            it("실패한다") {
+                every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createAdministratorAnnotation()
+                shouldThrowExactly<LoginFailedException> {
+                    loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
+                }
+            }
         }
     }
-
-    @Test
-    fun `요청의 Authorization 헤더로 저장된 회원을 불러온다`() {
-        every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
-        every { nativeWebRequest.getHeader(AUTHORIZATION) } returns "Bearer valid_token"
-        every { jwtTokenProvider.isValidToken("valid_token") } returns true
-        every { jwtTokenProvider.getSubject("valid_token") } returns "user_email@email.com"
-        val expectedUser = User(
-            name = "홍길동1",
-            email = "user_email@email.com",
-            phoneNumber = "010-0000-0000",
-            gender = Gender.MALE,
-            birthday = createLocalDate(2020, 4, 17),
-            password = Password("password")
-        )
-        every { userService.getByEmail("user_email@email.com") } returns expectedUser
-
-        val result = loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
-        assertThat(result).usingRecursiveComparison().isEqualTo(expectedUser)
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        "Bearertokeninfo",
-        "''",
-        "Bearer"
-    )
-    fun `요청의 Authorization 헤더의 형식이 올바르지 않을 경우 예외가 발생한다`(header: String) {
-        every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
-        every { nativeWebRequest.getHeader(AUTHORIZATION) } returns header
-
-        assertThrows<LoginFailedException> {
-            loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
-        }
-    }
-
-    @Test
-    fun `요청의 Authorization 헤더가 존재하지 않을 경우 예외가 발생한다`() {
-        every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
-        every { nativeWebRequest.getHeader(AUTHORIZATION) } returns null
-
-        assertThrows<LoginFailedException> {
-            loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
-        }
-    }
-
-    @Test
-    fun `요청의 토큰이 유효하지 않은 경우 예외가 발생한다`() {
-        every { methodParameter.getParameterAnnotation<LoginUser>(any()) } returns createUserAnnotation()
-        every { nativeWebRequest.getHeader(AUTHORIZATION) } returns "invalid_token"
-        every { jwtTokenProvider.isValidToken("invalid_token") } returns false
-
-        assertThrows<LoginFailedException> {
-            loginUserResolver.resolveArgument(methodParameter, null, nativeWebRequest, null)
-        }
-    }
-
-    private fun createUserAnnotation(): LoginUser = LoginUser::class.createInstance()
-
-    private fun createAdministratorAnnotation(): LoginUser? = LoginUser::class.primaryConstructor?.call(true)
-}
+})

--- a/src/test/kotlin/apply/ui/admin/recruitment/RecruitmentFormTest.kt
+++ b/src/test/kotlin/apply/ui/admin/recruitment/RecruitmentFormTest.kt
@@ -4,58 +4,55 @@ import apply.createRecruitmentData
 import apply.createRecruitmentForm
 import apply.createRecruitmentItemData
 import com.vaadin.flow.component.UI
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 
-@ExtendWith(MockKExtension::class)
-internal class RecruitmentFormTest {
+internal class RecruitmentFormTest : DescribeSpec({
+
     /**
      * Static classes are mocked for the following reasons:
      * [issue](https://github.com/vaadin/vaadin-date-picker-flow/issues/262)
      */
-    @BeforeEach
-    internal fun setUp() {
+    beforeEach {
         mockkStatic("com.vaadin.flow.component.UI")
         every { UI.getCurrent() }.returns(UI())
     }
 
-    @Test
-    fun `유효한 값을 입력하는 경우`() {
-        val actual = createRecruitmentForm().bindOrNull()
-        assertThat(actual).isEqualTo(createRecruitmentData())
-    }
+    describe("RecruitmentForm") {
+        it("유효한 값을 입력하는 경우") {
+            val actual = createRecruitmentForm().bindOrNull()
+            actual shouldBe createRecruitmentData()
+        }
 
-    @Test
-    fun `잘못된 값을 입력한 경우`() {
-        val actual = createRecruitmentForm(title = "").bindOrNull()
-        assertThat(actual).isNull()
-    }
+        it("잘못된 값을 입력한 경우") {
+            val actual = createRecruitmentForm(title = "").bindOrNull()
+            actual.shouldBeNull()
+        }
 
-    @ValueSource(booleans = [true, false])
-    @ParameterizedTest
-    fun `공개 여부 값이 설정되어 있는지 확인`(hidden: Boolean) {
-        val actual = createRecruitmentForm(hidden = hidden).bindOrNull()
-        assertThat(actual).isNotNull()
-        assertThat(actual!!.hidden).isEqualTo(hidden)
-    }
+        it("공개 여부 값이 설정되어 있는지 확인") {
+            listOf(
+                    true,
+                    false
+            ).forAll { hidden ->
+                val actual = createRecruitmentForm(hidden = hidden).bindOrNull()
+                actual.shouldNotBeNull()
+                actual.hidden shouldBe hidden
+            }
+        }
 
-    @Test
-    fun `양식에 값을 채울 수 있다`() {
-        val data = createRecruitmentData(id = 1L, recruitmentItems = listOf(createRecruitmentItemData(id = 1L)))
-        val form = createRecruitmentForm()
-        form.fill(data)
-        assertThat(form.bindOrNull()).isEqualTo(
-            createRecruitmentData(
-                id = 1L,
-                recruitmentItems = listOf(createRecruitmentItemData(id = 1L))
+        it("양식에 값을 채울 수 있다") {
+            val data = createRecruitmentData(id = 1L, recruitmentItems = listOf(createRecruitmentItemData(id = 1L)))
+            val form = createRecruitmentForm()
+            form.fill(data)
+            form.bindOrNull() shouldBe createRecruitmentData(
+                    id = 1L,
+                    recruitmentItems = listOf(createRecruitmentItemData(id = 1L))
             )
-        )
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/ui/admin/recruitment/RecruitmentFormTest.kt
+++ b/src/test/kotlin/apply/ui/admin/recruitment/RecruitmentFormTest.kt
@@ -36,8 +36,8 @@ internal class RecruitmentFormTest : DescribeSpec({
 
         it("공개 여부 값이 설정되어 있는지 확인") {
             listOf(
-                    true,
-                    false
+                true,
+                false
             ).forAll { hidden ->
                 val actual = createRecruitmentForm(hidden = hidden).bindOrNull()
                 actual.shouldNotBeNull()
@@ -50,8 +50,8 @@ internal class RecruitmentFormTest : DescribeSpec({
             val form = createRecruitmentForm()
             form.fill(data)
             form.bindOrNull() shouldBe createRecruitmentData(
-                    id = 1L,
-                    recruitmentItems = listOf(createRecruitmentItemData(id = 1L))
+                id = 1L,
+                recruitmentItems = listOf(createRecruitmentItemData(id = 1L))
             )
         }
     }

--- a/src/test/kotlin/apply/ui/admin/selections/EvaluationItemScoreFormTest.kt
+++ b/src/test/kotlin/apply/ui/admin/selections/EvaluationItemScoreFormTest.kt
@@ -4,32 +4,30 @@ import apply.application.EvaluationItemScoreData
 import apply.createEvaluationAnswerForm
 import com.vaadin.flow.component.UI
 import dev.mett.vaadin.tooltip.Tooltips
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.junit5.MockKExtension
 import io.mockk.mockkStatic
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(MockKExtension::class)
-class EvaluationItemScoreFormTest {
-    @BeforeEach
-    internal fun setUp() {
+class EvaluationItemScoreFormTest : DescribeSpec({
+
+    beforeEach {
         mockkStatic("dev.mett.vaadin.tooltip.Tooltips")
         every { Tooltips.getCurrent() }.returns(Tooltips(UI()))
     }
 
-    @Test
-    fun `유효한 값을 입력하는 경우`() {
-        val actual = createEvaluationAnswerForm(score = 3, evaluationItemId = 1L).bindOrNull()
-        assertThat(actual).isNotNull
-        assertThat(actual).isEqualTo(EvaluationItemScoreData(score = 3, id = 1L))
-    }
+    describe("EvaluationItemScoreForm") {
+        it("유효한 값을 입력하는 경우") {
+            val actual = createEvaluationAnswerForm(score = 3, evaluationItemId = 1L).bindOrNull()
+            actual.shouldNotBeNull()
+            actual shouldBe EvaluationItemScoreData(score = 3, id = 1L)
+        }
 
-    @Test
-    fun `잘못된 값을 입력한 경우`() {
-        val actual = createEvaluationAnswerForm(score = -1).bindOrNull()
-        assertThat(actual).isNull()
+        it("잘못된 값을 입력한 경우") {
+            val actual = createEvaluationAnswerForm(score = -1).bindOrNull()
+            actual.shouldBeNull()
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
@@ -1,10 +1,6 @@
 package apply.ui.api
 
-import apply.application.ApplicantAndFormResponse
-import apply.application.ApplicantService
-import apply.application.ApplicationFormResponse
-import apply.application.ApplicationFormService
-import apply.application.MyApplicationFormResponse
+import apply.application.*
 import apply.createApplicationForm
 import apply.createApplicationForms
 import apply.createUser

--- a/src/test/kotlin/apply/ui/api/EvaluationTargetRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/EvaluationTargetRestControllerTest.kt
@@ -1,15 +1,7 @@
 package apply.ui.api
 
 import apply.EVALUATION_TARGET_NOTE
-import apply.application.EvaluationItemResponse
-import apply.application.EvaluationItemScoreData
-import apply.application.EvaluationTargetCsvService
-import apply.application.EvaluationTargetData
-import apply.application.EvaluationTargetResponse
-import apply.application.EvaluationTargetService
-import apply.application.GradeEvaluationResponse
-import apply.application.MailTargetResponse
-import apply.application.MailTargetService
+import apply.application.*
 import apply.createEvaluationItem
 import apply.domain.evaluationtarget.EvaluationAnswers
 import apply.domain.evaluationtarget.EvaluationStatus
@@ -26,14 +18,8 @@ import org.springframework.mock.web.MockMultipartFile
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.JsonFieldType
-import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
-import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
-import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
-import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
-import org.springframework.restdocs.request.RequestDocumentation.partWithName
-import org.springframework.restdocs.request.RequestDocumentation.pathParameters
-import org.springframework.restdocs.request.RequestDocumentation.requestParameters
-import org.springframework.restdocs.request.RequestDocumentation.requestParts
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.io.File

--- a/src/test/kotlin/apply/ui/api/RecruitmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/RecruitmentRestControllerTest.kt
@@ -18,9 +18,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.JsonFieldType
-import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
-import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
-import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.payload.PayloadDocumentation.*
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content

--- a/src/test/kotlin/apply/ui/api/UserRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/UserRestControllerTest.kt
@@ -1,13 +1,6 @@
 package apply.ui.api
 
-import apply.application.AuthenticateUserRequest
-import apply.application.EditInformationRequest
-import apply.application.EditPasswordRequest
-import apply.application.RegisterUserRequest
-import apply.application.ResetPasswordRequest
-import apply.application.UserAuthenticationService
-import apply.application.UserResponse
-import apply.application.UserService
+import apply.application.*
 import apply.application.mail.MailService
 import apply.createUser
 import apply.domain.authenticationcode.AuthenticationCode

--- a/src/test/kotlin/apply/utils/CsvGeneratorTest.kt
+++ b/src/test/kotlin/apply/utils/CsvGeneratorTest.kt
@@ -1,30 +1,31 @@
 package apply.utils
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import java.io.BufferedReader
 
-class CsvGeneratorTest {
-    @Test
-    fun `Csv 파일의 내용을 생성한다`() {
-        // given
-        val headers = arrayOf("header1", "header2", "header3")
-        val csvRows = listOf(
-            CsvRow("csvContent1", "csvContent2", "csvContent3"),
-            CsvRow("csvContent4", "csvContent5", "csvContent6"),
-            CsvRow("csvContent7", "csvContent8", "csvContent9")
-        )
+class CsvGeneratorTest : DescribeSpec({
+    describe("CsvGenerator") {
+        it("Csv 파일의 내용을 생성한다") {
+            // given
+            val headers = arrayOf("header1", "header2", "header3")
+            val csvRows = listOf(
+                    CsvRow("csvContent1", "csvContent2", "csvContent3"),
+                    CsvRow("csvContent4", "csvContent5", "csvContent6"),
+                    CsvRow("csvContent7", "csvContent8", "csvContent9")
+            )
 
-        // when
-        val actual = CsvGenerator().generateBy(headers, csvRows)
+            // when
+            val actual = CsvGenerator().generateBy(headers, csvRows)
 
-        // then
-        val expected = listOf(
-            "header1,header2,header3",
-            "csvContent1,csvContent2,csvContent3",
-            "csvContent4,csvContent5,csvContent6",
-            "csvContent7,csvContent8,csvContent9"
-        )
-        assertThat(BufferedReader(actual.reader()).readLines()).isEqualTo(expected)
+            // then
+            val expected = listOf(
+                    "header1,header2,header3",
+                    "csvContent1,csvContent2,csvContent3",
+                    "csvContent4,csvContent5,csvContent6",
+                    "csvContent7,csvContent8,csvContent9"
+            )
+            BufferedReader(actual.reader()).readLines() shouldBe expected
+        }
     }
-}
+})

--- a/src/test/kotlin/apply/utils/CsvGeneratorTest.kt
+++ b/src/test/kotlin/apply/utils/CsvGeneratorTest.kt
@@ -10,9 +10,9 @@ class CsvGeneratorTest : DescribeSpec({
             // given
             val headers = arrayOf("header1", "header2", "header3")
             val csvRows = listOf(
-                    CsvRow("csvContent1", "csvContent2", "csvContent3"),
-                    CsvRow("csvContent4", "csvContent5", "csvContent6"),
-                    CsvRow("csvContent7", "csvContent8", "csvContent9")
+                CsvRow("csvContent1", "csvContent2", "csvContent3"),
+                CsvRow("csvContent4", "csvContent5", "csvContent6"),
+                CsvRow("csvContent7", "csvContent8", "csvContent9")
             )
 
             // when
@@ -20,10 +20,10 @@ class CsvGeneratorTest : DescribeSpec({
 
             // then
             val expected = listOf(
-                    "header1,header2,header3",
-                    "csvContent1,csvContent2,csvContent3",
-                    "csvContent4,csvContent5,csvContent6",
-                    "csvContent7,csvContent8,csvContent9"
+                "header1,header2,header3",
+                "csvContent1,csvContent2,csvContent3",
+                "csvContent4,csvContent5,csvContent6",
+                "csvContent7,csvContent8,csvContent9"
             )
             BufferedReader(actual.reader()).readLines() shouldBe expected
         }


### PR DESCRIPTION
close #536 

### 작업 내용
- 단위테스트 migration 이후 남은 테스트들을 kotest 로 migration 했습니다. (#535)
- DCI 패턴을 사용한 Kotest 의 Describe Spec 으로 migration 했습니다.
- Rest Docs 과 관련된 테스트는 다음 이슈에서 migration 할 예정입니다. (#574)

### DIC 패턴이란?
- 참고 : [DCI 패턴](https://johngrib.github.io/wiki/junit5-nested/)
   
![https://user-images.githubusercontent.com/82805588/177330081-8d213f74-fa37-4492-8c40-de6920d13bf8.png](https://user-images.githubusercontent.com/82805588/177330081-8d213f74-fa37-4492-8c40-de6920d13bf8.png)

### describe Spec 의 장단점 [✅]

- (장) 형식이 자유롭다 (describe, context, it 셋 다 최상위에 위치할 수 있다.)
- (단) behaviour에 비해 형식이 간단하다.
    - DCI 는 주어진 상황과 테스트 확인에 대한 단계가 2단계이다.
    - 반면, GWT는 3단계로 이루어진다. → 좀 더 틀이 잡혀있는듯한 느낌? formal하다.

### 생성자 spec 사용시 mocking 관련 이슈

- `@MockK` 어노테이션으로 mocking을 할 수 없다.
- 직접 `mockk<Class>()` 를 해야 한다.
- 이러한 경우 `lateinit var` 를 사용할 필요가 없으니, `val`을 사용한다.
- [https://kotest.io/docs/framework/integrations/mocking.html](https://kotest.io/docs/framework/integrations/mocking.html)