### PR TITLE
refactor(evaluation): refactor the code related to before evaluation

### DIFF
--- a/src/main/kotlin/apply/application/EvaluationDtos.kt
+++ b/src/main/kotlin/apply/application/EvaluationDtos.kt
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size
 
-const val NO_BEFORE_EVALUATION: String = "이전 평가 없음"
+private const val NO_BEFORE_EVALUATION: String = "이전 평가 없음"
 
 data class EvaluationSelectData(
     @field:NotBlank
@@ -24,6 +24,10 @@ data class EvaluationSelectData(
         evaluation.title,
         evaluation.id
     )
+
+    companion object {
+        fun noBefore(): EvaluationSelectData = EvaluationSelectData(NO_BEFORE_EVALUATION)
+    }
 }
 
 data class RecruitmentSelectData(
@@ -64,7 +68,7 @@ data class EvaluationData(
         title = evaluation.title,
         description = evaluation.description,
         recruitment = RecruitmentSelectData(recruitment),
-        beforeEvaluation = beforeEvaluation?.let(::EvaluationSelectData) ?: EvaluationSelectData(NO_BEFORE_EVALUATION),
+        beforeEvaluation = beforeEvaluation?.let(::EvaluationSelectData) ?: EvaluationSelectData.noBefore(),
         evaluationItems = evaluationItems.map(::EvaluationItemData),
         id = evaluation.id
     )

--- a/src/main/kotlin/apply/application/EvaluationDtos.kt
+++ b/src/main/kotlin/apply/application/EvaluationDtos.kt
@@ -12,6 +12,8 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size
 
+const val NO_BEFORE_EVALUATION: String = "이전 평가 없음"
+
 data class EvaluationSelectData(
     @field:NotBlank
     @field:Size(min = 1, max = 31)
@@ -102,14 +104,29 @@ data class EvaluationResponse(
     val description: String,
     val recruitmentId: Long,
     val beforeEvaluationId: Long
-)
+) {
+    constructor(evaluation: Evaluation) : this(
+        evaluation.id,
+        evaluation.title,
+        evaluation.description,
+        evaluation.recruitmentId,
+        evaluation.beforeEvaluationId
+    )
+}
 
 data class EvaluationGridResponse(
     val id: Long,
     val title: String,
     val recruitmentTitle: String,
     val beforeEvaluationTitle: String
-)
+) {
+    constructor(evaluation: Evaluation, recruitment: Recruitment, beforeEvaluation: Evaluation?) : this(
+        evaluation.id,
+        evaluation.title,
+        recruitment.title,
+        beforeEvaluation?.title ?: NO_BEFORE_EVALUATION
+    )
+}
 
 data class EvaluationItemResponse(
     val title: String,

--- a/src/main/kotlin/apply/application/EvaluationDtos.kt
+++ b/src/main/kotlin/apply/application/EvaluationDtos.kt
@@ -62,13 +62,7 @@ data class EvaluationData(
         title = evaluation.title,
         description = evaluation.description,
         recruitment = RecruitmentSelectData(recruitment),
-        beforeEvaluation = EvaluationSelectData(
-            beforeEvaluation ?: Evaluation(
-                title = "이전 평가 없음",
-                description = "이전 평가 없음",
-                recruitmentId = recruitment.id
-            )
-        ),
+        beforeEvaluation = beforeEvaluation?.let(::EvaluationSelectData) ?: EvaluationSelectData(NO_BEFORE_EVALUATION),
         evaluationItems = evaluationItems.map(::EvaluationItemData),
         id = evaluation.id
     )
@@ -106,27 +100,16 @@ data class EvaluationResponse(
     val id: Long,
     val title: String,
     val description: String,
-    val recruitmentTitle: String,
     val recruitmentId: Long,
-    val beforeEvaluationTitle: String = "",
-    val beforeEvaluationId: Long = 0L
-) {
-    constructor(
-        evaluation: Evaluation,
-        recruitmentTitle: String,
-        recruitmentId: Long,
-        beforeEvaluationTitle: String,
-        beforeEvaluationId: Long
-    ) : this(
-        evaluation.id,
-        evaluation.title,
-        evaluation.description,
-        recruitmentTitle,
-        recruitmentId,
-        beforeEvaluationTitle,
-        beforeEvaluationId
-    )
-}
+    val beforeEvaluationId: Long
+)
+
+data class EvaluationGridResponse(
+    val id: Long,
+    val title: String,
+    val recruitmentTitle: String,
+    val beforeEvaluationTitle: String
+)
 
 data class EvaluationItemResponse(
     val title: String,

--- a/src/main/kotlin/apply/application/EvaluationService.kt
+++ b/src/main/kotlin/apply/application/EvaluationService.kt
@@ -62,11 +62,6 @@ class EvaluationService(
         }
     }
 
