### PR TITLE
feat(test): create recruitment fixture

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ repositories {
 }
 
 extra["vaadinVersion"] = "14.3.3"
-extra["kotlin-coroutines.version"] = "1.6.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -55,6 +54,7 @@ dependencies {
     asciidoctor("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testImplementation("io.kotest:kotest-runner-junit5:5.3.2")
+    testImplementation("io.rest-assured:rest-assured:3.3.0")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/apply/application/AssignmentDtos.kt
+++ b/src/main/kotlin/apply/application/AssignmentDtos.kt
@@ -27,12 +27,14 @@ data class AssignmentRequest(
 data class AssignmentData(
     val githubUsername: String,
     val pullRequestUrl: String,
-    val note: String
+    val note: String,
+    val id: Long? = 0
 ) {
     constructor(assignment: Assignment?) : this(
         assignment?.githubUsername.orEmpty(),
         assignment?.pullRequestUrl.orEmpty(),
-        assignment?.note.orEmpty()
+        assignment?.note.orEmpty(),
+        assignment?.id
     )
 }
 

--- a/src/main/kotlin/apply/application/AssignmentService.kt
+++ b/src/main/kotlin/apply/application/AssignmentService.kt
@@ -17,14 +17,15 @@ class AssignmentService(
     private val missionRepository: MissionRepository,
     private val evaluationTargetRepository: EvaluationTargetRepository
 ) {
-    fun create(missionId: Long, userId: Long, request: AssignmentRequest) {
+    fun create(missionId: Long, userId: Long, request: AssignmentRequest): Long {
         check(!assignmentRepository.existsByUserIdAndMissionId(userId, missionId)) { "이미 제출한 과제 제출물이 존재합니다." }
         val mission = missionRepository.getById(missionId)
         check(mission.isSubmitting) { "제출 불가능한 과제입니다." }
         findEvaluationTargetOf(mission.evaluationId, userId).passIfBeforeEvaluation()
-        assignmentRepository.save(
+        val assignment = assignmentRepository.save(
             Assignment(userId, missionId, request.githubUsername, request.pullRequestUrl, request.note)
         )
+        return assignment.id
     }
 
     fun update(missionId: Long, userId: Long, request: AssignmentRequest) {

--- a/src/main/kotlin/apply/application/AssignmentService.kt
+++ b/src/main/kotlin/apply/application/AssignmentService.kt
@@ -17,7 +17,7 @@ class AssignmentService(
     private val missionRepository: MissionRepository,
     private val evaluationTargetRepository: EvaluationTargetRepository
 ) {
-    fun create(missionId: Long, userId: Long, request: AssignmentRequest): Long {
+    fun create(missionId: Long, userId: Long, request: AssignmentRequest): AssignmentData {
         check(!assignmentRepository.existsByUserIdAndMissionId(userId, missionId)) { "이미 제출한 과제 제출물이 존재합니다." }
         val mission = missionRepository.getById(missionId)
         check(mission.isSubmitting) { "제출 불가능한 과제입니다." }
@@ -25,7 +25,7 @@ class AssignmentService(
         val assignment = assignmentRepository.save(
             Assignment(userId, missionId, request.githubUsername, request.pullRequestUrl, request.note)
         )
-        return assignment.id
+        return AssignmentData(assignment)
     }
 
     fun update(missionId: Long, userId: Long, request: AssignmentRequest) {

--- a/src/main/kotlin/apply/application/CheaterService.kt
+++ b/src/main/kotlin/apply/application/CheaterService.kt
@@ -18,12 +18,13 @@ class CheaterService(
         CheaterResponse(it, user)
     }
 
-    fun save(request: CheaterData) {
+    fun save(request: CheaterData): Long {
         val email = request.email
         require(!cheaterRepository.existsByEmail(email)) {
             "이미 등록된 부정 행위자입니다."
         }
-        cheaterRepository.save(Cheater(email, request.description))
+        val cheater = cheaterRepository.save(Cheater(email, request.description))
+        return cheater.id
     }
 
     fun deleteById(id: Long) {

--- a/src/main/kotlin/apply/application/CheaterService.kt
+++ b/src/main/kotlin/apply/application/CheaterService.kt
@@ -2,6 +2,7 @@ package apply.application
 
 import apply.domain.cheater.Cheater
 import apply.domain.cheater.CheaterRepository
+import apply.domain.cheater.getById
 import apply.domain.user.UserRepository
 import apply.domain.user.findByEmail
 import org.springframework.stereotype.Service
@@ -25,6 +26,10 @@ class CheaterService(
         }
         val cheater = cheaterRepository.save(Cheater(email, request.description))
         return cheater.id
+    }
+
+    fun getById(id: Long): Cheater {
+        return cheaterRepository.getById(id)
     }
 
     fun deleteById(id: Long) {

--- a/src/main/kotlin/apply/application/CheaterService.kt
+++ b/src/main/kotlin/apply/application/CheaterService.kt
@@ -19,13 +19,13 @@ class CheaterService(
         CheaterResponse(it, user)
     }
 
-    fun save(request: CheaterData): Long {
+    fun save(request: CheaterData): CheaterResponse {
         val email = request.email
         require(!cheaterRepository.existsByEmail(email)) {
             "이미 등록된 부정 행위자입니다."
         }
         val cheater = cheaterRepository.save(Cheater(email, request.description))
-        return cheater.id
+        return CheaterResponse(cheater, userRepository.findByEmail(cheater.email))
     }
 
     fun getById(id: Long): Cheater {

--- a/src/main/kotlin/apply/application/EvaluationService.kt
+++ b/src/main/kotlin/apply/application/EvaluationService.kt
@@ -16,7 +16,7 @@ class EvaluationService(
     private val evaluationItemRepository: EvaluationItemRepository,
     private val recruitmentRepository: RecruitmentRepository
 ) {
-    fun save(request: EvaluationData) {
+    fun save(request: EvaluationData): Long {
         val evaluation = evaluationRepository.save(
             Evaluation(
                 request.title,
@@ -34,6 +34,7 @@ class EvaluationService(
                 EvaluationItem(it.title, it.description, it.maximumScore, it.position, evaluation.id, it.id)
             }
         )
+        return evaluation.id
     }
 
     private fun findEvaluationItemsToDelete(evaluationId: Long, excludedItemIds: List<Long>): List<EvaluationItem> {

--- a/src/main/kotlin/apply/application/EvaluationService.kt
+++ b/src/main/kotlin/apply/application/EvaluationService.kt
@@ -16,7 +16,7 @@ class EvaluationService(
     private val evaluationItemRepository: EvaluationItemRepository,
     private val recruitmentRepository: RecruitmentRepository
 ) {
-    fun save(request: EvaluationData): Long {
+    fun save(request: EvaluationData): EvaluationData {
         val evaluation = evaluationRepository.save(
             Evaluation(
                 request.title,
@@ -34,7 +34,8 @@ class EvaluationService(
                 EvaluationItem(it.title, it.description, it.maximumScore, it.position, evaluation.id, it.id)
             }
         )
-        return evaluation.id
+        request.id = evaluation.id
+        return request
     }
 
     private fun findEvaluationItemsToDelete(evaluationId: Long, excludedItemIds: List<Long>): List<EvaluationItem> {

--- a/src/main/kotlin/apply/application/MailHistoryService.kt
+++ b/src/main/kotlin/apply/application/MailHistoryService.kt
@@ -12,8 +12,8 @@ import javax.transaction.Transactional
 class MailHistoryService(
     private val mailHistoryRepository: MailHistoryRepository
 ) {
-    fun save(request: MailData) {
-        mailHistoryRepository.save(
+    fun save(request: MailData): Long {
+        val mailHistory = mailHistoryRepository.save(
             MailHistory(
                 request.subject,
                 request.body,
@@ -22,6 +22,7 @@ class MailHistoryService(
                 request.sentTime
             )
         )
+        return mailHistory.id
     }
 
     fun findAll(): List<MailData> {

--- a/src/main/kotlin/apply/application/MailHistoryService.kt
+++ b/src/main/kotlin/apply/application/MailHistoryService.kt
@@ -12,7 +12,7 @@ import javax.transaction.Transactional
 class MailHistoryService(
     private val mailHistoryRepository: MailHistoryRepository
 ) {
-    fun save(request: MailData): Long {
+    fun save(request: MailData): MailData {
         val mailHistory = mailHistoryRepository.save(
             MailHistory(
                 request.subject,
@@ -22,7 +22,7 @@ class MailHistoryService(
                 request.sentTime
             )
         )
-        return mailHistory.id
+        return MailData(mailHistory)
     }
 
     fun findAll(): List<MailData> {

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -18,9 +18,9 @@ class MissionService(
     private val evaluationTargetRepository: EvaluationTargetRepository,
     private val assignmentRepository: AssignmentRepository
 ) {
-    fun save(request: MissionData) {
+    fun save(request: MissionData): Long {
         validate(request)
-        missionRepository.save(
+        val mission = missionRepository.save(
             request.let {
                 Mission(
                     it.title,
@@ -34,6 +34,7 @@ class MissionService(
                 )
             }
         )
+        return mission.id
     }
 
     private fun validate(request: MissionData) {

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -18,7 +18,7 @@ class MissionService(
     private val evaluationTargetRepository: EvaluationTargetRepository,
     private val assignmentRepository: AssignmentRepository
 ) {
-    fun save(request: MissionData): Long {
+    fun save(request: MissionData): MissionData {
         validate(request)
         val mission = missionRepository.save(
             request.let {
@@ -34,7 +34,8 @@ class MissionService(
                 )
             }
         )
-        return mission.id
+        request.id = mission.id
+        return request
     }
 
     private fun validate(request: MissionData) {

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -56,6 +56,10 @@ class MissionService(
         return request.id == 0L || !missionRepository.existsById(request.id)
     }
 
+    fun getById(id: Long): Mission {
+        return missionRepository.getById(id)
+    }
+
     fun getDataById(id: Long): MissionData {
         val mission = missionRepository.getById(id)
         val evaluation = evaluationRepository.getById(mission.evaluationId)

--- a/src/main/kotlin/apply/application/RecruitmentService.kt
+++ b/src/main/kotlin/apply/application/RecruitmentService.kt
@@ -17,7 +17,7 @@ class RecruitmentService(
     private val recruitmentItemRepository: RecruitmentItemRepository,
     private val termRepository: TermRepository
 ) {
-    fun save(request: RecruitmentData) {
+    fun save(request: RecruitmentData): Long {
         val recruitment = recruitmentRepository.save(
             Recruitment(
                 request.title,
@@ -37,6 +37,7 @@ class RecruitmentService(
                 RecruitmentItem(recruitment.id, it.title, it.position, it.maximumLength, it.description, it.id)
             }
         )
+        return recruitment.id
     }
 
     private fun findRecruitmentItemsToDelete(recruitmentId: Long, excludedItemIds: List<Long>): List<RecruitmentItem> {

--- a/src/main/kotlin/apply/application/RecruitmentService.kt
+++ b/src/main/kotlin/apply/application/RecruitmentService.kt
@@ -17,7 +17,7 @@ class RecruitmentService(
     private val recruitmentItemRepository: RecruitmentItemRepository,
     private val termRepository: TermRepository
 ) {
-    fun save(request: RecruitmentData): Long {
+    fun save(request: RecruitmentData): RecruitmentData {
         val recruitment = recruitmentRepository.save(
             Recruitment(
                 request.title,
@@ -37,7 +37,8 @@ class RecruitmentService(
                 RecruitmentItem(recruitment.id, it.title, it.position, it.maximumLength, it.description, it.id)
             }
         )
-        return recruitment.id
+        request.id = recruitment.id
+        return request
     }
 
     private fun findRecruitmentItemsToDelete(recruitmentId: Long, excludedItemIds: List<Long>): List<RecruitmentItem> {

--- a/src/main/kotlin/apply/application/TermService.kt
+++ b/src/main/kotlin/apply/application/TermService.kt
@@ -12,10 +12,11 @@ class TermService(
     private val termRepository: TermRepository,
     private val recruitmentRepository: RecruitmentRepository
 ) {
-    fun save(request: TermData) {
+    fun save(request: TermData): Long {
         check(request.name != Term.SINGLE.name) { "기수명은 ${Term.SINGLE.name}일 수 없습니다." }
         check(!termRepository.existsByName(request.name)) { "이미 등록된 기수명입니다." }
-        termRepository.save(request.toEntity())
+        val term = termRepository.save(request.toEntity())
+        return term.id
     }
 
     fun findAll(): List<TermResponse> {

--- a/src/main/kotlin/apply/application/TermService.kt
+++ b/src/main/kotlin/apply/application/TermService.kt
@@ -13,10 +13,11 @@ class TermService(
     private val termRepository: TermRepository,
     private val recruitmentRepository: RecruitmentRepository
 ) {
-    fun save(request: TermData): TermResponse {
+    fun save(request: TermData): TermData {
         check(request.name != Term.SINGLE.name) { "기수명은 ${Term.SINGLE.name}일 수 없습니다." }
         check(!termRepository.existsByName(request.name)) { "이미 등록된 기수명입니다." }
-        return TermResponse(termRepository.save(request.toEntity()))
+        request.id = termRepository.save(request.toEntity()).id
+        return request
     }
 
     fun getById(id: Long): Term {

--- a/src/main/kotlin/apply/application/TermService.kt
+++ b/src/main/kotlin/apply/application/TermService.kt
@@ -1,7 +1,6 @@
 package apply.application
 
 import apply.domain.recruitment.RecruitmentRepository
-import apply.domain.recruitment.getById
 import apply.domain.term.Term
 import apply.domain.term.TermRepository
 import apply.domain.term.getById
@@ -14,11 +13,10 @@ class TermService(
     private val termRepository: TermRepository,
     private val recruitmentRepository: RecruitmentRepository
 ) {
-    fun save(request: TermData): Long {
+    fun save(request: TermData): TermResponse {
         check(request.name != Term.SINGLE.name) { "기수명은 ${Term.SINGLE.name}일 수 없습니다." }
         check(!termRepository.existsByName(request.name)) { "이미 등록된 기수명입니다." }
-        val term = termRepository.save(request.toEntity())
-        return term.id
+        return TermResponse(termRepository.save(request.toEntity()))
     }
 
     fun getById(id: Long): Term {

--- a/src/main/kotlin/apply/application/TermService.kt
+++ b/src/main/kotlin/apply/application/TermService.kt
@@ -1,8 +1,10 @@
 package apply.application
 
 import apply.domain.recruitment.RecruitmentRepository
+import apply.domain.recruitment.getById
 import apply.domain.term.Term
 import apply.domain.term.TermRepository
+import apply.domain.term.getById
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,6 +19,10 @@ class TermService(
         check(!termRepository.existsByName(request.name)) { "이미 등록된 기수명입니다." }
         val term = termRepository.save(request.toEntity())
         return term.id
+    }
+
+    fun getById(id: Long): Term {
+        return termRepository.getById(id)
     }
 
     fun findAll(): List<TermResponse> {

--- a/src/main/kotlin/apply/domain/cheater/CheaterRepository.kt
+++ b/src/main/kotlin/apply/domain/cheater/CheaterRepository.kt
@@ -1,6 +1,10 @@
 package apply.domain.cheater
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.findByIdOrNull
+
+fun CheaterRepository.getById(id: Long): Cheater = findByIdOrNull(id)
+    ?: throw NoSuchElementException("부정행위자가 존재하지 않습니다. id: $id")
 
 interface CheaterRepository : JpaRepository<Cheater, Long> {
     fun existsByEmail(email: String): Boolean

--- a/src/main/kotlin/apply/ui/api/AssignmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/AssignmentRestController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 import javax.validation.Valid
 
 @RestController
@@ -28,8 +29,10 @@ class AssignmentRestController(
         @RequestBody @Valid request: AssignmentRequest,
         @LoginUser user: User
     ): ResponseEntity<Unit> {
-        assignmentService.create(missionId, user.id, request)
-        return ResponseEntity.ok().build()
+        val assignmentId = assignmentService.create(missionId, user.id, request)
+        return ResponseEntity
+            .created(URI.create("/api/recruitments/$recruitmentId/missions/$missionId/assignments/$assignmentId"))
+            .build()
     }
 
     @GetMapping("/missions/{missionId}/assignments/me")

--- a/src/main/kotlin/apply/ui/api/AssignmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/AssignmentRestController.kt
@@ -28,11 +28,11 @@ class AssignmentRestController(
         @PathVariable missionId: Long,
         @RequestBody @Valid request: AssignmentRequest,
         @LoginUser user: User
-    ): ResponseEntity<Unit> {
-        val assignmentId = assignmentService.create(missionId, user.id, request)
+    ): ResponseEntity<ApiResponse<AssignmentData>> {
+        val assignment = assignmentService.create(missionId, user.id, request)
         return ResponseEntity
-            .created(URI.create("/api/recruitments/$recruitmentId/missions/$missionId/assignments/$assignmentId"))
-            .build()
+            .created(URI.create("/api/recruitments/$recruitmentId/missions/$missionId/assignments/${assignment.id}"))
+            .body(ApiResponse.success(assignment))
     }
 
     @GetMapping("/missions/{missionId}/assignments/me")

--- a/src/main/kotlin/apply/ui/api/CheaterRestController.kt
+++ b/src/main/kotlin/apply/ui/api/CheaterRestController.kt
@@ -33,8 +33,8 @@ class CheaterRestController(
         @RequestBody request: CheaterData,
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
-        val saveId = cheaterService.save(request)
-        return ResponseEntity.created(URI.create("/api/cheaters/$saveId")).build()
+        val savedId = cheaterService.save(request)
+        return ResponseEntity.created(URI.create("/api/cheaters/$savedId")).build()
     }
 
     @DeleteMapping("/{cheaterId}")

--- a/src/main/kotlin/apply/ui/api/CheaterRestController.kt
+++ b/src/main/kotlin/apply/ui/api/CheaterRestController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("/api/cheaters")
@@ -32,8 +33,8 @@ class CheaterRestController(
         @RequestBody request: CheaterData,
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
-        cheaterService.save(request)
-        return ResponseEntity.ok().build()
+        val saveId = cheaterService.save(request)
+        return ResponseEntity.created(URI.create("/api/cheaters/$saveId")).build()
     }
 
     @DeleteMapping("/{cheaterId}")

--- a/src/main/kotlin/apply/ui/api/CheaterRestController.kt
+++ b/src/main/kotlin/apply/ui/api/CheaterRestController.kt
@@ -33,9 +33,10 @@ class CheaterRestController(
     fun save(
         @RequestBody request: CheaterData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
-        val savedId = cheaterService.save(request)
-        return ResponseEntity.created(URI.create("/api/cheaters/$savedId")).build()
+    ): ResponseEntity<ApiResponse<CheaterResponse>> {
+        val cheaterResponse = cheaterService.save(request)
+        return ResponseEntity.created(URI.create("/api/cheaters/${cheaterResponse.id}"))
+            .body(ApiResponse.success(cheaterResponse))
     }
 
     @GetMapping("/{cheaterId}")

--- a/src/main/kotlin/apply/ui/api/CheaterRestController.kt
+++ b/src/main/kotlin/apply/ui/api/CheaterRestController.kt
@@ -3,6 +3,7 @@ package apply.ui.api
 import apply.application.CheaterData
 import apply.application.CheaterResponse
 import apply.application.CheaterService
+import apply.domain.cheater.Cheater
 import apply.domain.user.User
 import apply.security.LoginUser
 import org.springframework.http.ResponseEntity
@@ -35,6 +36,15 @@ class CheaterRestController(
     ): ResponseEntity<Unit> {
         val savedId = cheaterService.save(request)
         return ResponseEntity.created(URI.create("/api/cheaters/$savedId")).build()
+    }
+
+    @GetMapping("/{cheaterId}")
+    fun findById(
+        @PathVariable cheaterId: Long,
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<ApiResponse<Cheater>> {
+        val cheater = cheaterService.getById(cheaterId)
+        return ResponseEntity.ok(ApiResponse.success(cheater))
     }
 
     @DeleteMapping("/{cheaterId}")

--- a/src/main/kotlin/apply/ui/api/EvaluationRestController.kt
+++ b/src/main/kotlin/apply/ui/api/EvaluationRestController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("/api/recruitments/{recruitmentId}/evaluations")
@@ -25,8 +26,8 @@ class EvaluationRestController(
         @RequestBody evaluationData: EvaluationData,
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
-        evaluationService.save(evaluationData)
-        return ResponseEntity.ok().build()
+        val savedId = evaluationService.save(evaluationData)
+        return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/evaluations/$savedId")).build()
     }
 
     @GetMapping("/{evaluationId}")

--- a/src/main/kotlin/apply/ui/api/EvaluationRestController.kt
+++ b/src/main/kotlin/apply/ui/api/EvaluationRestController.kt
@@ -25,9 +25,10 @@ class EvaluationRestController(
         @PathVariable recruitmentId: Long,
         @RequestBody evaluationData: EvaluationData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
-        val savedId = evaluationService.save(evaluationData)
-        return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/evaluations/$savedId")).build()
+    ): ResponseEntity<ApiResponse<EvaluationData>> {
+        val evaluation = evaluationService.save(evaluationData)
+        return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/evaluations/${evaluation.id}"))
+            .body(ApiResponse.success(evaluation))
     }
 
     @GetMapping("/{evaluationId}")

--- a/src/main/kotlin/apply/ui/api/MailHistoryRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MailHistoryRestController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 import javax.validation.Valid
 
 @RestController
@@ -24,8 +25,8 @@ class MailHistoryRestController(
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
         // todo: 파일 첨부하여 보내는 로직 필요
-        mailHistoryService.save(request)
-        return ResponseEntity.ok().build()
+        val savedId = mailHistoryService.save(request)
+        return ResponseEntity.created(URI.create("/api/mail-history/$savedId")).build()
     }
 
     @GetMapping("/{mailHistoryId}")

--- a/src/main/kotlin/apply/ui/api/MailHistoryRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MailHistoryRestController.kt
@@ -23,10 +23,11 @@ class MailHistoryRestController(
     fun save(
         @RequestBody @Valid request: MailData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
+    ): ResponseEntity<ApiResponse<MailData>> {
         // todo: 파일 첨부하여 보내는 로직 필요
-        val savedId = mailHistoryService.save(request)
-        return ResponseEntity.created(URI.create("/api/mail-history/$savedId")).build()
+        val mailData = mailHistoryService.save(request)
+        return ResponseEntity.created(URI.create("/api/mail-history/${mailData.id}"))
+            .body(ApiResponse.success(mailData))
     }
 
     @GetMapping("/{mailHistoryId}")

--- a/src/main/kotlin/apply/ui/api/MissionRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MissionRestController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("/api/recruitments/{recruitmentId}")
@@ -26,8 +27,8 @@ class MissionRestController(
         @RequestBody missionData: MissionData,
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
-        missionService.save(missionData)
-        return ResponseEntity.ok().build()
+        val saveId = missionService.save(missionData)
+        return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/missions/$saveId")).build()
     }
 
     @GetMapping("/missions")

--- a/src/main/kotlin/apply/ui/api/MissionRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MissionRestController.kt
@@ -4,6 +4,7 @@ import apply.application.MissionAndEvaluationResponse
 import apply.application.MissionData
 import apply.application.MissionResponse
 import apply.application.MissionService
+import apply.domain.mission.Mission
 import apply.domain.user.User
 import apply.security.LoginUser
 import org.springframework.http.ResponseEntity
@@ -29,6 +30,16 @@ class MissionRestController(
     ): ResponseEntity<Unit> {
         val saveId = missionService.save(missionData)
         return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/missions/$saveId")).build()
+    }
+
+    @GetMapping("/missions/{missionId}")
+    fun getById(
+        @PathVariable recruitmentId: Long,
+        @PathVariable missionId: Long,
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<ApiResponse<Mission>> {
+        val mission = missionService.getById(missionId)
+        return ResponseEntity.ok(ApiResponse.success(mission))
     }
 
     @GetMapping("/missions")

--- a/src/main/kotlin/apply/ui/api/MissionRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MissionRestController.kt
@@ -27,9 +27,10 @@ class MissionRestController(
         @PathVariable recruitmentId: Long,
         @RequestBody missionData: MissionData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
-        val saveId = missionService.save(missionData)
-        return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/missions/$saveId")).build()
+    ): ResponseEntity<ApiResponse<MissionData>> {
+        val mission = missionService.save(missionData)
+        return ResponseEntity.created(URI.create("/api/recruitments/$recruitmentId/missions/${mission.id}"))
+            .body(ApiResponse.success(mission))
     }
 
     @GetMapping("/missions/{missionId}")

--- a/src/main/kotlin/apply/ui/api/RecruitmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/RecruitmentRestController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("/api/recruitments")
@@ -48,8 +49,8 @@ class RecruitmentRestController(
         @RequestBody request: RecruitmentData,
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
-        recruitmentService.save(request)
-        return ResponseEntity.ok().build()
+        val savedId = recruitmentService.save(request)
+        return ResponseEntity.created(URI.create("/api/recruitments/$savedId")).build()
     }
 
     @DeleteMapping("/{recruitmentId}")

--- a/src/main/kotlin/apply/ui/api/RecruitmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/RecruitmentRestController.kt
@@ -48,9 +48,10 @@ class RecruitmentRestController(
     fun save(
         @RequestBody request: RecruitmentData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
-        val savedId = recruitmentService.save(request)
-        return ResponseEntity.created(URI.create("/api/recruitments/$savedId")).build()
+    ): ResponseEntity<ApiResponse<RecruitmentData>> {
+        val recruitmentData = recruitmentService.save(request)
+        return ResponseEntity.created(URI.create("/api/recruitments/${recruitmentData.id}"))
+            .body(ApiResponse.success(recruitmentData))
     }
 
     @DeleteMapping("/{recruitmentId}")

--- a/src/main/kotlin/apply/ui/api/TermRestController.kt
+++ b/src/main/kotlin/apply/ui/api/TermRestController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("/api/terms")
@@ -21,8 +22,8 @@ class TermRestController(
     fun create(
         @RequestBody termData: TermData
     ): ResponseEntity<Unit> {
-        termService.save(termData)
-        return ResponseEntity.ok().build()
+        val savedId = termService.save(termData)
+        return ResponseEntity.created(URI.create("/api/terms/$savedId")).build()
     }
 
     @GetMapping

--- a/src/main/kotlin/apply/ui/api/TermRestController.kt
+++ b/src/main/kotlin/apply/ui/api/TermRestController.kt
@@ -1,9 +1,11 @@
 package apply.ui.api
 
-import apply.application.TermResponse
 import apply.application.TermData
+import apply.application.TermResponse
 import apply.application.TermService
 import apply.domain.term.Term
+import apply.domain.user.User
+import apply.security.LoginUser
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,7 +23,8 @@ class TermRestController(
 ) {
     @PostMapping
     fun create(
-        @RequestBody termData: TermData
+        @RequestBody termData: TermData,
+        @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
         val savedId = termService.save(termData)
         return ResponseEntity.created(URI.create("/api/terms/$savedId")).build()
@@ -29,21 +32,25 @@ class TermRestController(
 
     @GetMapping("/{termId}")
     fun getById(
-        @PathVariable termId: Long
+        @PathVariable termId: Long,
+        @LoginUser(administrator = true) user: User
     ): ResponseEntity<ApiResponse<Term>> {
         val term = termService.getById(termId)
         return ResponseEntity.ok(ApiResponse.success(term))
     }
 
     @GetMapping
-    fun findAll(): ResponseEntity<ApiResponse<List<TermResponse>>> {
+    fun findAll(
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<ApiResponse<List<TermResponse>>> {
         val terms = termService.findAll()
         return ResponseEntity.ok(ApiResponse.success(terms))
     }
 
     @DeleteMapping("/{termId}")
     fun deleteById(
-        @PathVariable termId: Long
+        @PathVariable termId: Long,
+        @LoginUser(administrator = true) user: User
     ): ResponseEntity<Unit> {
         termService.deleteById(termId)
         return ResponseEntity.ok().build()

--- a/src/main/kotlin/apply/ui/api/TermRestController.kt
+++ b/src/main/kotlin/apply/ui/api/TermRestController.kt
@@ -25,7 +25,7 @@ class TermRestController(
     fun create(
         @RequestBody termData: TermData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<ApiResponse<TermResponse>> {
+    ): ResponseEntity<ApiResponse<TermData>> {
         val term = termService.save(termData)
         return ResponseEntity.created(URI.create("/api/terms/${term.id}")).body(ApiResponse.success(term))
     }

--- a/src/main/kotlin/apply/ui/api/TermRestController.kt
+++ b/src/main/kotlin/apply/ui/api/TermRestController.kt
@@ -25,9 +25,9 @@ class TermRestController(
     fun create(
         @RequestBody termData: TermData,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
-        val savedId = termService.save(termData)
-        return ResponseEntity.created(URI.create("/api/terms/$savedId")).build()
+    ): ResponseEntity<ApiResponse<TermResponse>> {
+        val term = termService.save(termData)
+        return ResponseEntity.created(URI.create("/api/terms/${term.id}")).body(ApiResponse.success(term))
     }
 
     @GetMapping("/{termId}")

--- a/src/main/kotlin/apply/ui/api/TermRestController.kt
+++ b/src/main/kotlin/apply/ui/api/TermRestController.kt
@@ -3,6 +3,7 @@ package apply.ui.api
 import apply.application.TermResponse
 import apply.application.TermData
 import apply.application.TermService
+import apply.domain.term.Term
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,6 +25,14 @@ class TermRestController(
     ): ResponseEntity<Unit> {
         val savedId = termService.save(termData)
         return ResponseEntity.created(URI.create("/api/terms/$savedId")).build()
+    }
+
+    @GetMapping("/{termId}")
+    fun getById(
+        @PathVariable termId: Long
+    ): ResponseEntity<ApiResponse<Term>> {
+        val term = termService.getById(termId)
+        return ResponseEntity.ok(ApiResponse.success(term))
     }
 
     @GetMapping

--- a/src/test/kotlin/apply/acceptance/fixture/RecruitmentFixture.kt
+++ b/src/test/kotlin/apply/acceptance/fixture/RecruitmentFixture.kt
@@ -1,0 +1,86 @@
+package apply.acceptance.fixture
+
+import apply.ui.api.ApiResponse
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import io.restassured.mapper.TypeRef
+import java.time.LocalDateTime
+
+class Recruitment(
+    val title: String,
+    val term: Term,
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime,
+    val recruitable: Boolean,
+    val hidden: Boolean,
+    val recruitmentItems: List<RecruitmentItem>
+)
+
+class RecruitmentBuilder {
+    var title: String = "웹 백엔드 3기"
+    var termId: Long = 0L
+    lateinit var term: Term
+    var startDateTime: LocalDateTime = LocalDateTime.now().minusYears(1)
+    var endDateTime: LocalDateTime = LocalDateTime.now().plusYears(1)
+    var recruitable = false
+    var hidden = true
+    var recruitmentItems: List<RecruitmentItem> = recruitmentItems {
+        recruitmentItem()
+        recruitmentItem {
+            title = "프로그래밍 학습 과정과 현재 자신이 생각하는 역량은?"
+            position = 2
+            maximumLength = 1500
+            description = "우아한테크코스는..."
+        }
+        recruitmentItem {
+            title = "프로그래밍 학습 과정과 현재 자신이 생각하는 역량은?"
+            position = 3
+            maximumLength = 2000
+            description = "우아한테크코스는..."
+        }
+    }
+
+    fun build(): Recruitment {
+        if (!::term.isInitialized) {
+            term = getTermById()
+        }
+
+        val recruitment = Recruitment(
+            title,
+            term,
+            startDateTime,
+            endDateTime,
+            recruitable,
+            hidden,
+            recruitmentItems
+        )
+
+        postRecruitment(recruitment)
+        return recruitment
+    }
+
+    private fun postRecruitment(recruitment: Recruitment) {
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(recruitment)
+            .`when`()
+            .post("/api/recruitments")
+    }
+
+    private fun getTermById(): Term {
+        return RestAssured.given()
+            .get("/api/terms/$termId")
+            .then()
+            .extract()
+            .`as`(object : TypeRef<ApiResponse<Term>>() {})
+            .body as Term
+    }
+}
+
+fun recruitment(builder: RecruitmentBuilder.() -> Unit): Recruitment {
+    return RecruitmentBuilder().apply(builder).build()
+}
+
+fun recruitment(): Recruitment {
+    return RecruitmentBuilder().build()
+}

--- a/src/test/kotlin/apply/acceptance/fixture/RecruitmentItemFixture.kt
+++ b/src/test/kotlin/apply/acceptance/fixture/RecruitmentItemFixture.kt
@@ -1,16 +1,25 @@
 package apply.acceptance.fixture
 
+import apply.application.RecruitmentItemData
+
 class RecruitmentItem(
     val title: String,
     val position: Int,
     val maximumLength: Int,
     val description: String
-)
+) {
+    constructor(recruitmentItemData: RecruitmentItemData) : this(
+        recruitmentItemData.title,
+        recruitmentItemData.position,
+        recruitmentItemData.maximumLength,
+        recruitmentItemData.description
+    )
+}
 
 class RecruitmentItemBuilder {
     var title: String = "프로그래밍 학습 과정과 현재 자신이 생각하는 역량은?"
     var position: Int = 1
-    var maximumLength = 1000
+    var maximumLength: Int = 1000
     var description: String = "우아한테크코스는..."
 
     fun build(): RecruitmentItem {

--- a/src/test/kotlin/apply/acceptance/fixture/RecruitmentItemFixture.kt
+++ b/src/test/kotlin/apply/acceptance/fixture/RecruitmentItemFixture.kt
@@ -1,0 +1,39 @@
+package apply.acceptance.fixture
+
+class RecruitmentItem(
+    val title: String,
+    val position: Int,
+    val maximumLength: Int,
+    val description: String
+)
+
+class RecruitmentItemBuilder {
+    var title: String = "프로그래밍 학습 과정과 현재 자신이 생각하는 역량은?"
+    var position: Int = 1
+    var maximumLength = 1000
+    var description: String = "우아한테크코스는..."
+
+    fun build(): RecruitmentItem {
+        return RecruitmentItem(title, position, maximumLength, description)
+    }
+}
+
+class RecruitmentItemsBuilder {
+    private var recruitmentItems = mutableListOf<RecruitmentItem>()
+
+    fun recruitmentItem(builder: RecruitmentItemBuilder.() -> Unit) {
+        recruitmentItems.add(RecruitmentItemBuilder().apply(builder).build())
+    }
+
+    fun recruitmentItem() {
+        recruitmentItems.add(RecruitmentItemBuilder().build())
+    }
+
+    fun build(): List<RecruitmentItem> {
+        return recruitmentItems
+    }
+}
+
+fun recruitmentItems(builder: RecruitmentItemsBuilder.() -> Unit): List<RecruitmentItem> {
+    return RecruitmentItemsBuilder().apply(builder).build()
+}

--- a/src/test/kotlin/apply/acceptance/fixture/TermFixture.kt
+++ b/src/test/kotlin/apply/acceptance/fixture/TermFixture.kt
@@ -1,0 +1,33 @@
+package apply.acceptance.fixture
+
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+
+class Term(val name: String, val id: Long)
+
+class TermBuilder {
+    var name: String = "단독 모집"
+    var id: Long = 0L
+
+    fun build(): Term {
+        val term = Term(name, id)
+        postTerm(term)
+        return term
+    }
+
+    private fun postTerm(term: Term) {
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .body(term)
+            .`when`()
+            .post("/api/terms")
+    }
+}
+
+fun term(builder: TermBuilder.() -> Unit): Term {
+    return TermBuilder().apply { id = 0L }.apply(builder).build()
+}
+
+fun term(): Term {
+    return TermBuilder().build()
+}

--- a/src/test/kotlin/apply/acceptance/fixture/TermFixture.kt
+++ b/src/test/kotlin/apply/acceptance/fixture/TermFixture.kt
@@ -1,9 +1,14 @@
 package apply.acceptance.fixture
 
+import apply.application.TermData
+import apply.ui.api.ApiResponse
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
+import io.restassured.mapper.TypeRef
 
-class Term(val name: String, val id: Long)
+class Term(var name: String, var id: Long) {
+    constructor(termData: TermData) : this(termData.name, termData.id)
+}
 
 class TermBuilder {
     var name: String = "단독 모집"
@@ -11,21 +16,23 @@ class TermBuilder {
 
     fun build(): Term {
         val term = Term(name, id)
-        postTerm(term)
-        return term
+        return postTerm(term)
     }
 
-    private fun postTerm(term: Term) {
-        RestAssured.given()
+    private fun postTerm(term: Term): Term {
+        val savedTermData = RestAssured.given()
             .contentType(ContentType.JSON)
             .body(term)
             .`when`()
             .post("/api/terms")
+            .`as`(object : TypeRef<ApiResponse<TermData>>() {})
+            .body as TermData
+        return Term(savedTermData)
     }
 }
 
 fun term(builder: TermBuilder.() -> Unit): Term {
-    return TermBuilder().apply { id = 0L }.apply(builder).build()
+    return TermBuilder().apply(builder).build()
 }
 
 fun term(): Term {

--- a/src/test/kotlin/apply/application/CheaterServiceTest.kt
+++ b/src/test/kotlin/apply/application/CheaterServiceTest.kt
@@ -1,9 +1,11 @@
 package apply.application
 
 import apply.createCheaterData
+import apply.createUser
 import apply.domain.cheater.Cheater
 import apply.domain.cheater.CheaterRepository
 import apply.domain.user.UserRepository
+import apply.domain.user.findByEmail
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import org.junit.jupiter.api.BeforeEach
@@ -31,6 +33,7 @@ internal class CheaterServiceTest {
         val cheaterData = createCheaterData()
         every { cheaterRepository.existsByEmail(any()) } returns false
         every { cheaterRepository.save(any()) } returns Cheater(cheaterData.email, cheaterData.description)
+        every { userRepository.findByEmail(any()) } returns createUser()
         assertDoesNotThrow { cheaterService.save(cheaterData) }
     }
 

--- a/src/test/kotlin/apply/ui/api/AssignmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/AssignmentRestControllerTest.kt
@@ -5,9 +5,7 @@ import apply.createAssignmentData
 import apply.createAssignmentRequest
 import apply.createAssignmentResponse
 import com.ninjasquad.springmockk.MockkBean
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.HttpHeaders
@@ -29,7 +27,8 @@ internal class AssignmentRestControllerTest : RestControllerTest() {
 
     @Test
     fun `과제 제출물을 제출한다`() {
-        every { assignmentService.create(any(), any(), createAssignmentRequest()) } just Runs
+        val assignmentId = 1L
+        every { assignmentService.create(any(), any(), createAssignmentRequest()) } returns assignmentId
 
         mockMvc.post(
             "/api/recruitments/{recruitmentId}/missions/{missionId}/assignments",
@@ -40,7 +39,13 @@ internal class AssignmentRestControllerTest : RestControllerTest() {
             content = objectMapper.writeValueAsString(createAssignmentRequest())
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
         }.andExpect {
-            status { isOk }
+            status { isCreated }
+            header {
+                string(
+                    HttpHeaders.LOCATION,
+                    "/api/recruitments/$recruitmentId/missions/$missionId/assignments/$assignmentId"
+                )
+            }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/AssignmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/AssignmentRestControllerTest.kt
@@ -1,9 +1,11 @@
 package apply.ui.api
 
+import apply.application.AssignmentData
 import apply.application.AssignmentService
 import apply.createAssignmentData
 import apply.createAssignmentRequest
 import apply.createAssignmentResponse
+import apply.domain.assignment.Assignment
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
@@ -27,8 +29,11 @@ internal class AssignmentRestControllerTest : RestControllerTest() {
 
     @Test
     fun `과제 제출물을 제출한다`() {
-        val assignmentId = 1L
-        every { assignmentService.create(any(), any(), createAssignmentRequest()) } returns assignmentId
+        val assignment =
+            Assignment(1L, missionId, "parang", "https://github.com/woowacourse-study/2022-kotudy/issues/47", "note")
+        val assignmentData = AssignmentData(assignment)
+
+        every { assignmentService.create(any(), any(), createAssignmentRequest()) } returns assignmentData
 
         mockMvc.post(
             "/api/recruitments/{recruitmentId}/missions/{missionId}/assignments",
@@ -43,9 +48,10 @@ internal class AssignmentRestControllerTest : RestControllerTest() {
             header {
                 string(
                     HttpHeaders.LOCATION,
-                    "/api/recruitments/$recruitmentId/missions/$missionId/assignments/$assignmentId"
+                    "/api/recruitments/$recruitmentId/missions/$missionId/assignments/${assignmentData.id}"
                 )
             }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(assignmentData))) }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/CheaterRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/CheaterRestControllerTest.kt
@@ -57,14 +57,16 @@ internal class CheaterRestControllerTest : RestControllerTest() {
     @Test
     fun `부정행위자를 추가한다`() {
         val cheaterData = createCheaterData()
-        every { cheaterService.save(cheaterData) } just Runs
+        val cheaterId = 1L
+        every { cheaterService.save(cheaterData) } returns cheaterId
 
         mockMvc.post("/api/cheaters") {
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(cheaterData)
         }.andExpect {
-            status { isOk }
+            status { isCreated }
+            header { string(HttpHeaders.LOCATION, "/api/cheaters/$cheaterId") }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/CheaterRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/CheaterRestControllerTest.kt
@@ -79,16 +79,18 @@ internal class CheaterRestControllerTest : RestControllerTest() {
     @Test
     fun `부정행위자를 추가한다`() {
         val cheaterData = createCheaterData()
-        val cheaterId = 1L
-        every { cheaterService.save(cheaterData) } returns cheaterId
+        val cheaterResponse = CheaterResponse(Cheater(cheaterData.email, cheaterData.description), createUser())
+
+        every { cheaterService.save(cheaterData) } returns cheaterResponse
 
         mockMvc.post("/api/cheaters") {
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
             contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(cheaterData)
+            content = objectMapper.writeValueAsString(cheaterResponse)
         }.andExpect {
             status { isCreated }
-            header { string(HttpHeaders.LOCATION, "/api/cheaters/$cheaterId") }
+            header { string(HttpHeaders.LOCATION, "/api/cheaters/${cheaterResponse.id}") }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(cheaterResponse))) }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/CheaterRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/CheaterRestControllerTest.kt
@@ -15,9 +15,11 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import support.createLocalDateTime
 
 @WebMvcTest(
@@ -52,6 +54,26 @@ internal class CheaterRestControllerTest : RestControllerTest() {
             status { isOk }
             content { json(objectMapper.writeValueAsString(ApiResponse.success(cheaterResponses))) }
         }
+    }
+
+    @Test
+    fun `부정행위자 id로 부정행위자를 조회한다`() {
+        val cheater = Cheater(email = cheatedUser.email, id = cheatedUser.id)
+        every { cheaterService.getById(cheater.id) } answers { cheater }
+
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get(
+                "/api/cheaters/{cheaterId}", cheater.id
+            )
+                .header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.content().json(
+                    objectMapper.writeValueAsString(
+                        ApiResponse.success(cheater)
+                    )
+                )
+            )
     }
 
     @Test

--- a/src/test/kotlin/apply/ui/api/EvaluationRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/EvaluationRestControllerTest.kt
@@ -31,16 +31,20 @@ internal class EvaluationRestControllerTest : RestControllerTest() {
 
     @Test
     fun `평가를 추가한다`() {
-        every { evaluationService.save(any()) } just Runs
+        // every { evaluationService.save(any()) } just Runs
+        val evaluationId = 1L
+        val recruitmentId = 1L
+        every { evaluationService.save(any()) } returns evaluationId
 
-        mockMvc.post("/api/recruitments/{recruitmentId}/evaluations", 1L) {
+        mockMvc.post("/api/recruitments/{recruitmentId}/evaluations", recruitmentId) {
             content = objectMapper.writeValueAsBytes(
                 EvaluationData(createEvaluation(), createRecruitment(), null, emptyList())
             )
             contentType = MediaType.APPLICATION_JSON
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
         }.andExpect {
-            status { isOk }
+            status { isCreated }
+            header { string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId/evaluations/$evaluationId") }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/EvaluationRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/EvaluationRestControllerTest.kt
@@ -25,26 +25,28 @@ import org.springframework.test.web.servlet.post
         ComponentScan.Filter(type = FilterType.REGEX, pattern = ["apply.security.*"])
     ]
 )
+
 internal class EvaluationRestControllerTest : RestControllerTest() {
     @MockkBean
     private lateinit var evaluationService: EvaluationService
 
     @Test
     fun `평가를 추가한다`() {
-        // every { evaluationService.save(any()) } just Runs
-        val evaluationId = 1L
-        val recruitmentId = 1L
-        every { evaluationService.save(any()) } returns evaluationId
+        val evaluationData = EvaluationData(createEvaluation(), createRecruitment(), null, emptyList())
+        every { evaluationService.save(any()) } returns evaluationData
 
-        mockMvc.post("/api/recruitments/{recruitmentId}/evaluations", recruitmentId) {
-            content = objectMapper.writeValueAsBytes(
-                EvaluationData(createEvaluation(), createRecruitment(), null, emptyList())
-            )
+        mockMvc.post("/api/recruitments/{recruitmentId}/evaluations", evaluationData.recruitment.id) {
+            content = objectMapper.writeValueAsBytes(evaluationData)
             contentType = MediaType.APPLICATION_JSON
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
         }.andExpect {
             status { isCreated }
-            header { string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId/evaluations/$evaluationId") }
+            header {
+                string(
+                    HttpHeaders.LOCATION,
+                    "/api/recruitments/${evaluationData.recruitment.id}/evaluations/${evaluationData.id}"
+                )
+            }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/MailHistoryRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MailHistoryRestControllerTest.kt
@@ -3,9 +3,7 @@ package apply.ui.api
 import apply.application.MailHistoryService
 import apply.createMailData
 import com.ninjasquad.springmockk.MockkBean
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.ComponentScan
@@ -27,14 +25,16 @@ class MailHistoryRestControllerTest : RestControllerTest() {
 
     @Test
     fun `이메일 이력을 저장한다`() {
-        every { mailHistoryService.save(any()) } just Runs
+        val mailHistoryId = 1L
+        every { mailHistoryService.save(any()) } returns mailHistoryId
 
         mockMvc.post("/api/mail-history") {
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(createMailData())
         }.andExpect {
-            status { isOk }
+            status { isCreated }
+            header { string(HttpHeaders.LOCATION, "/api/mail-history/$mailHistoryId") }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/MailHistoryRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MailHistoryRestControllerTest.kt
@@ -1,7 +1,9 @@
 package apply.ui.api
 
 import apply.application.MailHistoryService
+import apply.application.mail.MailData
 import apply.createMailData
+import apply.createMailHistory
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
@@ -25,8 +27,8 @@ class MailHistoryRestControllerTest : RestControllerTest() {
 
     @Test
     fun `이메일 이력을 저장한다`() {
-        val mailHistoryId = 1L
-        every { mailHistoryService.save(any()) } returns mailHistoryId
+        val mailData = MailData(createMailHistory())
+        every { mailHistoryService.save(any()) } returns mailData
 
         mockMvc.post("/api/mail-history") {
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
@@ -34,7 +36,8 @@ class MailHistoryRestControllerTest : RestControllerTest() {
             content = objectMapper.writeValueAsString(createMailData())
         }.andExpect {
             status { isCreated }
-            header { string(HttpHeaders.LOCATION, "/api/mail-history/$mailHistoryId") }
+            header { string(HttpHeaders.LOCATION, "/api/mail-history/${mailData.id}") }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(mailData))) }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
@@ -34,7 +34,8 @@ internal class MissionRestControllerTest : RestControllerTest() {
 
     @Test
     fun `과제를 추가한다`() {
-        every { missionService.save(any()) } just Runs
+        val missionId = 1L
+        every { missionService.save(any()) } returns missionId
 
         mockMvc.post(
             "/api/recruitments/{recruitmentId}/missions",
@@ -44,7 +45,8 @@ internal class MissionRestControllerTest : RestControllerTest() {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(createMissionData())
         }.andExpect {
-            status { isOk }
+            status { isCreated }
+            header { string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId/missions/$missionId") }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
@@ -36,8 +36,8 @@ internal class MissionRestControllerTest : RestControllerTest() {
 
     @Test
     fun `과제를 추가한다`() {
-        val missionId = 1L
-        every { missionService.save(any()) } returns missionId
+        val missionData = createMissionData()
+        every { missionService.save(any()) } returns missionData
 
         mockMvc.post(
             "/api/recruitments/{recruitmentId}/missions",
@@ -48,7 +48,8 @@ internal class MissionRestControllerTest : RestControllerTest() {
             content = objectMapper.writeValueAsString(createMissionData())
         }.andExpect {
             status { isCreated }
-            header { string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId/missions/$missionId") }
+            header { string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId/missions/${missionData.id}") }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(missionData))) }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
@@ -16,9 +16,11 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(
     controllers = [MissionRestController::class],
@@ -48,6 +50,27 @@ internal class MissionRestControllerTest : RestControllerTest() {
             status { isCreated }
             header { string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId/missions/$missionId") }
         }
+    }
+
+    @Test
+    fun `과제 id로 과제를 조회한다`() {
+        val mission = createMission(id = 1L)
+        every { missionService.getById(mission.id) } answers { mission }
+
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get(
+                "/api/recruitments/{recruitmentId}/missions/{missionId}",
+                recruitmentId, mission.id
+            )
+                .header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.content().json(
+                    objectMapper.writeValueAsString(
+                        ApiResponse.success(mission)
+                    )
+                )
+            )
     }
 
     @Test

--- a/src/test/kotlin/apply/ui/api/RecruitmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/RecruitmentRestControllerTest.kt
@@ -24,6 +24,7 @@ import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(
@@ -95,7 +96,8 @@ internal class RecruitmentRestControllerTest : RestControllerTest() {
 
     @Test
     fun `지원과 지원 항목을 저장한다`() {
-        every { recruitmentService.save(recruitmentData) } just Runs
+        val recruitmentId = 1L
+        every { recruitmentService.save(recruitmentData) } returns recruitmentId
 
         mockMvc.perform(
             RestDocumentationRequestBuilders.post(
@@ -104,7 +106,9 @@ internal class RecruitmentRestControllerTest : RestControllerTest() {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
                 .header(HttpHeaders.CONTENT_TYPE, "application/json")
                 .content(objectMapper.writeValueAsString(recruitmentData))
-        ).andExpect(status().isOk)
+        )
+            .andExpect(status().isCreated)
+            .andExpect(header().string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId"))
             .andDo(
                 document(
                     "recruitments-save",

--- a/src/test/kotlin/apply/ui/api/RecruitmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/RecruitmentRestControllerTest.kt
@@ -96,8 +96,7 @@ internal class RecruitmentRestControllerTest : RestControllerTest() {
 
     @Test
     fun `지원과 지원 항목을 저장한다`() {
-        val recruitmentId = 1L
-        every { recruitmentService.save(recruitmentData) } returns recruitmentId
+        every { recruitmentService.save(recruitmentData) } returns recruitmentData
 
         mockMvc.perform(
             RestDocumentationRequestBuilders.post(
@@ -108,7 +107,8 @@ internal class RecruitmentRestControllerTest : RestControllerTest() {
                 .content(objectMapper.writeValueAsString(recruitmentData))
         )
             .andExpect(status().isCreated)
-            .andExpect(header().string(HttpHeaders.LOCATION, "/api/recruitments/$recruitmentId"))
+            .andExpect(header().string(HttpHeaders.LOCATION, "/api/recruitments/${recruitmentData.id}"))
+            .andExpect(content().json(objectMapper.writeValueAsString(ApiResponse.success(recruitmentData))))
             .andDo(
                 document(
                     "recruitments-save",

--- a/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
@@ -33,7 +34,8 @@ internal class TermRestControllerTest : RestControllerTest() {
 
     @Test
     fun `기수를 생성한다`() {
-        every { termService.save(TermData("3기")) } just Runs
+        val termId = 1L
+        every { termService.save(TermData("3기")) } returns termId
 
         mockMvc.post(
             "/api/terms"
@@ -41,7 +43,8 @@ internal class TermRestControllerTest : RestControllerTest() {
             content = objectMapper.writeValueAsString(TermData("3기"))
             contentType = MediaType.APPLICATION_JSON
         }.andExpect {
-            status { isOk }
+            status { isCreated }
+            header { string(HttpHeaders.LOCATION, "/api/terms/$termId") }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
@@ -15,9 +15,11 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(
     controllers = [TermRestController::class],
@@ -46,6 +48,27 @@ internal class TermRestControllerTest : RestControllerTest() {
             status { isCreated }
             header { string(HttpHeaders.LOCATION, "/api/terms/$termId") }
         }
+    }
+
+    @Test
+    fun `기수 id로 기수를 조회한다`() {
+        val term = Term("1기", 1L)
+        every { termService.getById(term.id) } answers { term }
+
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get(
+                "/api/terms/{id}",
+                term.id
+            )
+                .header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.content().json(
+                    objectMapper.writeValueAsString(
+                        ApiResponse.success(term)
+                    )
+                )
+            )
     }
 
     @Test

--- a/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
@@ -36,8 +36,8 @@ internal class TermRestControllerTest : RestControllerTest() {
 
     @Test
     fun `기수를 생성한다`() {
-        val termId = 1L
-        every { termService.save(TermData("3기")) } returns termId
+        val termResponse = TermResponse(1L, "3기")
+        every { termService.save(TermData("3기")) } returns termResponse
 
         mockMvc.post(
             "/api/terms"
@@ -47,7 +47,8 @@ internal class TermRestControllerTest : RestControllerTest() {
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
         }.andExpect {
             status { isCreated }
-            header { string(HttpHeaders.LOCATION, "/api/terms/$termId") }
+            header { string(HttpHeaders.LOCATION, "/api/terms/${termResponse.id}") }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(termResponse))) }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
@@ -36,8 +36,8 @@ internal class TermRestControllerTest : RestControllerTest() {
 
     @Test
     fun `기수를 생성한다`() {
-        val termResponse = TermResponse(1L, "3기")
-        every { termService.save(TermData("3기")) } returns termResponse
+        val termData = TermData("3기", 1L)
+        every { termService.save(TermData("3기")) } returns termData
 
         mockMvc.post(
             "/api/terms"
@@ -47,8 +47,8 @@ internal class TermRestControllerTest : RestControllerTest() {
             header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
         }.andExpect {
             status { isCreated }
-            header { string(HttpHeaders.LOCATION, "/api/terms/${termResponse.id}") }
-            content { json(objectMapper.writeValueAsString(ApiResponse.success(termResponse))) }
+            header { string(HttpHeaders.LOCATION, "/api/terms/${termData.id}") }
+            content { json(objectMapper.writeValueAsString(ApiResponse.success(termData))) }
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/TermRestControllerTest.kt
@@ -44,6 +44,7 @@ internal class TermRestControllerTest : RestControllerTest() {
         ) {
             content = objectMapper.writeValueAsString(TermData("3기"))
             contentType = MediaType.APPLICATION_JSON
+            header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
         }.andExpect {
             status { isCreated }
             header { string(HttpHeaders.LOCATION, "/api/terms/$termId") }
@@ -78,7 +79,9 @@ internal class TermRestControllerTest : RestControllerTest() {
 
         mockMvc.get(
             "/api/terms"
-        ).andExpect {
+        ) {
+            header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
+        }.andExpect {
             status { isOk }
             content { json(objectMapper.writeValueAsString(ApiResponse.success(terms))) }
         }
@@ -91,7 +94,9 @@ internal class TermRestControllerTest : RestControllerTest() {
 
         mockMvc.delete(
             "/api/terms/{termId}", termId
-        ).andExpect {
+        ) {
+            header(HttpHeaders.AUTHORIZATION, "Bearer valid_token")
+        }.andExpect {
             status { isOk }
         }
     }


### PR DESCRIPTION
## 주의 사항
이전 PR이 머지되지 않아 커밋 기록이 조금 어지럽네요. 실제로 추가된 파일은 아래 3개 밖에 없습니다.
[TermFixture](https://github.com/woowacourse/service-apply/pull/576/files#diff-4ab5139e0b6edefdf0a8c6ad671148f8a486defafde4ea666f0c9cbd71d69dde)
[RecruitmentItemFixture](https://github.com/woowacourse/service-apply/pull/576/files#diff-4a93bdc35449ba945045f773c61d6a6015b97cbf93a21b25c16f81b9e50605f1)
[RecruitmentFixture](https://github.com/woowacourse/service-apply/pull/576/files#diff-7759436b70d9667fbdca27ae1159925b3be77a0966ef424abe7a9c4cfd5520f3)
요 세 가지 파일만 봐주시면 감사하겠습니다.

그리고 admin user 로그인은 vaddin으로 구현되어 인수테스트 픽스처에 추가하지 못했습니다. 
테스트를 돌려보시려면 `TermRestController` - `create`, `getById`, `RecruitmentRestController` - `save`의 `@LoginUser` 어노테이션을 주석처리해주세요.

감사합니다.

close #538 