### PR TITLE
feat(apply): introduce dsl for acceptance tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.mockito")
     }
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("com.ninja-squad:springmockk:3.1.2")

--- a/src/main/kotlin/apply/config/Databases.kt
+++ b/src/main/kotlin/apply/config/Databases.kt
@@ -63,7 +63,7 @@ class H2(
     entityManager: EntityManager,
     properties: DatabaseInitializationProperties
 ) : AbstractDatabase(entityManager, properties) {
-    override val metaTablesSql: String = "show tables"
+    override val metaTablesSql: String = "select table_name from information_schema.tables where table_schema = 'PUBLIC'"
     override val constraintsOffSql: String = "set referential_integrity false"
     override val constraintsOnSql: String = "set referential_integrity true"
     override fun createTruncateTableSql(tableName: String): String = "truncate table $tableName restart identity"

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,3 +1,5 @@
+spring.autoconfigure.exclude=com.vaadin.flow.spring.SpringBootAutoConfiguration
+
 spring.datasource.url=jdbc:h2:~/test;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=USER
 spring.datasource.username=sa
 

--- a/src/test/kotlin/apply/acceptance/AcceptanceDsl.kt
+++ b/src/test/kotlin/apply/acceptance/AcceptanceDsl.kt
@@ -1,0 +1,72 @@
+package apply.acceptance
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.time.LocalDateTime
+
+private val now: LocalDateTime = LocalDateTime.now()
+
+data class Recruitment(
+    var title: String = "웹 백엔드 4기",
+    var term: Term? = null,
+    var termId: Long = 0L,
+    var startDateTime: LocalDateTime = now.minusYears(1),
+    var endDateTime: LocalDateTime = now.plusYears(1),
+    var recruitable: Boolean = false,
+    var hidden: Boolean = true,
+    var recruitmentItems: List<RecruitmentItem> = emptyList(),
+    var id: Long = 0L,
+)
+
+data class RecruitmentItem(
+    var title: String = "프로그래밍 학습 과정과 현재 자신이 생각하는 역량은?",
+    var position: Int = 1,
+    var maximumLength: Int = 1000,
+    var description: String = "현재 어느 정도의 역량을 보유한 상태인지를 구체적으로 작성해 주세요.",
+    var id: Long = 0L,
+)
+
+class RecruitmentItems {
+    val items: MutableList<RecruitmentItem> = mutableListOf()
+
+    fun recruitmentItem(block: RecruitmentItem.() -> Unit = {}) {
+        items.add(RecruitmentItem().apply(block))
+    }
+}
+
+fun recruitmentItems(block: RecruitmentItems.() -> Unit): List<RecruitmentItem> {
+    return RecruitmentItems().apply(block).items
+}
+
+fun WebTestClient.recruitment(block: Recruitment.() -> Unit = {}): Recruitment {
+    val recruitment = Recruitment().apply(block)
+    if (recruitment.term == null) {
+        recruitment.term = Term(id = recruitment.termId)
+    }
+    post().uri("/api/recruitments")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(recruitment)
+        .exchange()
+        .expectStatus().isCreated()
+        .expectHeader().value(HttpHeaders.LOCATION) { recruitment.id = it.extractId() }
+    return recruitment
+}
+
+data class Term(
+    var name: String = "4기",
+    var id: Long = 0L,
+)
+
+fun WebTestClient.term(block: Term.() -> Unit = {}): Term {
+    val term = Term().apply(block)
+    post().uri("/api/terms")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(term)
+        .exchange()
+        .expectStatus().isCreated()
+        .expectHeader().value(HttpHeaders.LOCATION) { term.id = it.extractId() }
+    return term
+}
+
+private fun String.extractId(): Long = substringAfterLast("/").toLong()

--- a/src/test/kotlin/apply/acceptance/AcceptanceDslTest.kt
+++ b/src/test/kotlin/apply/acceptance/AcceptanceDslTest.kt
@@ -1,0 +1,55 @@
+package apply.acceptance
+
+import io.kotest.matchers.collections.shouldNotContainDuplicates
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import support.createLocalDateTime
+
+class AcceptanceDslTest : AcceptanceTest() {
+    init {
+        Given("기수 생성 예시") {
+            When("기수를 생성하면") {
+                val term1 = term()
+                val term2 = term {
+                    name = "5기"
+                }
+
+                Then("기수가 생성된다") {
+                    term1.id shouldNotBe term2.id
+                    term2.name shouldBe "5기"
+                }
+            }
+        }
+
+        Given("모집 생성 예시") {
+            When("모집을 생성하면") {
+                val recruitment1 = recruitment()
+                val recruitment2 = recruitment {
+                    termId = 0L
+                }
+                val recruitment3 = recruitment {
+                    title = "웹 백엔드 5기"
+                    term = term {
+                        name = "5기"
+                    }
+                    startDateTime = createLocalDateTime(2022, 10, 17)
+                    endDateTime = createLocalDateTime(2022, 10, 24)
+                    recruitmentItems = recruitmentItems {
+                        recruitmentItem {
+                            title = "프로그래밍 학습 과정과 현재 자신이 생각하는 역량은?"
+                            position = 1
+                        }
+                        recruitmentItem {
+                            title = "프로그래머가 되려는 이유는 무엇인가요?"
+                            position = 2
+                        }
+                    }
+                }
+
+                Then("모집이 생성된다") {
+                    listOf(recruitment1.id, recruitment2.id, recruitment3.id).shouldNotContainDuplicates()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/apply/acceptance/AcceptanceTest.kt
+++ b/src/test/kotlin/apply/acceptance/AcceptanceTest.kt
@@ -1,0 +1,50 @@
+package apply.acceptance
+
+import apply.config.Database
+import apply.createMember
+import apply.security.LoginMemberResolver
+import com.ninjasquad.springmockk.SpykBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.reactive.server.WebTestClient
+import support.test.TestEnvironment
+import support.test.spec.afterRootTest
+import support.test.spec.beforeRootTest
+
+@SpykBean(LoginMemberResolver::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestEnvironment
+abstract class AcceptanceTest : BehaviorSpec() {
+    @Autowired
+    lateinit var client: WebTestClient
+
+    @Autowired
+    private lateinit var database: Database
+
+    @Autowired
+    private lateinit var loginMemberResolver: LoginMemberResolver
+
+    init {
+        extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+        beforeRootTest {
+            every { loginMemberResolver.resolveArgument(any(), any(), any(), any()) } returns createMember()
+        }
+
+        afterRootTest {
+            database.clear(database.retrieveTables())
+        }
+    }
+
+    fun recruitment(block: Recruitment.() -> Unit = {}): Recruitment {
+        return client.recruitment(block)
+    }
+
+    fun term(block: Term.() -> Unit = {}): Term {
+        return client.term(block)
+    }
+}


### PR DESCRIPTION
Resolves #538 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 인수 테스트를 위한 테스트 환경 구성은 늘 복잡하고 부담이 되는 작업이었습니다. 이를 개선하기 위해 테스트 환경 구축을 위한 DSL을 도입하였습니다.

# 어떻게 해결했나요?

- 기수 및 모집 생성을 위한 인수 테스트 DSL을 구현하였습니다.
   - `Recruitment`, `RecruitmentItem`, `Term` 데이터 클래스와 빌더 DSL을 추가하였습니다.
   - 해당 모델은 인수 테스트 전용으로, DTO와 완전히 일치하지 않으며 내부 개발자보다는 외부 개발자나 QA의 시선에서 설계하였습니다.
   - `recruitment()`, `term()` 확장 함수를 통해 API 호출과 ID 추출을 일관된 형태로 처리하도록 구성하였습니다.
   - 모든 필드는 기본값이 채워져 있고, 필요한 경우 이름 있는 인자를 사용해 값만 선택적으로 지정할 수 있도록 하였습니다.
- 공통 인수 테스트 추상 클래스인 `AcceptanceTest`를 추가하였습니다.
   - 로그인 사용자 스텁과 테스트 종료 후 DB 초기화를 공통 처리하였습니다.
- 기존의 잘못된 H2 테이블 조회 방식을 수정하였습니다.
- 테스트 환경에서 Vaadin 자동 설정을 제외하였습니다.
  - `spring.autoconfigure.exclude=com.vaadin.flow.spring.SpringBootAutoConfiguration` 설정을 추가해 테스트 컨텍스트를 경량화하였습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- Kotlin DSL의 구조와 사용성이 이해하기 쉬운지 봐주세요.
- 인수 테스트 DSL이 다른 테스트에서도 재사용하기 좋은 형태인지 확인해 주세요.

## 참고 자료

- [Writing Kotlin DSLs with nested builder pattern](https://proandroiddev.com/writing-kotlin-dsls-with-nested-builder-pattern-66452476d5ef)
- [Spring Batch를 더 우아하게 사용하기 - Spring Batch Plus](https://d2.naver.com/helloworld/9879422)

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