-    fun findById(id: Long): Evaluation? {
-        if (id == 0L) return null
-        return evaluationRepository.getById(id)
-    }
-
     fun deleteById(id: Long) {
         evaluationRepository.deleteById(id)
         resetBeforeEvaluationContain(id)
@@ -88,6 +83,11 @@ class EvaluationService(
         val recruitment = recruitmentRepository.getOne(evaluation.recruitmentId)
         val beforeEvaluation = findById(evaluation.beforeEvaluationId)
         return EvaluationData(evaluation, recruitment, beforeEvaluation, evaluationItems)
+    }
+
+    private fun findById(id: Long): Evaluation? {
+        if (id == 0L) return null
+        return evaluationRepository.getById(id)
     }
 
     fun findAllRecruitmentSelectData(): List<RecruitmentSelectData> {

--- a/src/main/kotlin/apply/application/EvaluationService.kt
+++ b/src/main/kotlin/apply/application/EvaluationService.kt
@@ -10,6 +10,8 @@ import apply.domain.recruitment.getById
 import org.springframework.stereotype.Service
 import javax.transaction.Transactional
 
+const val NO_BEFORE_EVALUATION: String = "이전 평가 없음"
+
 @Transactional
 @Service
 class EvaluationService(
@@ -36,11 +38,11 @@ class EvaluationService(
             }
         )
         return EvaluationResponse(
-            evaluation,
-            request.recruitment.title,
-            request.recruitment.id,
-            request.beforeEvaluation.title,
-            request.beforeEvaluation.id
+            evaluation.id,
+            evaluation.title,
+            evaluation.description,
+            evaluation.recruitmentId,
+            evaluation.beforeEvaluationId
         )
     }
 
@@ -55,24 +57,21 @@ class EvaluationService(
         val recruitment = recruitmentRepository.getById(evaluation.recruitmentId)
         val beforeEvaluation = findById(evaluation.beforeEvaluationId)
         return EvaluationResponse(
-            evaluation,
-            recruitment.title,
+            evaluation.id,
+            evaluation.title,
+            evaluation.description,
             recruitment.id,
-            beforeEvaluation?.title ?: "이전 평가 없음",
             beforeEvaluation?.id ?: 0
         )
     }
 
-    fun findAllWithRecruitment(): List<EvaluationResponse> {
+    fun findAllWithRecruitment(): List<EvaluationGridResponse> {
         return evaluationRepository.findAll().map {
-            EvaluationResponse(
+            EvaluationGridResponse(
                 it.id,
                 it.title,
-                it.description,
                 recruitmentRepository.getOne(it.recruitmentId).title,
-                it.recruitmentId,
-                findById(it.beforeEvaluationId)?.title ?: "이전 평가 없음",
-                it.beforeEvaluationId
+                findById(it.beforeEvaluationId)?.title ?: NO_BEFORE_EVALUATION
             )
         }
     }

--- a/src/main/kotlin/apply/application/EvaluationService.kt
+++ b/src/main/kotlin/apply/application/EvaluationService.kt
@@ -73,10 +73,6 @@ class EvaluationService(
             .forEach { it.resetBeforeEvaluation() }
     }
 
-    fun findAllByRecruitmentId(recruitmentId: Long): List<Evaluation> {
-        return evaluationRepository.findAllByRecruitmentId(recruitmentId)
-    }
-
     fun getDataById(id: Long): EvaluationData {
         val evaluation = evaluationRepository.getById(id)
         val evaluationItems = evaluationItemRepository.findByEvaluationIdOrderByPosition(evaluation.id)
@@ -96,7 +92,7 @@ class EvaluationService(
             .sortedByDescending { it.id }
     }
 
-    fun getAllSelectDataByRecruitmentId(id: Long): List<EvaluationSelectData> {
-        return findAllByRecruitmentId(id).map { EvaluationSelectData(it) }
+    fun getAllSelectDataByRecruitmentId(recruitmentId: Long): List<EvaluationSelectData> {
+        return evaluationRepository.findAllByRecruitmentId(recruitmentId).map(::EvaluationSelectData)
     }
 }

--- a/src/main/kotlin/apply/ui/admin/evaluation/EvaluationForm.kt
+++ b/src/main/kotlin/apply/ui/admin/evaluation/EvaluationForm.kt
@@ -3,7 +3,6 @@ package apply.ui.admin.evaluation
 import apply.application.EvaluationData
 import apply.application.EvaluationItemData
 import apply.application.EvaluationSelectData
-import apply.application.NO_BEFORE_EVALUATION
 import apply.application.RecruitmentSelectData
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.select.Select
@@ -39,7 +38,7 @@ class EvaluationForm() : BindingIdentityFormLayout<EvaluationData>(EvaluationDat
     ) : this() {
         recruitment.setItems(recruitments)
         recruitment.addValueChangeListener {
-            val evaluations = listOf(EvaluationSelectData(NO_BEFORE_EVALUATION)) + listener(it.value.id)
+            val evaluations = listOf(EvaluationSelectData.noBefore()) + listener(it.value.id)
             beforeEvaluation.setItems(evaluations)
         }
     }

--- a/src/main/kotlin/apply/ui/admin/evaluation/EvaluationForm.kt
+++ b/src/main/kotlin/apply/ui/admin/evaluation/EvaluationForm.kt
@@ -3,8 +3,8 @@ package apply.ui.admin.evaluation
 import apply.application.EvaluationData
 import apply.application.EvaluationItemData
 import apply.application.EvaluationSelectData
+import apply.application.NO_BEFORE_EVALUATION
 import apply.application.RecruitmentSelectData
-import apply.domain.evaluation.Evaluation
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.select.Select
 import com.vaadin.flow.component.textfield.TextArea
@@ -39,16 +39,8 @@ class EvaluationForm() : BindingIdentityFormLayout<EvaluationData>(EvaluationDat
     ) : this() {
         recruitment.setItems(recruitments)
         recruitment.addValueChangeListener {
-            val evaluations: List<EvaluationSelectData> = mutableListOf(
-                EvaluationSelectData(
-                    Evaluation(
-                        title = "이전 평가 없음",
-                        description = "이전 평가 없음",
-                        recruitmentId = it.value.id
-                    )
-                )
-            )
-            beforeEvaluation.setItems(evaluations.plus(listener(it.value.id)))
+            val evaluations = listOf(EvaluationSelectData(NO_BEFORE_EVALUATION)) + listener(it.value.id)
+            beforeEvaluation.setItems(evaluations)
         }
     }
 

--- a/src/main/kotlin/apply/ui/admin/evaluation/EvaluationsView.kt
+++ b/src/main/kotlin/apply/ui/admin/evaluation/EvaluationsView.kt
@@ -1,6 +1,6 @@
 package apply.ui.admin.evaluation
 
-import apply.application.EvaluationResponse
+import apply.application.EvaluationGridResponse
 import apply.application.EvaluationService
 import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
@@ -45,16 +45,16 @@ class EvaluationsView(private val evaluationService: EvaluationService) : Vertic
     }
 
     private fun createGrid(): Component {
-        return Grid<EvaluationResponse>(10).apply {
-            addSortableColumn("평가명", EvaluationResponse::title)
-            addSortableColumn("모집명", EvaluationResponse::recruitmentTitle)
-            addSortableColumn("이전 평가명", EvaluationResponse::beforeEvaluationTitle)
+        return Grid<EvaluationGridResponse>(10).apply {
+            addSortableColumn("평가명", EvaluationGridResponse::title)
+            addSortableColumn("모집명", EvaluationGridResponse::recruitmentTitle)
+            addSortableColumn("이전 평가명", EvaluationGridResponse::beforeEvaluationTitle)
             addColumn(createEditAndDeleteButton()).apply { isAutoWidth = true }
             setItems(evaluationService.findAllWithRecruitment())
         }
     }
 
-    private fun createEditAndDeleteButton(): Renderer<EvaluationResponse> {
+    private fun createEditAndDeleteButton(): Renderer<EvaluationGridResponse> {
         return ComponentRenderer { evaluationResponse ->
             HorizontalLayout(
                 createPrimarySmallButton("수정") {

--- a/src/main/kotlin/apply/ui/admin/mail/GroupMailTargetDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/mail/GroupMailTargetDialog.kt
@@ -1,11 +1,11 @@
 package apply.ui.admin.mail
 
+import apply.application.EvaluationSelectData
 import apply.application.EvaluationService
 import apply.application.MailTargetResponse
 import apply.application.MailTargetService
 import apply.application.RecruitmentResponse
 import apply.application.RecruitmentService
-import apply.domain.evaluation.Evaluation
 import apply.domain.evaluationtarget.EvaluationStatus
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.button.Button
@@ -55,7 +55,7 @@ class GroupMailTargetDialog(
     }
 
     private fun createSearchFilter(): HorizontalLayout {
-        val evaluationItem = createItemSelect<Evaluation>("평가")
+        val evaluationItem = createItemSelect<EvaluationSelectData>("평가")
         return HorizontalLayout(
             createRecruitmentItem(evaluationItem), evaluationItem, createEvaluationStatusItem(evaluationItem),
         ).apply {
@@ -63,13 +63,13 @@ class GroupMailTargetDialog(
         }
     }
 
-    private fun createRecruitmentItem(evaluationItem: Select<Evaluation>): Select<RecruitmentResponse> {
+    private fun createRecruitmentItem(evaluationItem: Select<EvaluationSelectData>): Select<RecruitmentResponse> {
         return createItemSelect<RecruitmentResponse>("모집").apply {
             setItems(*recruitmentService.findAll().toTypedArray())
             setItemLabelGenerator { it.title }
             addValueChangeListener {
                 evaluationItem.apply {
-                    setItems(*evaluationService.findAllByRecruitmentId(it.value.id).toTypedArray())
+                    setItems(*evaluationService.getAllSelectDataByRecruitmentId(it.value.id).toTypedArray())
                     setItemLabelGenerator { it.title }
                 }
             }
@@ -77,7 +77,7 @@ class GroupMailTargetDialog(
     }
 
     private fun createEvaluationStatusItem(
-        evaluationItem: Select<Evaluation>
+        evaluationItem: Select<EvaluationSelectData>
     ): Select<EvaluationStatus> {
         return createItemSelect<EvaluationStatus>("평가 상태").apply {
             val descriptionTooltip = TooltipConfiguration("평가되지 않은 탈락자는 나오지 않습니다.").apply { trigger = "mouseenter" }

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -3,6 +3,7 @@ package apply.ui.admin.selections
 import apply.application.ApplicantAndFormResponse
 import apply.application.ApplicantService
 import apply.application.AssignmentService
+import apply.application.EvaluationSelectData
 import apply.application.EvaluationService
 import apply.application.EvaluationTargetCsvService
 import apply.application.EvaluationTargetResponse
@@ -11,7 +12,6 @@ import apply.application.ExcelService
 import apply.application.RecruitmentItemService
 import apply.application.RecruitmentService
 import apply.domain.applicationform.ApplicationForm
-import apply.domain.evaluation.Evaluation
 import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.Text
@@ -59,7 +59,8 @@ class SelectionView(
     private val evaluationTargetCsvService: EvaluationTargetCsvService
 ) : VerticalLayout(), HasUrlParameter<Long> {
     private var recruitmentId: Long = 0L
-    private var evaluations: List<Evaluation> = evaluationService.findAllByRecruitmentId(recruitmentId)
+    private var evaluations: List<EvaluationSelectData> =
+        evaluationService.getAllSelectDataByRecruitmentId(recruitmentId)
     private var tabs: Tabs = Tabs()
     private var selectedTabIndex: Int = 0
     private var evaluationFileButtons: HorizontalLayout = createEvaluationFileButtons()
@@ -118,11 +119,10 @@ class SelectionView(
         val userResponses = applicantService.findAllByRecruitmentIdAndKeyword(recruitmentId, keyword)
         tabsToGrids[Tab(TOTAL_APPLIED_USER_LABEL)] = createTotalUsersGrid(userResponses)
 
-        evaluations = evaluationService.findAllByRecruitmentId(recruitmentId)
+        evaluations = evaluationService.getAllSelectDataByRecruitmentId(recruitmentId)
         for (evaluation in evaluations) {
-            val evaluationTargetResponses =
-                evaluationTargetService.findAllByEvaluationIdAndKeyword(evaluation.id, keyword)
-            tabsToGrids[Tab(evaluation.title)] = createEvaluationTargetsGrid(evaluationTargetResponses)
+            val responses = evaluationTargetService.findAllByEvaluationIdAndKeyword(evaluation.id, keyword)
+            tabsToGrids[Tab(evaluation.title)] = createEvaluationTargetsGrid(responses)
         }
         return tabsToGrids
     }

--- a/src/main/kotlin/apply/ui/api/EvaluationRestController.kt
+++ b/src/main/kotlin/apply/ui/api/EvaluationRestController.kt
@@ -1,6 +1,7 @@
 package apply.ui.api
 
 import apply.application.EvaluationData
+import apply.application.EvaluationGridResponse
 import apply.application.EvaluationResponse
 import apply.application.EvaluationService
 import apply.domain.user.User
@@ -45,7 +46,7 @@ class EvaluationRestController(
     fun findAllWithRecruitment(
         @PathVariable recruitmentId: Long,
         @LoginUser(administrator = true) user: User
-    ): ResponseEntity<ApiResponse<List<EvaluationResponse>>> {
+    ): ResponseEntity<ApiResponse<List<EvaluationGridResponse>>> {
         val responses = evaluationService.findAllWithRecruitment()
         return ResponseEntity.ok(ApiResponse.success(responses))
     }

--- a/src/main/kotlin/apply/ui/api/ExcelController.kt
+++ b/src/main/kotlin/apply/ui/api/ExcelController.kt
@@ -45,10 +45,10 @@ class ExcelController(
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<InputStreamResource> {
         val excel = excelService.createTargetExcel(evaluationId)
-        val evaluation = evaluationService.findById(evaluationId)
+        val evaluation = evaluationService.getById(evaluationId)
         val headers = HttpHeaders().apply {
             contentDisposition = ContentDisposition.builder("attachment")
-                .filename("${evaluation?.title}.xlsx")
+                .filename("${evaluation.title}.xlsx")
                 .build()
         }
         return ResponseEntity.ok()

--- a/src/test/kotlin/apply/application/EvaluationServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationServiceTest.kt
@@ -3,7 +3,6 @@ package apply.application
 import apply.createEvaluation
 import apply.createRecruitment
 import apply.domain.evaluation.EvaluationRepository
-import apply.domain.evaluation.getById
 import apply.domain.evaluationItem.EvaluationItemRepository
 import apply.domain.recruitment.RecruitmentRepository
 import io.kotest.core.spec.style.BehaviorSpec
@@ -31,10 +30,7 @@ class EvaluationServiceTest : BehaviorSpec({
         val evaluation3 = createEvaluation(title = "평가3", recruitmentId = 2L, beforeEvaluationId = 0L, id = 3L)
 
         every { evaluationRepository.findAll() } returns listOf(evaluation1, evaluation2, evaluation3)
-        every { recruitmentRepository.getOne(1L) } returns recruitment1
-        every { recruitmentRepository.getOne(2L) } returns recruitment2
-        every { evaluationRepository.getById(1L) } returns evaluation1
-        every { evaluationRepository.getById(2L) } returns evaluation2
+        every { recruitmentRepository.findAllById(any()) } returns listOf(recruitment1, recruitment2)
 
         When("모든 평가를 모집과 함께 조회하면") {
             val actual = evaluationService.findAllWithRecruitment()

--- a/src/test/kotlin/apply/application/EvaluationServiceTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationServiceTest.kt
@@ -40,9 +40,9 @@ class EvaluationServiceTest : BehaviorSpec({
             val actual = evaluationService.findAllWithRecruitment()
 
             Then("모집명과 평가명을 확인할 수 있다") {
-                actual[0] shouldBe EvaluationResponse(evaluation1, "모집1", 1L, "이전 평가 없음", 0L)
-                actual[1] shouldBe EvaluationResponse(evaluation2, "모집1", 1L, "평가1", 1L)
-                actual[2] shouldBe EvaluationResponse(evaluation3, "모집2", 2L, "이전 평가 없음", 0L)
+                actual[0] shouldBe EvaluationGridResponse(evaluation1.id, "평가1", "모집1", "이전 평가 없음")
+                actual[1] shouldBe EvaluationGridResponse(evaluation2.id, "평가2", "모집1", "평가1")
+                actual[2] shouldBe EvaluationGridResponse(evaluation3.id, "평가3", "모집2", "이전 평가 없음")
             }
         }
     }

--- a/src/test/kotlin/apply/ui/api/EvaluationRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/EvaluationRestControllerTest.kt
@@ -1,6 +1,7 @@
 package apply.ui.api
 
 import apply.application.EvaluationData
+import apply.application.EvaluationGridResponse
 import apply.application.EvaluationResponse
 import apply.application.EvaluationService
 import apply.createEvaluation
@@ -23,7 +24,7 @@ class EvaluationRestControllerTest : RestControllerTest() {
 
     @Test
     fun `평가를 추가한다`() {
-        val response = EvaluationResponse(1L, "평가1", "평가1 설명", "우테코 3기 백엔드", 4L)
+        val response = EvaluationResponse(1L, "평가1", "평가1 설명", recruitmentId = 4L, beforeEvaluationId = 2L)
         every { evaluationService.save(any()) } returns response
 
         mockMvc.post("/api/recruitments/{recruitmentId}/evaluations", 1L) {
@@ -37,7 +38,7 @@ class EvaluationRestControllerTest : RestControllerTest() {
 
     @Test
     fun `특정 평가를 조회한다`() {
-        val response = EvaluationResponse(1L, "평가1", "평가1 설명", "우테코 3기 백엔드", 4L)
+        val response = EvaluationResponse(1L, "평가1", "평가1 설명", recruitmentId = 4L, beforeEvaluationId = 2L)
         every { evaluationService.getById(any()) } returns response
 
         mockMvc.get("/api/recruitments/{recruitmentId}/evaluations/{evaluationId}", 1L, 1L) {
@@ -51,8 +52,8 @@ class EvaluationRestControllerTest : RestControllerTest() {
     @Test
     fun `모든 (상세한) 평가를 조회한다`() {
         val responses = listOf(
-            EvaluationResponse(1L, "평가1", "평가1 설명", "우테코 3기 백엔드", 4L),
-            EvaluationResponse(2L, "평가2", "평가2 설명", "우테코 3기 프론트", 5L)
+            EvaluationGridResponse(1L, "평가1", "우테코 3기 백엔드", "이전 평가 없음"),
+            EvaluationGridResponse(2L, "평가2", "우테코 3기 프론트", "평가1")
         )
         every { evaluationService.findAllWithRecruitment() } returns responses
 


### PR DESCRIPTION
Resolves #580
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- `이전 평가 없음`이라는 문자열이 평가(evaluation)와 관련된 코드에서 자주 반복되고 있었습니다. 또한, 관리자 페이지 화면에서는 보이지 않는데 View 코드에서는 더 많은 데이터를 가지고 있었습니다.

# 어떻게 해결했나요?

- `이전 평가 없음` 문자열을 `EvaluationDtos`에서 상수로 선언하여 사용하도록 변경하였습니다.
- 관리자 평가 페이지에서 보여주는 정보보다 View에서 응답으로 불필요하게 더 많은 데이터를 받지 않도록 평가와 관련된 service, dto, view의 코드를 전반적으로 리팩터링하였습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- `EvaluationDtos`보다 상수화가 더 적합하다고 생각하는 위치가 있다면 알려주세요.
- 관리자 평가 페이지와 비교해서 사용되지 않는데 View 클래스에서 불필요하게 많은 데이터를 응답을 받는 경우가 있다면 알려주세요.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)