### PR TITLE
feat(apply): change the application form page ui

### DIFF
--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -9,7 +9,6 @@ import MessageTextarea from "../../components/@common/MessageTextarea/MessageTex
 import MessageTextInput from "../../components/@common/MessageTextInput/MessageTextInput";
 import CheckBox from "../../components/form/CheckBox/CheckBox";
 import Form from "../../components/form/Form/Form";
-import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
 import { FORM } from "../../constants/form";
 import { CONFIRM_MESSAGE, SUCCESS_MESSAGE } from "../../constants/messages";
 import { PATH, PARAM } from "../../constants/path";
@@ -121,11 +120,8 @@ const ApplicationRegister = () => {
 
   return (
     <div className={styles.box}>
-      {currentRecruitment && (
-        <RecruitmentItem className={styles["recruitment-item"]} recruitment={currentRecruitment} />
-      )}
-
       <Container title="지원서 작성" titleAlign={TITLE_ALIGN.LEFT}>
+        <h3 className={styles["recruitment-title"]}>{currentRecruitment.title}</h3>
         <Form onSubmit={handleSubmit}>
           {status === PARAM.APPLICATION_FORM_STATUS.EDIT && (
             <p className={styles["autosave-indicator"]}>

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
@@ -5,6 +5,14 @@
   gap: 1rem;
 }
 
+.recruitment-title {
+  margin-bottom: 2.5rem;
+
+  font-size: 1.125rem;
+  font-weight: normal;
+  color: var(--gray-007);
+}
+
 .label-bold label {
   font-weight: bold;
 }


### PR DESCRIPTION
Resolves #631 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?
- 지원서 작성 페이지를 개선한다. 

# 어떻게 해결했나요?
- 지원서 모집 페이지 상단에 있던 `RecruitmentItem`을 제거했습니다.
- `h3` 태그로 모집 타이틀 영역을 추가했습니다.

### 수정 전
https://github.com/woowacourse/service-apply/issues/600 이슈의 작업으로 `RecruitmentItem`의 디자인이 달라졌습니다. 해당 작업이 아직 머지되지 않아서, 아래 캡쳐본은 수정된 디자인이 적용되지 않은 모습입니다.
![image](https://user-images.githubusercontent.com/71116429/192153716-fe892b10-3ad2-46d2-9a2c-3fe90ce6e736.png)


### 수정 후
![image](https://user-images.githubusercontent.com/71116429/192153524-02ab7400-f382-4035-83e3-5a2d0f910911.png)


# 어떤 부분에 집중하여 리뷰해야 할까요?
- 피그마와 다른 부분이 없는지 확인해주세요.
- 질문) 피그마에 따라 작업했습니다만 개인적으로는 모집 타이틀이 너무 강조되지 않는 것 같아서, font-weight라도 조금 더 들어가는 게 좋지 않겠나 싶은데요. 다른 분들 의견 궁금합니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
