### PR TITLE
feat: improve the side navigation ui

### DIFF
--- a/src/main/kotlin/apply/ui/admin/BaseLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/BaseLayout.kt
@@ -5,7 +5,9 @@ import apply.ui.admin.administrator.AdministratorsView
 import apply.ui.admin.cheater.CheatersView
 import apply.ui.admin.evaluation.EvaluationsView
 import apply.ui.admin.mail.MailsView
+import apply.ui.admin.mission.MissionsView
 import apply.ui.admin.recruitment.RecruitmentsView
+import apply.ui.admin.selections.SelectionView
 import apply.ui.admin.term.TermsView
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.applayout.AppLayout
@@ -32,7 +34,6 @@ class BaseLayout(
     private fun createDrawer(): Component {
         return VerticalLayout().apply {
             setSizeFull()
-            element.style.set("overflow", "auto")
             themeList["dark"] = true
             alignItems = FlexComponent.Alignment.CENTER
             add(createTitle(), createLogo(width), createMenu())
@@ -50,7 +51,7 @@ class BaseLayout(
     }
 
     private fun createMenu(): Component {
-        return createTabs(createMenuItems().map { it.toComponent() })
+        return createTabs(createMenuItems().flatMap { it.toComponents() })
     }
 
     private fun createMenuItems(): List<MenuItem> {
@@ -59,8 +60,15 @@ class BaseLayout(
             "기수 관리" of TermsView::class.java,
             "모집 관리" of RecruitmentsView::class.java,
             "평가 관리" of EvaluationsView::class.java,
-            "과제 관리".accordionOf("admin/missions", recruitments),
-            "선발 과정".accordionOf("admin/selections", recruitments),
+            createBorderItem(),
+            "모집선택".createComboBoxTab(
+                recruitments,
+                listOf(
+                    "과제 관리" of MissionsView::class.java,
+                    "선발 과정" of SelectionView::class.java,
+                )
+            ),
+            createBorderItem(),
             "부정행위자" of CheatersView::class.java,
             "메일 관리" of MailsView::class.java,
             "관리자" of AdministratorsView::class.java

--- a/src/main/kotlin/apply/ui/admin/BaseLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/BaseLayout.kt
@@ -1,25 +1,15 @@
 package apply.ui.admin
 
 import apply.application.RecruitmentService
-import apply.ui.admin.administrator.AdministratorsView
-import apply.ui.admin.cheater.CheatersView
-import apply.ui.admin.evaluation.EvaluationsView
-import apply.ui.admin.mail.MailsView
-import apply.ui.admin.mission.MissionsView
-import apply.ui.admin.recruitment.RecruitmentsView
-import apply.ui.admin.selections.SelectionView
-import apply.ui.admin.term.TermsView
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.applayout.AppLayout
 import com.vaadin.flow.component.applayout.DrawerToggle
 import com.vaadin.flow.component.html.H1
-import com.vaadin.flow.component.html.Image
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.theme.Theme
 import com.vaadin.flow.theme.lumo.Lumo
-import support.views.createTabs
 
 @Theme(value = Lumo::class)
 class BaseLayout(
@@ -36,42 +26,11 @@ class BaseLayout(
             setSizeFull()
             themeList["dark"] = true
             alignItems = FlexComponent.Alignment.CENTER
-            add(createTitle(), createLogo(width), createMenu())
+            add(createTitle(), MenuLayout(recruitmentService))
         }
     }
 
     private fun createTitle(): Component {
         return HorizontalLayout(H1("지원 플랫폼"))
-    }
-
-    private fun createLogo(width: String): Component {
-        return Image("images/logo/logo_full_white.png", "우아한테크코스").apply {
-            maxWidth = width
-        }
-    }
-
-    private fun createMenu(): Component {
-        return createTabs(createMenuItems().flatMap { it.toComponents() })
-    }
-
-    private fun createMenuItems(): List<MenuItem> {
-        val recruitments = recruitmentService.findAll()
-        return listOf(
-            "기수 관리" of TermsView::class.java,
-            "모집 관리" of RecruitmentsView::class.java,
-            "평가 관리" of EvaluationsView::class.java,
-            createBorderItem(),
-            "모집선택".createComboBoxTab(
-                recruitments,
-                listOf(
-                    "과제 관리" of MissionsView::class.java,
-                    "선발 과정" of SelectionView::class.java,
-                )
-            ),
-            createBorderItem(),
-            "부정행위자" of CheatersView::class.java,
-            "메일 관리" of MailsView::class.java,
-            "관리자" of AdministratorsView::class.java
-        )
     }
 }

--- a/src/main/kotlin/apply/ui/admin/MenuItems.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuItems.kt
@@ -2,58 +2,98 @@ package apply.ui.admin
 
 import apply.application.RecruitmentResponse
 import com.vaadin.flow.component.Component
-import com.vaadin.flow.component.accordion.Accordion
-import com.vaadin.flow.component.details.DetailsVariant
-import com.vaadin.flow.component.html.Anchor
+import com.vaadin.flow.component.combobox.ComboBox
 import com.vaadin.flow.component.tabs.Tab
 import com.vaadin.flow.router.RouterLink
-import support.views.createTabs
+import support.views.HasUrlParamLayout
+import support.views.createBorder
+import support.views.createHiddenTab
+import support.views.createRouteLink
 
 infix fun String.of(navigationTarget: Class<out Component>): MenuItem {
     return SingleMenuItem(this, navigationTarget)
 }
 
-fun String.accordionOf(path: String, recruitments: List<RecruitmentResponse>): MenuItem {
-    return AccordionMenuItem(this, path, recruitments.map { it.toContent() })
+infix fun String.of(navigationTarget: Class<out HasUrlParamLayout<Long>>): ParamMenuItem {
+    return ParamMenuItem(this, navigationTarget)
 }
 
-private fun RecruitmentResponse.toContent(): AccordionContent = AccordionContent(id, title)
+fun String.createComboBoxTab(recruitments: List<RecruitmentResponse>, innerItems: List<ParamMenuItem>): MenuItem {
+    return ComboBoxMenuItem(this, recruitments.reversed(), innerItems)
+}
 
-sealed class MenuItem(protected val title: String) {
-    abstract fun toComponent(): Component
+sealed class MenuItem(protected val title: String = "") {
+    abstract fun toComponents(): List<Component>
+}
+
+fun createBorderItem(): MenuItem {
+    return BorderMenuItem()
+}
+
+class BorderMenuItem : MenuItem() {
+    override fun toComponents(): List<Component> {
+        return listOf(
+            Tab(createBorder()).apply {
+                isEnabled = false
+            }
+        )
+    }
 }
 
 class SingleMenuItem(
     title: String,
     private val navigationTarget: Class<out Component>
 ) : MenuItem(title) {
-    override fun toComponent(): Component {
-        return Tab(RouterLink(title, navigationTarget))
+    override fun toComponents(): List<Component> {
+        return listOf(
+            Tab(
+                createRouteLink(title).apply {
+                    setRoute(navigationTarget)
+                }
+            )
+        )
     }
 }
 
-data class AccordionContent(val id: Any, val title: String)
-
-class AccordionMenuItem(
+class ParamMenuItem(
     title: String,
-    private val path: String,
-    private val contents: List<AccordionContent>
+    val navigationTarget: Class<out HasUrlParamLayout<Long>>
 ) : MenuItem(title) {
-    override fun toComponent(): Component {
-        return Accordion().apply {
-            add(title, createTabs()).addThemeVariants(DetailsVariant.REVERSE)
-            close()
+    val link: RouterLink = createRouteLink(title)
+    val tab: Tab = createHiddenTab(link)
+    override fun toComponents(): List<Component> {
+        return listOf(tab)
+    }
+}
+
+class ComboBoxMenuItem(
+    title: String,
+    private val contents: List<RecruitmentResponse>,
+    private val innerItems: List<ParamMenuItem>
+) : MenuItem(title) {
+    override fun toComponents(): List<Component> {
+        val comboBox = ComboBox<RecruitmentResponse>("모집을 선택해 선발을 진행하세요.").apply {
+            placeholder = title
+            setItems(contents)
+            setItemLabelGenerator { it.title }
+
+            addValueChangeListener {
+                for (innerItem in innerItems) {
+                    routeEvent(innerItem)
+                }
+            }
+        }
+
+        return mutableListOf<Component>(Tab(comboBox)).apply {
+            addAll(innerItems.flatMap { it.toComponents() })
         }
     }
 
-    private fun createTabs(): Component? {
-        if (contents.isEmpty()) {
-            return null
+    private fun ComboBox<RecruitmentResponse>.routeEvent(paramMenuItem: ParamMenuItem) {
+        with(paramMenuItem) {
+            tab.isVisible = true
+            tab.isSelected = false
+            link.setRoute(navigationTarget, value.id)
         }
-        return createTabs(contents.toTabs(path))
-    }
-
-    private fun List<AccordionContent>.toTabs(path: String): List<Component> {
-        return map { Tab(Anchor("$path/${it.id}", it.title)) }
     }
 }

--- a/src/main/kotlin/apply/ui/admin/MenuItems.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuItems.kt
@@ -22,12 +22,12 @@ fun String.createComboBoxTab(recruitments: List<RecruitmentResponse>, innerItems
     return ComboBoxMenuItem(this, recruitments.reversed(), innerItems)
 }
 
-sealed class MenuItem(protected val title: String = "") {
-    abstract fun toComponents(): List<Component>
-}
-
 fun createBorderItem(): MenuItem {
     return BorderMenuItem()
+}
+
+sealed class MenuItem(protected val title: String = "") {
+    abstract fun toComponents(): List<Component>
 }
 
 class BorderMenuItem : MenuItem() {

--- a/src/main/kotlin/apply/ui/admin/MenuLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuLayout.kt
@@ -1,0 +1,70 @@
+package apply.ui.admin
+
+import apply.application.RecruitmentService
+import apply.ui.admin.cheater.CheatersView
+import apply.ui.admin.evaluation.EvaluationsView
+import apply.ui.admin.mail.MailsView
+import apply.ui.admin.mission.MissionsView
+import apply.ui.admin.recruitment.RecruitmentsView
+import apply.ui.admin.selections.SelectionView
+import apply.ui.admin.term.TermsView
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.orderedlayout.FlexComponent
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import support.views.createTabs
+
+class MenuLayout(
+    private val recruitmentService: RecruitmentService
+) : VerticalLayout() {
+
+    init {
+        setHeightFull()
+        isPadding = false
+        add(createTopMenuLayer(), createBottomMenuLayer())
+    }
+
+    private fun createTopMenuLayer(): VerticalLayout {
+        return VerticalLayout().apply {
+            isPadding = false
+            add(createMenu(createTopMenuItems()))
+        }
+    }
+
+    private fun createBottomMenuLayer(): VerticalLayout {
+        return VerticalLayout(createMenu(createBottomMenuItems())).apply {
+            isPadding = false
+            setHeightFull()
+            justifyContentMode = FlexComponent.JustifyContentMode.END
+        }
+    }
+
+    private fun createMenu(list: List<MenuItem>): Component {
+        return createTabs(list.flatMap { it.toComponents() })
+    }
+
+    private fun createTopMenuItems(): List<MenuItem> {
+        val recruitments = recruitmentService.findAll()
+        return listOf(
+            "모집선택".createComboBoxTab(
+                recruitments,
+                listOf(
+                    "과제 관리" of MissionsView::class.java,
+                    "선발 과정" of SelectionView::class.java,
+                )
+            )
+        )
+    }
+
+    private fun createBottomMenuItems(): List<MenuItem> {
+        return listOf(
+            createBorderItem(),
+            "기수 관리" of TermsView::class.java,
+            "모집 관리" of RecruitmentsView::class.java,
+            "평가 관리" of EvaluationsView::class.java,
+            createBorderItem(),
+            "부정행위자" of CheatersView::class.java,
+            "메일 관리" of MailsView::class.java,
+            "관리자 관리" of MailsView::class.java
+        )
+    }
+}

--- a/src/main/kotlin/apply/ui/admin/MenuLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuLayout.kt
@@ -13,10 +13,11 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.tabs.Tabs
 import support.views.createTabs
 
+private const val UNSELECT_ALL: Int = -1
+
 class MenuLayout(
     private val recruitmentService: RecruitmentService
 ) : VerticalLayout() {
-
     private val topMenu = createMenu(createTopMenuItems())
     private val bottomMenu = createMenu(createBottomMenuItems())
 
@@ -29,11 +30,11 @@ class MenuLayout(
 
     private fun addMenuSelectSeparateEvent() {
         topMenu.addSelectedChangeListener {
-            bottomMenu.selectedIndex = -1
+            bottomMenu.selectedIndex = UNSELECT_ALL
             topMenu.selectedTab = it.selectedTab
         }
         bottomMenu.addSelectedChangeListener {
-            topMenu.selectedIndex = -1
+            topMenu.selectedIndex = UNSELECT_ALL
             bottomMenu.selectedTab = it.selectedTab
         }
     }
@@ -78,9 +79,9 @@ class MenuLayout(
             "모집 관리" of RecruitmentsView::class.java,
             "평가 관리" of EvaluationsView::class.java,
             createBorderItem(),
-            "부정행위자" of CheatersView::class.java,
             "메일 관리" of MailsView::class.java,
-            "관리자 관리" of MailsView::class.java
+            "부정행위자" of CheatersView::class.java,
+            "관리자" of MailsView::class.java
         )
     }
 }

--- a/src/main/kotlin/apply/ui/admin/MenuLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuLayout.kt
@@ -8,37 +8,53 @@ import apply.ui.admin.mission.MissionsView
 import apply.ui.admin.recruitment.RecruitmentsView
 import apply.ui.admin.selections.SelectionView
 import apply.ui.admin.term.TermsView
-import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.component.tabs.Tabs
 import support.views.createTabs
 
 class MenuLayout(
     private val recruitmentService: RecruitmentService
 ) : VerticalLayout() {
 
+    private val topMenu = createMenu(createTopMenuItems())
+    private val bottomMenu = createMenu(createBottomMenuItems())
+
     init {
         setHeightFull()
         isPadding = false
+        addMenuSelectSeparateEvent()
         add(createTopMenuLayer(), createBottomMenuLayer())
+    }
+
+    private fun addMenuSelectSeparateEvent() {
+        topMenu.addSelectedChangeListener {
+            bottomMenu.selectedIndex = -1
+            topMenu.selectedTab = it.selectedTab
+        }
+        bottomMenu.addSelectedChangeListener {
+            topMenu.selectedIndex = -1
+            bottomMenu.selectedTab = it.selectedTab
+        }
     }
 
     private fun createTopMenuLayer(): VerticalLayout {
         return VerticalLayout().apply {
             isPadding = false
-            add(createMenu(createTopMenuItems()))
+            add(topMenu)
         }
     }
 
     private fun createBottomMenuLayer(): VerticalLayout {
-        return VerticalLayout(createMenu(createBottomMenuItems())).apply {
+        return VerticalLayout().apply {
             isPadding = false
             setHeightFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
+            add(bottomMenu)
         }
     }
 
-    private fun createMenu(list: List<MenuItem>): Component {
+    private fun createMenu(list: List<MenuItem>): Tabs {
         return createTabs(list.flatMap { it.toComponents() })
     }
 

--- a/src/main/kotlin/apply/ui/admin/MenuLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuLayout.kt
@@ -28,33 +28,6 @@ class MenuLayout(
         add(createTopMenuLayer(), createBottomMenuLayer())
     }
 
-    private fun addMenuSelectSeparateEvent() {
-        topMenu.addSelectedChangeListener {
-            bottomMenu.selectedIndex = UNSELECT_ALL
-            topMenu.selectedTab = it.selectedTab
-        }
-        bottomMenu.addSelectedChangeListener {
-            topMenu.selectedIndex = UNSELECT_ALL
-            bottomMenu.selectedTab = it.selectedTab
-        }
-    }
-
-    private fun createTopMenuLayer(): VerticalLayout {
-        return VerticalLayout().apply {
-            isPadding = false
-            add(topMenu)
-        }
-    }
-
-    private fun createBottomMenuLayer(): VerticalLayout {
-        return VerticalLayout().apply {
-            isPadding = false
-            setHeightFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.END
-            add(bottomMenu)
-        }
-    }
-
     private fun createMenu(list: List<MenuItem>): Tabs {
         return createTabs(list.flatMap { it.toComponents() })
     }
@@ -83,5 +56,32 @@ class MenuLayout(
             "부정행위자" of CheatersView::class.java,
             "관리자" of MailsView::class.java
         )
+    }
+
+    private fun addMenuSelectSeparateEvent() {
+        topMenu.addSelectedChangeListener {
+            bottomMenu.selectedIndex = UNSELECT_ALL
+            topMenu.selectedTab = it.selectedTab
+        }
+        bottomMenu.addSelectedChangeListener {
+            topMenu.selectedIndex = UNSELECT_ALL
+            bottomMenu.selectedTab = it.selectedTab
+        }
+    }
+
+    private fun createTopMenuLayer(): VerticalLayout {
+        return VerticalLayout().apply {
+            isPadding = false
+            add(topMenu)
+        }
+    }
+
+    private fun createBottomMenuLayer(): VerticalLayout {
+        return VerticalLayout().apply {
+            isPadding = false
+            setHeightFull()
+            justifyContentMode = FlexComponent.JustifyContentMode.END
+            add(bottomMenu)
+        }
     }
 }

--- a/src/main/kotlin/apply/ui/admin/MenuLayout.kt
+++ b/src/main/kotlin/apply/ui/admin/MenuLayout.kt
@@ -1,6 +1,7 @@
 package apply.ui.admin
 
 import apply.application.RecruitmentService
+import apply.ui.admin.administrator.AdministratorsView
 import apply.ui.admin.cheater.CheatersView
 import apply.ui.admin.evaluation.EvaluationsView
 import apply.ui.admin.mail.MailsView
@@ -54,7 +55,7 @@ class MenuLayout(
             createBorderItem(),
             "메일 관리" of MailsView::class.java,
             "부정행위자" of CheatersView::class.java,
-            "관리자" of MailsView::class.java
+            "관리자" of AdministratorsView::class.java
         )
     }
 

--- a/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
+++ b/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
@@ -11,14 +11,13 @@ import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.grid.Grid
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
-import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.data.renderer.ComponentRenderer
 import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.BeforeEvent
-import com.vaadin.flow.router.HasUrlParameter
 import com.vaadin.flow.router.Route
 import com.vaadin.flow.router.WildcardParameter
 import support.views.EDIT_VALUE
+import support.views.HasUrlParamLayout
 import support.views.NEW_VALUE
 import support.views.Title
 import support.views.addSortableColumn
@@ -31,7 +30,7 @@ import support.views.createPrimarySmallButton
 class MissionsView(
     private val recruitmentService: RecruitmentService,
     private val missionService: MissionService
-) : VerticalLayout(), HasUrlParameter<Long> {
+) : HasUrlParamLayout<Long>() {
     private var recruitmentId: Long = 0L
 
     override fun setParameter(event: BeforeEvent, @WildcardParameter parameter: Long) {
@@ -42,7 +41,6 @@ class MissionsView(
         removeAll()
         add(createTitle(), createButton(), createGrid())
     }
-
 
     private fun createTitle(): Component {
         return Title("${recruitmentService.getById(recruitmentId).title} 과제 관리")

--- a/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
+++ b/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
@@ -35,9 +35,14 @@ class MissionsView(
     private var recruitmentId: Long = 0L
 
     override fun setParameter(event: BeforeEvent, @WildcardParameter parameter: Long) {
+        if (recruitmentId == parameter) {
+            return
+        }
         recruitmentId = parameter
+        removeAll()
         add(createTitle(), createButton(), createGrid())
     }
+
 
     private fun createTitle(): Component {
         return Title("${recruitmentService.getById(recruitmentId).title} 과제 관리")

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -36,9 +36,9 @@ import com.vaadin.flow.component.upload.receivers.MemoryBuffer
 import com.vaadin.flow.data.renderer.ComponentRenderer
 import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.BeforeEvent
-import com.vaadin.flow.router.HasUrlParameter
 import com.vaadin.flow.router.Route
 import com.vaadin.flow.router.WildcardParameter
+import support.views.HasUrlParamLayout
 import support.views.addSortableColumn
 import support.views.addSortableDateColumn
 import support.views.addSortableDateTimeColumn
@@ -64,7 +64,7 @@ class SelectionView(
     private val myMissionService: MyMissionService,
     private val excelService: ExcelService,
     private val evaluationTargetCsvService: EvaluationTargetCsvService
-) : VerticalLayout(), HasUrlParameter<Long> {
+) : HasUrlParamLayout<Long>() {
     private var recruitmentId: Long = 0L
     private var evaluations: List<EvaluationSelectData> =
         evaluationService.getAllSelectDataByRecruitmentId(recruitmentId)
@@ -80,7 +80,6 @@ class SelectionView(
         removeAll()
         add(createTitle(), createContent())
     }
-
 
     private fun createTitle(): Component {
         return HorizontalLayout(H1(recruitmentService.getById(recruitmentId).title)).apply {

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -73,9 +73,14 @@ class SelectionView(
     private var evaluationFileButtons: HorizontalLayout = createEvaluationFileButtons()
 
     override fun setParameter(event: BeforeEvent, @WildcardParameter parameter: Long) {
+        if (recruitmentId == parameter) {
+            return
+        }
         this.recruitmentId = parameter
+        removeAll()
         add(createTitle(), createContent())
     }
+
 
     private fun createTitle(): Component {
         return HorizontalLayout(H1(recruitmentService.getById(recruitmentId).title)).apply {

--- a/src/main/kotlin/support/views/Components.kt
+++ b/src/main/kotlin/support/views/Components.kt
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.HasText
 import com.vaadin.flow.component.Key
 import com.vaadin.flow.component.Text
 import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.html.Div
 import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.icon.Icon
 import com.vaadin.flow.component.icon.VaadinIcon
@@ -13,10 +14,12 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup
 import com.vaadin.flow.component.select.Select
+import com.vaadin.flow.component.tabs.Tab
 import com.vaadin.flow.component.tabs.Tabs
 import com.vaadin.flow.component.tabs.TabsVariant
 import com.vaadin.flow.component.textfield.TextField
 import com.vaadin.flow.data.renderer.ComponentRenderer
+import com.vaadin.flow.router.RouterLink
 
 fun createIntSelect(min: Int = 0, max: Int): Select<Int> {
     return Select(*(min..max).toList().toTypedArray())
@@ -101,6 +104,26 @@ fun createTabs(components: List<Component>): Component {
         isAutoselect = false
         addThemeVariants(TabsVariant.LUMO_MINIMAL)
         add(*components.toTypedArray())
+    }
+}
+
+fun createHiddenTab(component: Component): Tab {
+    return Tab(component).apply {
+        isVisible = false
+    }
+}
+
+fun createBorder(): Component {
+    return Div().apply {
+        setWidthFull()
+        style.set("border-top", "1px solid gray")
+    }
+}
+
+fun createRouteLink(title: String): RouterLink {
+    return RouterLink().apply {
+        text = title
+        style.set("justify-content", "center")
     }
 }
 

--- a/src/main/kotlin/support/views/Components.kt
+++ b/src/main/kotlin/support/views/Components.kt
@@ -98,7 +98,7 @@ fun createNotification(text: String, durationValue: Int = 1000): Notification {
     }
 }
 
-fun createTabs(components: List<Component>): Component {
+fun createTabs(components: List<Component>): Tabs {
     return Tabs().apply {
         setWidthFull()
         orientation = Tabs.Orientation.VERTICAL

--- a/src/main/kotlin/support/views/Components.kt
+++ b/src/main/kotlin/support/views/Components.kt
@@ -100,6 +100,7 @@ fun createNotification(text: String, durationValue: Int = 1000): Notification {
 
 fun createTabs(components: List<Component>): Component {
     return Tabs().apply {
+        setWidthFull()
         orientation = Tabs.Orientation.VERTICAL
         isAutoselect = false
         addThemeVariants(TabsVariant.LUMO_MINIMAL)

--- a/src/main/kotlin/support/views/HasUrlParamLayout.kt
+++ b/src/main/kotlin/support/views/HasUrlParamLayout.kt
@@ -1,0 +1,6 @@
+package support.views
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.router.HasUrlParameter
+
+abstract class HasUrlParamLayout<T> : VerticalLayout(), HasUrlParameter<T>


### PR DESCRIPTION
Resolves #617

# 해결하려는 문제가 무엇인가요?

- 워크숍 요구사항에서 나온 요구사항 중  관리자 페이지의 Flow를 잘 이해하지 못하겠다는 의견과 좌측 탭 메뉴 각각이 하는 역할이 무엇인지 헷갈린다는 의견이 나왔고 이를 해결하고자 했습니다.

# 어떻게 해결했나요?

- 사용자를 고려해볼 때 기수관리, 모집관리, 평가관리 와 같은 기능들은 특정 관리자만 사용할 메뉴이므로 하단으로 내리고 선발 진행과 관련된 사항을 상위에 위치시켜보았습니다.
- 아코디언을 사용하고있던 지난 메뉴를 콤보박스를 활용하는 형태로 개선해보았습니다.
- 아코디언 방식에서 사용하던 `Anchor` 대신 `RouterLink`를 사용하여 화면이 새로고침되는 것을 막아보았습니다.
  - path가 들어가는 동적인 `RouterLink` 설정을 위해 VerticalLayout과 HasUrlParameter 를 하나로 묶는 추상클래스인 `HasUrlParamLayout` 을 생성했습니다.

~🚨🚨주의 : 아직 관리자 탭은 머지가 되지 않았기 때문에 클릭 시 메일 관리 페이지가 보입니다. 이후 관리자 기능 머지 후에 수정이 필요합니다~
**(10.26) 새로 리베이스 하면서 AdministratorsView로 이동되는 것도 반영했습니다.**

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 네이밍과 패키지 위치가 적절한지에 대해서 리뷰해주세요.
- 코틀린스럽게 개선할 부분이 있다면 리뷰해주세요.
- 바딘의 부적절한 사용이 있다면 리뷰해주세요.
- 실행시켜서 사용해보시고 불편한 부분을 리뷰해주세요. ( 영상자료도 #617 에 있음 )

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
