### PR TITLE
feat(apply): unify the common style of all pages

### DIFF
--- a/frontend/src/components/@common/Container/Container.js
+++ b/frontend/src/components/@common/Container/Container.js
@@ -1,11 +1,16 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
 import styles from "./Container.module.css";
 
 export const CONTAINER_SIZE = {
   DEFAULT: "default",
   NARROW: "narrow",
+};
+
+export const TITLE_ALIGN = {
+  LEFT: "left",
+  CENTER: "center",
+  RIGHT: "right",
 };
 
 const Container = ({ title, titleAlign, size, children, className, ...props }) => {
@@ -36,8 +41,8 @@ export default Container;
 
 Container.propTypes = {
   title: PropTypes.string,
-  titleAlign: PropTypes.oneOf(["left", "center", "right"]),
-  size: PropTypes.oneOf(["default", "narrow"]),
+  titleAlign: PropTypes.oneOf(Object.values(TITLE_ALIGN)),
+  size: PropTypes.oneOf(Object.values(CONTAINER_SIZE)),
   children: PropTypes.node,
 };
 

--- a/frontend/src/components/@common/Container/Container.js
+++ b/frontend/src/components/@common/Container/Container.js
@@ -8,12 +8,6 @@ export const CONTAINER_SIZE = {
   NARROW: "narrow",
 };
 
-export const TITLE_ALIGN = {
-  CENTER: "center",
-  START: "start",
-  END: "end",
-};
-
 const Container = ({ title, titleAlign = "center", size, children, className, ...props }) => {
   return (
     <div

--- a/frontend/src/components/@common/Container/Container.js
+++ b/frontend/src/components/@common/Container/Container.js
@@ -36,7 +36,7 @@ export default Container;
 
 Container.propTypes = {
   title: PropTypes.string,
-  titleAlign: PropTypes.oneOf(["center", "start", "end"]),
+  titleAlign: PropTypes.oneOf(["left", "center", "right"]),
   size: PropTypes.oneOf(["default", "narrow"]),
   children: PropTypes.node,
 };

--- a/frontend/src/components/@common/Container/Container.js
+++ b/frontend/src/components/@common/Container/Container.js
@@ -8,7 +8,7 @@ export const CONTAINER_SIZE = {
   NARROW: "narrow",
 };
 
-const Container = ({ title, titleAlign = "center", size, children, className, ...props }) => {
+const Container = ({ title, titleAlign, size, children, className, ...props }) => {
   return (
     <div
       className={classNames(

--- a/frontend/src/components/@common/Container/Container.js
+++ b/frontend/src/components/@common/Container/Container.js
@@ -8,7 +8,13 @@ export const CONTAINER_SIZE = {
   NARROW: "narrow",
 };
 
-const Container = ({ title, size, children, className, ...props }) => {
+export const TITLE_ALIGN = {
+  CENTER: "center",
+  START: "start",
+  END: "end",
+};
+
+const Container = ({ title, titleAlign = "center", size, children, className, ...props }) => {
   return (
     <div
       className={classNames(
@@ -20,7 +26,7 @@ const Container = ({ title, size, children, className, ...props }) => {
     >
       {title && (
         <h2
-          className={classNames(styles.title, {
+          className={classNames(styles.title, styles[`title-align-${titleAlign}`], {
             [styles["title-with-children"]]: children,
           })}
         >
@@ -36,10 +42,12 @@ export default Container;
 
 Container.propTypes = {
   title: PropTypes.string,
+  titleAlign: PropTypes.oneOf(["center", "start", "end"]),
   size: PropTypes.oneOf(["default", "narrow"]),
   children: PropTypes.node,
 };
 
 Container.defaultProps = {
   size: "default",
+  titleAlign: "center",
 };

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -1,8 +1,7 @@
 .box {
   width: var(--pc-main-width);
-  background: var(--white);
   padding: 2rem 1.25rem;
-  background-color: var(--white);
+  background: var(--white);
 }
 
 .narrow {

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -1,7 +1,6 @@
 .box {
   width: var(--pc-main-width);
   background: var(--white);
-  border: 1px solid var(--gray-003);
   padding: 1.875rem 1.25rem;
   background-color: var(--white);
 }
@@ -12,11 +11,22 @@
 
 .title {
   font-size: 1.75rem;
-  text-align: center;
 }
 
 .title-with-children {
   margin: 0.875rem 0 3rem;
+}
+
+.title-align-center {
+  text-align: center;
+}
+
+.title-align-start {
+  text-align: start;
+}
+
+.title-align-end {
+  text-align: end;
 }
 
 @media screen and (max-width: 800px) {

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -1,7 +1,7 @@
 .box {
   width: var(--pc-main-width);
   background: var(--white);
-  padding: 1.875rem 1.25rem;
+  padding: 2rem 1.25rem;
   background-color: var(--white);
 }
 
@@ -10,11 +10,11 @@
 }
 
 .title {
-  font-size: 1.75rem;
+  font-size: 2rem;
 }
 
 .title-with-children {
-  margin: 0.875rem 0 3rem;
+  margin-bottom: 2rem;
 }
 
 .title-align-left {

--- a/frontend/src/components/@common/Container/Container.module.css
+++ b/frontend/src/components/@common/Container/Container.module.css
@@ -17,16 +17,16 @@
   margin: 0.875rem 0 3rem;
 }
 
+.title-align-left {
+  text-align: left;
+}
+
 .title-align-center {
   text-align: center;
 }
 
-.title-align-start {
-  text-align: start;
-}
-
-.title-align-end {
-  text-align: end;
+.title-align-right {
+  text-align: right;
 }
 
 @media screen and (max-width: 800px) {

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -125,7 +125,7 @@ const ApplicationRegister = () => {
         <RecruitmentItem className={styles["recruitment-item"]} recruitment={currentRecruitment} />
       )}
 
-      <Container title="지원서 작성" titleAlign="start">
+      <Container title="지원서 작성" titleAlign="left">
         <Form onSubmit={handleSubmit}>
           {status === PARAM.APPLICATION_FORM_STATUS.EDIT && (
             <p className={styles["autosave-indicator"]}>

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -2,7 +2,7 @@ import { generatePath } from "react-router";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import * as Api from "../../api";
 import Button, { BUTTON_VARIANT } from "../../components/@common/Button/Button";
-import Container from "../../components/@common/Container/Container";
+import Container, { TITLE_ALIGN } from "../../components/@common/Container/Container";
 import Description from "../../components/@common/Description/Description";
 import Label from "../../components/@common/Label/Label";
 import MessageTextarea from "../../components/@common/MessageTextarea/MessageTextarea";
@@ -125,7 +125,7 @@ const ApplicationRegister = () => {
         <RecruitmentItem className={styles["recruitment-item"]} recruitment={currentRecruitment} />
       )}
 
-      <Container title="지원서 작성" titleAlign="left">
+      <Container title="지원서 작성" titleAlign={TITLE_ALIGN.LEFT}>
         <Form onSubmit={handleSubmit}>
           {status === PARAM.APPLICATION_FORM_STATUS.EDIT && (
             <p className={styles["autosave-indicator"]}>

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -125,7 +125,7 @@ const ApplicationRegister = () => {
         <RecruitmentItem className={styles["recruitment-item"]} recruitment={currentRecruitment} />
       )}
 
-      <Container title="지원서 작성" titleAlign="left">
+      <Container title="지원서 작성" titleAlign="start">
         <Form onSubmit={handleSubmit}>
           {status === PARAM.APPLICATION_FORM_STATUS.EDIT && (
             <p className={styles["autosave-indicator"]}>

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -125,7 +125,7 @@ const ApplicationRegister = () => {
         <RecruitmentItem className={styles["recruitment-item"]} recruitment={currentRecruitment} />
       )}
 
-      <Container title="지원서 작성">
+      <Container title="지원서 작성" titleAlign="left">
         <Form onSubmit={handleSubmit}>
           {status === PARAM.APPLICATION_FORM_STATUS.EDIT && (
             <p className={styles["autosave-indicator"]}>

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
@@ -87,7 +87,7 @@ const AssignmentSubmit = () => {
   }, []);
 
   return (
-    <Container title={currentMission?.title ?? ""} titleAlign="start">
+    <Container title={currentMission?.title ?? ""} titleAlign="left">
       <Form onSubmit={handleSubmit} className={styles.form}>
         <MessageTextInput
           label="GitHub ID"

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
@@ -87,7 +87,7 @@ const AssignmentSubmit = () => {
   }, []);
 
   return (
-    <Container title={currentMission?.title ?? ""}>
+    <Container title={currentMission?.title ?? ""} titleAlign="left">
       <Form onSubmit={handleSubmit} className={styles.form}>
         <MessageTextInput
           label="GitHub ID"

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
@@ -3,7 +3,7 @@ import { useLocation, useParams } from "react-router";
 import { useNavigate } from "react-router-dom";
 import { fetchAssignment, patchAssignment, postAssignment } from "../../api/recruitments";
 import Button from "../../components/@common/Button/Button";
-import Container from "../../components/@common/Container/Container";
+import Container, { TITLE_ALIGN } from "../../components/@common/Container/Container";
 import MessageTextarea from "../../components/@common/MessageTextarea/MessageTextarea";
 import MessageTextInput from "../../components/@common/MessageTextInput/MessageTextInput";
 import CancelButton from "../../components/form/CancelButton/CancelButton";
@@ -87,7 +87,7 @@ const AssignmentSubmit = () => {
   }, []);
 
   return (
-    <Container title={currentMission?.title ?? ""} titleAlign="left">
+    <Container title={currentMission?.title ?? ""} titleAlign={TITLE_ALIGN.LEFT}>
       <Form onSubmit={handleSubmit} className={styles.form}>
         <MessageTextInput
           label="GitHub ID"

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
@@ -87,7 +87,7 @@ const AssignmentSubmit = () => {
   }, []);
 
   return (
-    <Container title={currentMission?.title ?? ""} titleAlign="left">
+    <Container title={currentMission?.title ?? ""} titleAlign="start">
       <Form onSubmit={handleSubmit} className={styles.form}>
         <MessageTextInput
           label="GitHub ID"

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -142,7 +142,7 @@ const MyApplication = () => {
 
   return (
     <div className={styles.box}>
-      <Container title="내 지원 현황" className={styles["page-title"]} titleAlign="left" />
+      <Container title="내 지원 현황" titleAlign="left" className={styles["page-title"]} />
       {myRecruitments.map(({ submitted, ...recruitment }, index) => (
         <Panel
           key={`recruitment-${recruitment.id}`}

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -142,7 +142,7 @@ const MyApplication = () => {
 
   return (
     <div className={styles.box}>
-      <Container title="내 지원 현황" className={styles["page-title"]} />
+      <Container title="내 지원 현황" className={styles["page-title"]} titleAlign="left" />
       {myRecruitments.map(({ submitted, ...recruitment }, index) => (
         <Panel
           key={`recruitment-${recruitment.id}`}

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -142,7 +142,7 @@ const MyApplication = () => {
 
   return (
     <div className={styles.box}>
-      <Container title="내 지원 현황" className={styles["page-title"]} titleAlign="start" />
+      <Container title="내 지원 현황" className={styles["page-title"]} titleAlign="left" />
       {myRecruitments.map(({ submitted, ...recruitment }, index) => (
         <Panel
           key={`recruitment-${recruitment.id}`}

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { generatePath } from "react-router";
 import { useNavigate } from "react-router-dom";
-import { fetchMyApplicationForms } from "../../api/applicationForms";
-import Container from "../../components/@common/Container/Container";
+import { fetchMyApplicationForms } from "../../api/application-forms";
+import Container, { TITLE_ALIGN } from "../../components/@common/Container/Container";
 import Panel from "../../components/@common/Panel/Panel";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
 import { ERROR_MESSAGE } from "../../constants/messages";
@@ -142,7 +142,11 @@ const MyApplication = () => {
 
   return (
     <div className={styles.box}>
-      <Container title="내 지원 현황" titleAlign="left" className={styles["page-title"]} />
+      <Container
+        title="내 지원 현황"
+        titleAlign={TITLE_ALIGN.LEFT}
+        className={styles["page-title"]}
+      />
       {myRecruitments.map(({ submitted, ...recruitment }, index) => (
         <Panel
           key={`recruitment-${recruitment.id}`}

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { generatePath } from "react-router";
 import { useNavigate } from "react-router-dom";
-import { fetchMyApplicationForms } from "../../api/application-forms";
+import { fetchMyApplicationForms } from "../../api/applicationForms";
 import Container, { TITLE_ALIGN } from "../../components/@common/Container/Container";
 import Panel from "../../components/@common/Panel/Panel";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";

--- a/frontend/src/pages/MyApplication/MyApplication.js
+++ b/frontend/src/pages/MyApplication/MyApplication.js
@@ -142,7 +142,7 @@ const MyApplication = () => {
 
   return (
     <div className={styles.box}>
-      <Container title="내 지원 현황" className={styles["page-title"]} titleAlign="left" />
+      <Container title="내 지원 현황" className={styles["page-title"]} titleAlign="start" />
       {myRecruitments.map(({ submitted, ...recruitment }, index) => (
         <Panel
           key={`recruitment-${recruitment.id}`}

--- a/frontend/src/pages/MyPage/MyPage.module.css
+++ b/frontend/src/pages/MyPage/MyPage.module.css
@@ -1,5 +1,6 @@
 .box {
   display: flex;
+  margin-top: 3rem;
 }
 
 .illust-box {
@@ -33,7 +34,7 @@
 }
 
 .buttons {
-  margin: 3.5rem 0 2rem;
+  margin: 3.5rem 0 0;
   display: flex;
   gap: 1rem;
 }

--- a/frontend/src/pages/MyPage/MyPage.module.css
+++ b/frontend/src/pages/MyPage/MyPage.module.css
@@ -34,7 +34,7 @@
 }
 
 .buttons {
-  margin: 3.5rem 0 0;
+  margin-top: 3.5rem;
   display: flex;
   gap: 1rem;
 }

--- a/frontend/src/pages/MyPageEdit/MyPageEdit.module.css
+++ b/frontend/src/pages/MyPageEdit/MyPageEdit.module.css
@@ -1,5 +1,6 @@
 .box {
   display: flex;
+  margin-top: 3rem;
 }
 
 .illust-box {

--- a/frontend/src/pages/PasswordEdit/PasswordEdit.js
+++ b/frontend/src/pages/PasswordEdit/PasswordEdit.js
@@ -41,7 +41,7 @@ const PasswordEdit = () => {
 
   return (
     <Container size={CONTAINER_SIZE.NARROW} title="비밀번호 변경">
-      <Form onSubmit={handleSubmit}>
+      <Form onSubmit={handleSubmit} className={styles.box}>
         <MessageTextInput
           label="기존 비밀번호"
           placeholder="기존 비밀번호를 입력해 주세요"

--- a/frontend/src/pages/PasswordEdit/PasswordEdit.module.css
+++ b/frontend/src/pages/PasswordEdit/PasswordEdit.module.css
@@ -1,3 +1,7 @@
+.box {
+  margin-top: 3rem;
+}
+
 .buttons {
   display: flex;
   gap: 1rem;

--- a/frontend/src/pages/SignUp/SignUp.js
+++ b/frontend/src/pages/SignUp/SignUp.js
@@ -51,7 +51,7 @@ const SignUp = () => {
   };
 
   return (
-    <Container title="회원가입" size={CONTAINER_SIZE.NARROW} titleAlign="left">
+    <Container title="회원가입" size={CONTAINER_SIZE.NARROW} titleAlign="start">
       <Form onSubmit={handleSubmit}>
         <SummaryCheckField
           label="개인정보 수집 및 이용 동의"

--- a/frontend/src/pages/SignUp/SignUp.js
+++ b/frontend/src/pages/SignUp/SignUp.js
@@ -51,7 +51,7 @@ const SignUp = () => {
   };
 
   return (
-    <Container title="회원가입" size={CONTAINER_SIZE.NARROW} titleAlign="left">
+    <Container title="회원가입" titleAlign="left" size={CONTAINER_SIZE.NARROW}>
       <Form onSubmit={handleSubmit}>
         <SummaryCheckField
           label="개인정보 수집 및 이용 동의"

--- a/frontend/src/pages/SignUp/SignUp.js
+++ b/frontend/src/pages/SignUp/SignUp.js
@@ -51,7 +51,7 @@ const SignUp = () => {
   };
 
   return (
-    <Container title="회원가입" size={CONTAINER_SIZE.NARROW} titleAlign="start">
+    <Container title="회원가입" size={CONTAINER_SIZE.NARROW} titleAlign="left">
       <Form onSubmit={handleSubmit}>
         <SummaryCheckField
           label="개인정보 수집 및 이용 동의"

--- a/frontend/src/pages/SignUp/SignUp.js
+++ b/frontend/src/pages/SignUp/SignUp.js
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Button from "../../components/@common/Button/Button";
-import Container, { CONTAINER_SIZE } from "../../components/@common/Container/Container";
+import Container, {
+  CONTAINER_SIZE,
+  TITLE_ALIGN,
+} from "../../components/@common/Container/Container";
 import MessageTextInput from "../../components/@common/MessageTextInput/MessageTextInput";
 import BirthField from "../../components/form/BirthField/BirthField";
 import CancelButton from "../../components/form/CancelButton/CancelButton";
@@ -51,7 +54,7 @@ const SignUp = () => {
   };
 
   return (
-    <Container title="회원가입" titleAlign="left" size={CONTAINER_SIZE.NARROW}>
+    <Container title="회원가입" titleAlign={TITLE_ALIGN.LEFT} size={CONTAINER_SIZE.NARROW}>
       <Form onSubmit={handleSubmit}>
         <SummaryCheckField
           label="개인정보 수집 및 이용 동의"

--- a/frontend/src/pages/SignUp/SignUp.js
+++ b/frontend/src/pages/SignUp/SignUp.js
@@ -51,7 +51,7 @@ const SignUp = () => {
   };
 
   return (
-    <Container title="회원가입" size={CONTAINER_SIZE.NARROW}>
+    <Container title="회원가입" size={CONTAINER_SIZE.NARROW} titleAlign="left">
       <Form onSubmit={handleSubmit}>
         <SummaryCheckField
           label="개인정보 수집 및 이용 동의"


### PR DESCRIPTION
Resolves #629 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 메인 페이지와 다른 페이지의 공통 스타일을 맞춘다.

# 어떻게 해결했나요?

### Container의 border 제거
- Container의 box 스타일링 border를 제거했습니다.
- 적용 대상: 전체 페이지

### Container의 title 정렬 방식 변경
- Container에 `titleAlign` prop을 추가하여 해당 prop 값에 따라 `h2` 태그의 className을 다르게 주는 방식으로 구현했습니다. prop의 default 값은 'center'로 줬습니다.
- 좌측 정렬 대상 페이지: 지원서 작성 페이지, 내 지원 현황 페이지, 과제 제출 페이지, 회원가입 페이지
- 중앙 정렬 대상 페이지: 로그인 페이지, 마이 페이지, 내 정보 수정 페이지, 비밀번호 변경 페이지

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 질문) 타이틀 폰트 사이즈는 피그마와 다른 상황입니다. border와 title 정렬에 대해서만 기존에 논의되어서 border와 title 정렬에 대해서만 작업했는데요. 기존 타이틀 폰트 사이즈를 유지할 것인지, 피그마에 적용된 사이즈로 변경할 것인지 논의가 필요합니다. 
- 타이틀 정렬을 적용하는 다른 방식이 있다면 제안해주세요.
- 피그마와 다른 부분이 없는지 함께 확인해주세요. 
    (참고 - 배경색 변경은 [#601](https://github.com/woowacourse/service-apply/issues/601) 이슈에서 함께 진행합니다.)

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
