### PR TITLE
feat(apply): change the style of the recruitment list

### DIFF
--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,5 +1,5 @@
 {
   "printWidth": 100,
   "singleQuote": false,
-  "endOfLine": "lf"
+  "endOfLine": "auto"
 }

--- a/frontend/src/components/@common/StatusIndicator/StatusIndicator.module.css
+++ b/frontend/src/components/@common/StatusIndicator/StatusIndicator.module.css
@@ -1,0 +1,23 @@
+.statusIndicator-box {
+  text-align: right;
+  min-width: 5rem;
+}
+.statusIndicator {
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  text-align: right;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  user-select: none;
+
+  background: var(--gray-002);
+  color: var(--gray-006);
+  font-weight: bold;
+}
+
+.active {
+  background-color: var(--gray-002);
+  color: var(--blue);
+}

--- a/frontend/src/components/@common/StatusIndicator/StatusIndicator.stories.tsx
+++ b/frontend/src/components/@common/StatusIndicator/StatusIndicator.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import StatusIndicator, { StatusIndicatorProps } from "./StatusIndicator";
+
+export default {
+  title: "components/StatusIndicator",
+  component: StatusIndicator,
+} as ComponentMeta<typeof StatusIndicator>;
+
+const Template: ComponentStory<typeof StatusIndicator> = (args: StatusIndicatorProps) => (
+  <StatusIndicator {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  text: "지원하기",
+  active: true,
+};
+
+export const ClosedRecruitment = Template.bind({});
+ClosedRecruitment.args = {
+  text: "모집종료",
+  active: false,
+};

--- a/frontend/src/components/@common/StatusIndicator/StatusIndicator.tsx
+++ b/frontend/src/components/@common/StatusIndicator/StatusIndicator.tsx
@@ -1,0 +1,23 @@
+import classNames from "classnames";
+import styles from "./StatusIndicator.module.css";
+
+export type StatusIndicatorProps = {
+  text: string;
+  className: string;
+  active: boolean;
+};
+
+const StatusIndicator = ({ text, className, active, ...props }: StatusIndicatorProps) => {
+  return (
+    <span className={styles["statusIndicator-box"]}>
+      <span
+        className={classNames(className, styles.statusIndicator, active ? styles.active : "")}
+        {...props}
+      >
+        {text}
+      </span>
+    </span>
+  );
+};
+
+export default StatusIndicator;

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.js
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.js
@@ -1,19 +1,23 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import CalendarIcon from "../../assets/icon/calendar-icon.svg";
+import { RECRUITMENT_STATUS } from "../../constants/recruitment";
 import { formatDateTime } from "../../utils/format/date";
-import Button from "../@common/Button/Button";
+import StatusIndicator from "../@common/StatusIndicator/StatusIndicator";
 import styles from "./RecruitmentItem.module.css";
 
-const RecruitmentItem = ({
-  recruitment,
-  buttonLabel,
-  isButtonDisabled,
-  onClickButton,
-  className,
-  ...props
-}) => {
+const INDICATOR_LABEL = {
+  [RECRUITMENT_STATUS.RECRUITING]: "모집 중",
+  [RECRUITMENT_STATUS.RECRUITABLE]: "모집 예정",
+  [RECRUITMENT_STATUS.UNRECRUITABLE]: "일시 중지",
+  [RECRUITMENT_STATUS.ENDED]: "모집 종료",
+};
+
+const RecruitmentItem = ({ recruitment, onClickButton, className, ...props }) => {
+  const active = recruitment.status === RECRUITMENT_STATUS.RECRUITING;
+  const indicatorText = INDICATOR_LABEL[recruitment.status];
+
   const formattedStartDateTime = useMemo(
     () => (recruitment.startDateTime ? formatDateTime(new Date(recruitment.startDateTime)) : ""),
     [recruitment.startDateTime]
@@ -25,24 +29,19 @@ const RecruitmentItem = ({
   );
 
   return (
-    <div className={classNames(styles["content-wrapper"], className)} {...props}>
-      <div className={styles["text-container"]}>
-        <p className={styles.title}>
-          <strong>{recruitment.title}</strong>
+    <div
+      className={classNames(styles["content-wrapper"], className, active ? styles.active : "")}
+      {...props}
+      onClick={active ? onClickButton : () => {}}
+    >
+      <h4 className={classNames(styles.title)}>{recruitment.title}</h4>
+      <div className={styles.date}>
+        <img src={CalendarIcon} alt="달력 아이콘" className={styles.icon} />
+        <p>
+          {formattedStartDateTime} ~ {formattedEndDateTime}
         </p>
-        <div className={styles.date}>
-          <img src={CalendarIcon} alt="달력 아이콘" className={styles.icon} />
-          <p>
-            {formattedStartDateTime} ~ {formattedEndDateTime}
-          </p>
-        </div>
       </div>
-
-      {buttonLabel && (
-        <Button className={styles.button} disabled={isButtonDisabled} onClick={onClickButton}>
-          {buttonLabel}
-        </Button>
-      )}
+      {indicatorText && <StatusIndicator active={active} text={indicatorText} />}
     </div>
   );
 };
@@ -51,8 +50,6 @@ export default RecruitmentItem;
 
 RecruitmentItem.propTypes = {
   recruitment: PropTypes.object.isRequired,
-  buttonLabel: PropTypes.string,
-  isButtonDisabled: PropTypes.bool,
   onClickButton: PropTypes.func,
   className: PropTypes.string,
 };

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
@@ -4,37 +4,54 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.25rem 1.5rem 1rem;
+  padding: 1.5rem 1rem;
   background-color: var(--white);
-  border: 1px solid var(--gray-003);
+
+  color: var(--gray-004);
+  cursor: default;
+}
+
+.active {
+  color: var(--black);
+  cursor: pointer;
+}
+
+.content-wrapper.active:hover {
+  background-color: var(--gray-002);
+  transition: 300ms ease-in-out;
 }
 
 .text-container {
   display: flex;
-  flex-direction: column;
   gap: 0.875rem;
 }
 
 .title {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   font-weight: bold;
+  min-width: 10rem;
 }
 
 .date {
   display: flex;
   align-items: center;
+  font-size: 1rem;
   gap: 0.5rem;
   color: var(--gray-008);
 }
 
-.button {
-  min-width: 6rem;
+.icon {
+  width: 1rem;
 }
 
 @media screen and (max-width: 513px) {
+  .title {
+    font-size: 1rem;
+    min-width: 8rem;
+  }
   .date {
     gap: 0.25rem;
-    font-size: 0.875rem;
+    font-size: 0.6rem;
   }
 
   .icon {

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.stories.js
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.stories.js
@@ -1,4 +1,3 @@
-import React from "react";
 import RecruitmentItem from "./RecruitmentItem";
 
 export default {
@@ -21,12 +20,11 @@ Default.args = {
 export const WithButton = Template.bind({});
 
 WithButton.args = {
-  buttonLabel: "라벨",
-  activeButton: false,
-  onClick: () => {},
+  onClickButton: () => {},
   recruitment: {
     title: "제목",
     startDateTime: "2021-07-20 10:00:00",
     endDateTime: "2021-07-20 20:00:00",
+    status: "RECRUITING",
   },
 };

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -1,21 +1,13 @@
 import classNames from "classnames";
-import React, { useMemo } from "react";
-import { generatePath, Link, useNavigate, useLocation } from "react-router-dom";
+import { useMemo } from "react";
+import { generatePath, Link, useLocation, useNavigate } from "react-router-dom";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
-import { PATH, PARAM } from "../../constants/path";
-import { RECRUITMENT_STATUS } from "../../constants/recruitment";
+import { PARAM, PATH } from "../../constants/path";
 import { RECRUITS_TAB, RECRUITS_TAB_LIST } from "../../constants/tab";
 import useRecruitmentContext from "../../hooks/useRecruitmentContext";
 import useTokenContext from "../../hooks/useTokenContext";
 import { generateQuery } from "../../utils/route/query";
 import styles from "./Recruits.module.css";
-
-const BUTTON_LABEL = {
-  [RECRUITMENT_STATUS.RECRUITING]: "지원하기",
-  [RECRUITMENT_STATUS.RECRUITABLE]: "모집 예정",
-  [RECRUITMENT_STATUS.UNRECRUITABLE]: "일시 중지",
-  [RECRUITMENT_STATUS.ENDED]: "모집 종료",
-};
 
 const Recruits = () => {
   const { token } = useTokenContext();
@@ -97,8 +89,6 @@ const Recruits = () => {
                 <RecruitmentItem
                   key={recruitment.id}
                   recruitment={recruitment}
-                  isButtonDisabled={recruitment.status !== RECRUITMENT_STATUS.RECRUITING}
-                  buttonLabel={BUTTON_LABEL[recruitment.status]}
                   onClickButton={() => goToNewApplicationFormPage(recruitment)}
                   role="listitem"
                 />

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -63,7 +63,7 @@
 .recruitment-list {
   display: flex;
   flex-direction: column;
-  gap: 1.125rem;
+  gap: 0.625rem;
 }
 
 .empty-state-box {

--- a/frontend/src/pages/Recruits/Recruits.stories.js
+++ b/frontend/src/pages/Recruits/Recruits.stories.js
@@ -1,7 +1,6 @@
-import React from "react";
-import Recruits from "./Recruits";
-import Header from "../../components/Header/Header";
 import "../../App.css";
+import Header from "../../components/Header/Header";
+import Recruits from "./Recruits";
 
 export default {
   title: "pages/Recruits",

--- a/frontend/src/pages/SignUp/SignUp.stories.js
+++ b/frontend/src/pages/SignUp/SignUp.stories.js
@@ -1,5 +1,4 @@
-import React from "react";
-import { Route, MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import SignUp from "./SignUp";
 
 export default {

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/frontend/types/css.d.ts
+++ b/frontend/types/css.d.ts
@@ -1,1 +1,0 @@
-declare module "*.module.css";


### PR DESCRIPTION
Resolves #600

## 해결하려는 문제가 무엇인가요?
![image](https://user-images.githubusercontent.com/72348351/186801062-ac0520a2-8447-452e-b1ef-76f9efd459b2.png)
figma를 참조하여 지원리스트의 스타일을 변경한다.

## 어떻게 해결하였나요?
수정 전
<img width="549" alt="image" src="https://user-images.githubusercontent.com/72348351/186802231-e1d5a8e8-311d-4db5-81b9-ffd493f7d7d2.png">

수정 후
![11](https://user-images.githubusercontent.com/72348351/186803110-f3a77fbd-3423-4921-b71f-b8f3b6eb5ee6.gif)

## 어떤 부분에 집중하여 리뷰하여야 할까요?
- 인디케이터의 상태
지원하기, 모집예정, 일시중지, 모집종료 -> 모집 중, 모집 예정
으로 줄이는게 맞을지? 줄인다면 onClick을 인디케이터가 아니라 ListItem에 줘야할지?
인디케이터를 button으로 했는데 윗 질문에 맞춰서 onClick이 ListItem에 위임 된다면 span이나 p로 하는게 맞을 것 같네요
- 대부분 rem으로 작성 돼 있어서 1rem=16px 기준으로 rem 변환하여 스타일하였습니다.
- figma에는 인디케이터가 사이즈가 다 다른데, 다 같은게 통일성이 있지 않을까 해서 일단은 동일하게 작성하였습니다. 의견 부탁드립니다.
- 모집상태별 탭(nav) 제거가 이슈에 있긴한데.. 코스별 탭 추가에서 재사용 가능 해 보이는데 삭제해야할지 궁금합니다.
코스별 탭 추가는 자스민 담당입니다.

## RCA 룰
r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)