### PR TITLE
feat(apply): display the message that recruitments do not exist

### DIFF
--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -84,16 +84,20 @@ const Recruits = () => {
       <div className={styles["recruitment-list-box"]}>
         {recruitment && (
           <div className={styles["recruitment-list"]} role="list">
-            {sortedRecruitment.map((recruitment) => (
-              <RecruitmentItem
-                key={recruitment.id}
-                recruitment={recruitment}
-                isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
-                buttonLabel={BUTTON_LABEL[recruitment.status]}
-                onClickButton={() => goToNewApplicationFormPage(recruitment)}
-                role="listitem"
-              />
-            ))}
+            {sortedRecruitment.length === 0 ? (
+              <div className={styles["empty-state-box"]}>텅 비었어요...</div>
+            ) : (
+              sortedRecruitment.map((recruitment) => (
+                <RecruitmentItem
+                  key={recruitment.id}
+                  recruitment={recruitment}
+                  isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
+                  buttonLabel={BUTTON_LABEL[recruitment.status]}
+                  onClickButton={() => goToNewApplicationFormPage(recruitment)}
+                  role="listitem"
+                />
+              ))
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -85,7 +85,7 @@ const Recruits = () => {
         {recruitment && (
           <div className={styles["recruitment-list"]} role="list">
             {sortedRecruitment.length === 0 ? (
-              <div className={styles["empty-state-box"]}>텅 비었어요...</div>
+              <div className={styles["empty-state-box"]}>해당하는 공고가 존재하지 않습니다.</div>
             ) : (
               sortedRecruitment.map((recruitment) => (
                 <RecruitmentItem

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -85,7 +85,7 @@ const Recruits = () => {
         {recruitment && (
           <div className={styles["recruitment-list"]} role="list">
             {sortedRecruitment.length === 0 ? (
-              <div className={styles["empty-state-box"]}>해당하는 공고가 존재하지 않습니다.</div>
+              <div className={styles["empty-state-box"]}>해당하는 모집이 없습니다.</div>
             ) : (
               sortedRecruitment.map((recruitment) => (
                 <RecruitmentItem

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -66,6 +66,17 @@
   gap: 1.125rem;
 }
 
+.empty-state-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 0;
+
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--gray-005);
+}
+
 @media screen and (max-width: 800px) {
   .tab-item {
     font-size: 0.875rem;

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -76,10 +76,7 @@
 }
 
 @media screen and (max-width: 800px) {
-  .tab-item {
-    font-size: 0.875rem;
-  }
-
+  .tab-item,
   .empty-state-box {
     font-size: 0.875rem;
   }

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -71,13 +71,16 @@
   justify-content: center;
   padding: 2rem 0;
 
-  font-size: 2rem;
   font-weight: 700;
   color: var(--gray-005);
 }
 
 @media screen and (max-width: 800px) {
   .tab-item {
+    font-size: 0.875rem;
+  }
+
+  .empty-state-box {
     font-size: 0.875rem;
   }
 

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -69,7 +69,6 @@
 .empty-state-box {
   display: flex;
   justify-content: center;
-  align-items: center;
   padding: 2rem 0;
 
   font-size: 2rem;


### PR DESCRIPTION
### 모집 과정이 존재하지 않는 경우 안내 메시지
- [기존 메시지 상수](https://github.com/woowacourse/service-apply/blob/master/frontend/src/constants/messages.js)를 참고하여 '해당하는 공고가 존재하지 않습니다.'라는 문구로 결정했습니다.

<br >

### 반영한 UI 스크린샷

<img src="https://user-images.githubusercontent.com/71116429/179665407-dcf0d4ca-52f2-45a9-94fa-196da0f4dd71.png" width="70%" alt="empty state ui screenshot" >

<br >

### 3.0.0에서 필요한 추가 작업
- 3.0.0 개발에서 메인 페이지 UI를 변경할 계획이라, 임시 디자인으로 안내 메시지를 추가했습니다. 해당 안내 메시지는 변경될 수 있습니다.
- 컴포넌트 분리 관련 리팩토링 필요
  - 모집 과정 페이지의 내부 렌더링 로직이 많이 늘어남 -> 내부 리스트 컴포넌트 분리 필요
  - RecruitmentItem에서 button 관련 props를 받아 컴포넌트에 내려주고 있음. 관련 리팩토링 필요

close #545 