### PR TITLE
feat(apply): add introduction of educational programs

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -52,8 +52,7 @@ button {
 
 .main {
   flex: 1;
-  margin: 0 auto;
-  padding: 1rem 0.5rem;
+  margin: 4.375rem auto;
 }
 
 input,

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -1,5 +1,5 @@
 .box {
-  margin-bottom: 5.75rem;
+  margin-bottom: 4.5rem;
 }
 
 .header {

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -26,7 +26,7 @@ export const PROGRAM_TAB = {
   WOOWA_TECH_COURSE: {
     name: "woowacourse",
     label: "우아한테크코스",
-    description: `서비스를 개발하는 회사가 필요로 하는 역량을 가진 개발자 양성을 위한 프로그램입니다.\n자기주도 학습, 현장중심 경험, 깊이있는 협업을 함께하실 분들을 찾고 있어요.`,
+    description: `일반 사용자용 서비스를 개발하는 회사가 필요로 하는 역량을 가진 개발자를 양성하기 위한 프로그램입니다.\n자기주도 학습, 현장 중심 경험, 깊이 있는 협업을 통해 성장하실 분들을 찾고 있어요.`,
   },
   WOOWA_TECH_CAMP: {
     name: "woowacamp",
@@ -36,7 +36,7 @@ export const PROGRAM_TAB = {
   WOOWA_TECH_CAMP_PRO: {
     name: "woowacamppro",
     label: "우아한테크캠프 Pro",
-    description: `만 3년 이상 경력이 있는 재직자를 대상으로 하는 교육 과정 프로그램입니다.\n유지보수하기 좋은 코드를 실현하고 싶은, 서비스 회사가 필요로 하는 역량을 더 쌓고 싶은, 한 단계 더 성장하고 싶은 분들을 찾고 있어요.`,
+    description: `경력이 있는 재직자를 대상으로 유지보수하기 좋은 코드를 학습하는 교육 프로그램입니다.\n일반 사용자용 서비스 회사가 필요로 하는 역량을 더 쌓고 싶은 분들을 찾고 있어요.`,
   },
 } as const;
 

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -21,18 +21,22 @@ export const COURSE_TAB = {
   ALL: {
     name: "all",
     label: "전체",
+    description: "메인 소개",
   },
   WOOWA_TECH_COURSE: {
     name: "woowacourse",
     label: "우아한테크코스",
+    description: "우아한테크코스 소개",
   },
   WOOWA_TECH_CAMP: {
     name: "woowacamp",
     label: "우아한테크캠프",
+    description: "우아한테크캠프 소개",
   },
   WOOWA_TECH_CAMP_PRO: {
     name: "woowacamppro",
     label: "우아한테크캠프 Pro",
+    description: "우아한테크캠프 Pro 소개",
   },
 } as const;
 

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -21,22 +21,22 @@ export const PROGRAM_TAB = {
   ALL: {
     name: "all",
     label: "전체",
-    description: "메인 소개",
+    description: "",
   },
   WOOWA_TECH_COURSE: {
     name: "woowacourse",
     label: "우아한테크코스",
-    description: "우아한테크코스 소개",
+    description: `서비스를 개발하는 회사가 필요로 하는 역량을 가진 개발자 양성을 위한 프로그램입니다.\n자기주도 학습, 현장중심 경험, 깊이있는 협업을 함께하실 분들을 찾고 있어요.`,
   },
   WOOWA_TECH_CAMP: {
     name: "woowacamp",
     label: "우아한테크캠프",
-    description: "우아한테크캠프 소개",
+    description: `다양한 미니 프로젝트를 통해 실제 서비스를 만들며 개발 지식을 익히는 교육형 인턴 과정입니다.\n프로그래밍 기본 지식과 개발자로 살고 싶은 열정이 있는 분들을 찾고 있어요.`,
   },
   WOOWA_TECH_CAMP_PRO: {
     name: "woowacamppro",
     label: "우아한테크캠프 Pro",
-    description: "우아한테크캠프 Pro 소개",
+    description: `만 3년 이상 경력이 있는 재직자를 대상으로 하는 교육 과정 프로그램입니다.\n유지보수하기 좋은 코드를 실현하고 싶은, 서비스 회사가 필요로 하는 역량을 더 쌓고 싶은, 한 단계 더 성장하고 싶은 분들을 찾고 있어요.`,
   },
 } as const;
 

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -17,7 +17,7 @@ export const RECRUITS_TAB = {
   },
 } as const;
 
-export const COURSE_TAB = {
+export const PROGRAM_TAB = {
   ALL: {
     name: "all",
     label: "전체",
@@ -47,9 +47,9 @@ export const RECRUITS_TAB_LIST = [
   RECRUITS_TAB.ENDED,
 ] as const;
 
-export const COURSE_TAB_LIST = [
-  COURSE_TAB.ALL,
-  COURSE_TAB.WOOWA_TECH_COURSE,
-  COURSE_TAB.WOOWA_TECH_CAMP,
-  COURSE_TAB.WOOWA_TECH_CAMP_PRO,
+export const PROGRAM_TAB_LIST = [
+  PROGRAM_TAB.ALL,
+  PROGRAM_TAB.WOOWA_TECH_COURSE,
+  PROGRAM_TAB.WOOWA_TECH_CAMP,
+  PROGRAM_TAB.WOOWA_TECH_CAMP_PRO,
 ] as const;

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -18,7 +18,9 @@ const matchProgram = (recruitmentTitle: string, programLabel: string) => {
 
 const useRecruitList = () => {
   const { recruitment } = useRecruitmentContext();
-  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
+  const [courseTabStatus, setCourseTabStatus] = useState<
+    typeof COURSE_TAB[keyof typeof COURSE_TAB]
+  >(COURSE_TAB.ALL);
 
   const filteredRecruitment: Recruitment[] = useMemo(() => {
     const allRecruitment: Recruitment[] = recruitment[RECRUITS_TAB.ALL.name];

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -3,6 +3,8 @@ import useRecruitmentContext from "./useRecruitmentContext";
 import { RECRUITS_TAB, PROGRAM_TAB } from "../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
 
+type ProgramTabStatus = typeof PROGRAM_TAB[keyof typeof PROGRAM_TAB];
+
 const matchProgram = (recruitmentTitle: string, programLabel: string) => {
   const programList = Array.from(Object.values(PROGRAM_TAB)).sort(
     (a, b) => b.label.length - a.label.length
@@ -16,7 +18,11 @@ const matchProgram = (recruitmentTitle: string, programLabel: string) => {
   return matchingProgram.label === programLabel;
 };
 
-const useRecruitList = () => {
+const useRecruitList: () => {
+  programTabStatus: ProgramTabStatus;
+  setProgramTabStatus: React.Dispatch<React.SetStateAction<ProgramTabStatus>>;
+  filteredRecruitment: Recruitment[];
+} = () => {
   const { recruitment } = useRecruitmentContext();
   const [programTabStatus, setProgramTabStatus] = useState<
     typeof PROGRAM_TAB[keyof typeof PROGRAM_TAB]

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -1,26 +1,26 @@
 import { useState, useMemo } from "react";
 import useRecruitmentContext from "./useRecruitmentContext";
-import { RECRUITS_TAB, COURSE_TAB } from "../constants/tab";
+import { RECRUITS_TAB, PROGRAM_TAB } from "../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
 
 const matchProgram = (recruitmentTitle: string, programLabel: string) => {
-  const programList = Array.from(Object.values(COURSE_TAB)).sort(
+  const programList = Array.from(Object.values(PROGRAM_TAB)).sort(
     (a, b) => b.label.length - a.label.length
   );
 
   const matchingProgram =
     programList.find(({ label }) => {
       return new RegExp(String.raw`^${label}`, "i").test(recruitmentTitle);
-    }) ?? COURSE_TAB.ALL;
+    }) ?? PROGRAM_TAB.ALL;
 
   return matchingProgram.label === programLabel;
 };
 
 const useRecruitList = () => {
   const { recruitment } = useRecruitmentContext();
-  const [courseTabStatus, setCourseTabStatus] = useState<
-    typeof COURSE_TAB[keyof typeof COURSE_TAB]
-  >(COURSE_TAB.ALL);
+  const [programTabStatus, setProgramTabStatus] = useState<
+    typeof PROGRAM_TAB[keyof typeof PROGRAM_TAB]
+  >(PROGRAM_TAB.ALL);
 
   const filteredRecruitment: Recruitment[] = useMemo(() => {
     const allRecruitment: Recruitment[] = recruitment[RECRUITS_TAB.ALL.name];
@@ -28,16 +28,16 @@ const useRecruitList = () => {
       return new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime();
     });
 
-    if (courseTabStatus.label === COURSE_TAB.ALL.label) {
+    if (programTabStatus.label === PROGRAM_TAB.ALL.label) {
       return sortedRecruitmentItem;
     }
 
     return sortedRecruitmentItem.filter((recruitmentItem) =>
-      matchProgram(recruitmentItem.title, courseTabStatus.label)
+      matchProgram(recruitmentItem.title, programTabStatus.label)
     );
-  }, [recruitment, courseTabStatus]);
+  }, [recruitment, programTabStatus]);
 
-  return { courseTabStatus, setCourseTabStatus, filteredRecruitment };
+  return { programTabStatus, setProgramTabStatus, filteredRecruitment };
 };
 
 export default useRecruitList;

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import useRecruitmentContext from "./useRecruitmentContext";
-import { RECRUITS_TAB, COURSE_TAB } from "./../constants/tab";
+import { RECRUITS_TAB, COURSE_TAB } from "../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
 
 const matchProgram = (recruitmentTitle: string, programLabel: string) => {

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -18,32 +18,41 @@ const matchProgram = (recruitmentTitle: string, programLabel: string) => {
   return matchingProgram.label === programLabel;
 };
 
+const sortRecruitmentsByStartDateTime: (recruitments: Recruitment[]) => Recruitment[] = (
+  recruitments
+) =>
+  recruitments.sort((a, b) => {
+    return new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime();
+  });
+
+const filterRecruitmentsByProgramLabel: (
+  recruitments: Recruitment[],
+  programLabel: ProgramTabStatus["label"]
+) => Recruitment[] = (recruitments, programLabel) =>
+  recruitments.filter((recruitmentItem) => matchProgram(recruitmentItem.title, programLabel));
+
 const useRecruitList: () => {
   programTabStatus: ProgramTabStatus;
   setProgramTabStatus: React.Dispatch<React.SetStateAction<ProgramTabStatus>>;
-  filteredRecruitment: Recruitment[];
+  filteredRecruitments: Recruitment[];
 } = () => {
   const { recruitment } = useRecruitmentContext();
   const [programTabStatus, setProgramTabStatus] = useState<
     typeof PROGRAM_TAB[keyof typeof PROGRAM_TAB]
   >(PROGRAM_TAB.ALL);
 
-  const filteredRecruitment: Recruitment[] = useMemo(() => {
-    const allRecruitment: Recruitment[] = recruitment[RECRUITS_TAB.ALL.name];
-    const sortedRecruitmentItem: Recruitment[] = allRecruitment.sort((a, b) => {
-      return new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime();
-    });
+  const filteredRecruitments: Recruitment[] = useMemo(() => {
+    const recruitments: Recruitment[] = recruitment[RECRUITS_TAB.ALL.name];
+    const sortedRecruitments: Recruitment[] = sortRecruitmentsByStartDateTime(recruitments);
 
     if (programTabStatus.label === PROGRAM_TAB.ALL.label) {
-      return sortedRecruitmentItem;
+      return sortedRecruitments;
     }
 
-    return sortedRecruitmentItem.filter((recruitmentItem) =>
-      matchProgram(recruitmentItem.title, programTabStatus.label)
-    );
+    return filterRecruitmentsByProgramLabel(sortedRecruitments, programTabStatus.label);
   }, [recruitment, programTabStatus]);
 
-  return { programTabStatus, setProgramTabStatus, filteredRecruitment };
+  return { programTabStatus, setProgramTabStatus, filteredRecruitments };
 };
 
 export default useRecruitList;

--- a/frontend/src/hooks/useRecruitList.tsx
+++ b/frontend/src/hooks/useRecruitList.tsx
@@ -31,7 +31,7 @@ const useRecruitList = () => {
     });
   }, [recruitment, courseTabStatus]);
 
-  return [courseTabStatus, setCourseTabStatus, filteredRecruitment];
+  return { courseTabStatus, setCourseTabStatus, filteredRecruitment };
 };
 
 export default useRecruitList;

--- a/frontend/src/hooks/useRecruitList.tsx
+++ b/frontend/src/hooks/useRecruitList.tsx
@@ -1,0 +1,40 @@
+import { useState, useMemo } from "react";
+import { COURSE_TAB } from "../constants/tab";
+import useRecruitmentContext from "./useRecruitmentContext";
+import { RECRUITS_TAB } from "./../constants/tab";
+import { Recruitment } from "../../types/domains/recruitments";
+
+const useRecruitList = () => {
+  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
+  const { recruitment } = useRecruitmentContext();
+
+  const filteredRecruitment: Recruitment[] | undefined = useMemo(() => {
+    if (!recruitment) return recruitment;
+
+    const allRecruitment: Recruitment[] = recruitment[RECRUITS_TAB.ALL.name];
+    const sortedRecruitmentItem: Recruitment[] = allRecruitment.sort((a, b) => {
+      return new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime();
+    });
+
+    if (courseTabStatus.label === COURSE_TAB.ALL.label) {
+      return sortedRecruitmentItem;
+    }
+
+    if (courseTabStatus.label === COURSE_TAB.WOOWA_TECH_COURSE.label) {
+      return sortedRecruitmentItem.filter((recruitmentItem) =>
+        recruitmentItem.title.includes(courseTabStatus.label)
+      );
+    }
+
+    return sortedRecruitmentItem.filter((recruitmentItem) => {
+      const fullCourseNameArray = recruitmentItem.title.split(" ");
+      const courseName = fullCourseNameArray.slice(0, fullCourseNameArray.length - 1);
+
+      return courseName.join(" ").trim() === courseTabStatus.label;
+    });
+  }, [recruitment, courseTabStatus]);
+
+  return [courseTabStatus, setCourseTabStatus, filteredRecruitment];
+};
+
+export default useRecruitList;

--- a/frontend/src/hooks/useRecruitList.tsx
+++ b/frontend/src/hooks/useRecruitList.tsx
@@ -1,16 +1,13 @@
 import { useState, useMemo } from "react";
-import { COURSE_TAB } from "../constants/tab";
 import useRecruitmentContext from "./useRecruitmentContext";
-import { RECRUITS_TAB } from "./../constants/tab";
+import { RECRUITS_TAB, COURSE_TAB } from "./../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
 
 const useRecruitList = () => {
-  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
   const { recruitment } = useRecruitmentContext();
+  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
 
-  const filteredRecruitment: Recruitment[] | undefined = useMemo(() => {
-    if (!recruitment) return recruitment;
-
+  const filteredRecruitment: Recruitment[] = useMemo(() => {
     const allRecruitment: Recruitment[] = recruitment[RECRUITS_TAB.ALL.name];
     const sortedRecruitmentItem: Recruitment[] = allRecruitment.sort((a, b) => {
       return new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime();

--- a/frontend/src/hooks/useRecruitList.tsx
+++ b/frontend/src/hooks/useRecruitList.tsx
@@ -3,6 +3,19 @@ import useRecruitmentContext from "./useRecruitmentContext";
 import { RECRUITS_TAB, COURSE_TAB } from "./../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
 
+const matchProgram = (recruitmentTitle: string, programLabel: string) => {
+  const programList = Array.from(Object.values(COURSE_TAB)).sort(
+    (a, b) => b.label.length - a.label.length
+  );
+
+  const matchingProgram =
+    programList.find(({ label }) => {
+      return new RegExp(String.raw`^${label}`, "i").test(recruitmentTitle);
+    }) ?? COURSE_TAB.ALL;
+
+  return matchingProgram.label === programLabel;
+};
+
 const useRecruitList = () => {
   const { recruitment } = useRecruitmentContext();
   const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
@@ -17,18 +30,9 @@ const useRecruitList = () => {
       return sortedRecruitmentItem;
     }
 
-    if (courseTabStatus.label === COURSE_TAB.WOOWA_TECH_COURSE.label) {
-      return sortedRecruitmentItem.filter((recruitmentItem) =>
-        recruitmentItem.title.includes(courseTabStatus.label)
-      );
-    }
-
-    return sortedRecruitmentItem.filter((recruitmentItem) => {
-      const fullCourseNameArray = recruitmentItem.title.split(" ");
-      const courseName = fullCourseNameArray.slice(0, fullCourseNameArray.length - 1);
-
-      return courseName.join(" ").trim() === courseTabStatus.label;
-    });
+    return sortedRecruitmentItem.filter((recruitmentItem) =>
+      matchProgram(recruitmentItem.title, courseTabStatus.label)
+    );
   }, [recruitment, courseTabStatus]);
 
   return { courseTabStatus, setCourseTabStatus, filteredRecruitment };

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -5,14 +5,14 @@ import TabItem from "../../components/@common/TabItem/TabItem";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
 import { generateQuery } from "../../utils/route/query";
 import { PATH, PARAM } from "../../constants/path";
-import { COURSE_TAB, COURSE_TAB_LIST } from "../../constants/tab";
+import { PROGRAM_TAB, PROGRAM_TAB_LIST } from "../../constants/tab";
 import styles from "./Recruits.module.css";
 
 const Recruits = () => {
   const { token } = useTokenContext();
   const navigate = useNavigate();
 
-  const { courseTabStatus, setCourseTabStatus, filteredRecruitment } = useRecruitList();
+  const { programTabStatus, setProgramTabStatus, filteredRecruitment } = useRecruitList();
 
   const goToNewApplicationFormPage = (recruitment) => {
     if (!token) {
@@ -45,25 +45,25 @@ const Recruits = () => {
     <>
       <div className={styles["program-introduce-box"]}>
         <h1 className={styles["program-name"]}>
-          {courseTabStatus.name === COURSE_TAB.ALL.name
+          {programTabStatus.name === PROGRAM_TAB.ALL.name
             ? "메인 소개 타이틀"
-            : courseTabStatus.label}
+            : programTabStatus.label}
         </h1>
-        <p className={styles["program-description"]}>{courseTabStatus.description}</p>
+        <p className={styles["program-description"]}>{programTabStatus.description}</p>
       </div>
 
       <div className={styles["recruitment-list-box"]}>
         <h2 className={styles["recruitment-list-title"]}>지원하기</h2>
-        <div className={styles["course-tab-list"]}>
-          {COURSE_TAB_LIST.map((courseTabItem) => (
+        <div className={styles["program-tab-list"]}>
+          {PROGRAM_TAB_LIST.map((programTabListItem) => (
             <TabItem
-              key={courseTabItem.name}
-              checked={courseTabItem.label === courseTabStatus.label}
+              key={programTabListItem.name}
+              checked={programTabListItem.label === programTabStatus.label}
               onClickTabItem={() => {
-                setCourseTabStatus(courseTabItem);
+                setProgramTabStatus(programTabListItem);
               }}
             >
-              {courseTabItem.label}
+              {programTabListItem.label}
             </TabItem>
           ))}
         </div>

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -1,34 +1,23 @@
 import { useMemo, useState } from "react";
-import { generatePath, useNavigate, useLocation } from "react-router-dom";
+import { generatePath, useNavigate } from "react-router-dom";
 import TabItem from "../../components/@common/TabItem/TabItem";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
 import { PATH, PARAM } from "../../constants/path";
-import { RECRUITMENT_STATUS } from "../../constants/recruitment";
 import { COURSE_TAB, COURSE_TAB_LIST, RECRUITS_TAB } from "../../constants/tab";
 import useRecruitmentContext from "../../hooks/useRecruitmentContext";
 import useTokenContext from "../../hooks/useTokenContext";
 import { generateQuery } from "../../utils/route/query";
 import styles from "./Recruits.module.css";
 
-const BUTTON_LABEL = {
-  [RECRUITMENT_STATUS.RECRUITING]: "지원하기",
-  [RECRUITMENT_STATUS.RECRUITABLE]: "모집 예정",
-  [RECRUITMENT_STATUS.UNRECRUITABLE]: "일시 중지",
-  [RECRUITMENT_STATUS.ENDED]: "모집 종료",
-};
-
 const Recruits = () => {
   const { token } = useTokenContext();
   const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
   const navigate = useNavigate();
 
-  const query = new URLSearchParams(useLocation().search);
-  const selectedTab = query.get("status") ?? RECRUITS_TAB.ALL.name;
-
   const { recruitment } = useRecruitmentContext();
 
   const filteredRecruitment = useMemo(() => {
-    const sortedRecruitmentItem = recruitment[selectedTab].sort((a, b) => {
+    const sortedRecruitmentItem = recruitment[RECRUITS_TAB.ALL.name].sort((a, b) => {
       return new Date(b.startDateTime) - new Date(a.startDateTime);
     });
 
@@ -48,7 +37,7 @@ const Recruits = () => {
 
       return courseName.join(" ").trim() === courseTabStatus.label;
     });
-  }, [recruitment, selectedTab, courseTabStatus]);
+  }, [recruitment, courseTabStatus]);
 
   const goToNewApplicationFormPage = (recruitment) => {
     if (!token) {

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -12,7 +12,7 @@ const Recruits = () => {
   const { token } = useTokenContext();
   const navigate = useNavigate();
 
-  const [courseTabStatus, setCourseTabStatus, filteredRecruitment] = useRecruitList();
+  const { courseTabStatus, setCourseTabStatus, filteredRecruitment } = useRecruitList();
 
   const goToNewApplicationFormPage = (recruitment) => {
     if (!token) {

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -9,6 +9,7 @@ import useRecruitmentContext from "../../hooks/useRecruitmentContext";
 import useTokenContext from "../../hooks/useTokenContext";
 import { generateQuery } from "../../utils/route/query";
 import styles from "./Recruits.module.css";
+
 const BUTTON_LABEL = {
   [RECRUITMENT_STATUS.RECRUITING]: "지원하기",
   [RECRUITMENT_STATUS.RECRUITABLE]: "모집 예정",
@@ -78,7 +79,13 @@ const Recruits = () => {
 
   return (
     <>
+      <div className={styles["program-introduce-box"]}>
+        <h1 className={styles["program-name"]}>프로그램 이름</h1>
+        <p className={styles["program-description"]}>프로그램 소개</p>
+      </div>
+
       <div className={styles["recruitment-list-box"]}>
+        <h2 className={styles["recruitment-list-title"]}>지원하기</h2>
         <div className={styles["course-tab-list"]}>
           {COURSE_TAB_LIST.map(({ name, label }) => (
             <TabItem

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -46,7 +46,7 @@ const Recruits = () => {
       <div className={styles["program-introduce-box"]}>
         <h1 className={styles["program-name"]}>
           {programTabStatus.name === PROGRAM_TAB.ALL.name
-            ? `우아한교육프로그램과\n함께할 개발자를 찾고 있어요!`
+            ? `우아한형제들의 교육 프로그램과\n함께할 개발자를 찾고 있어요!`
             : programTabStatus.label}
         </h1>
         <p className={styles["program-description"]}>{programTabStatus.description}</p>

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -12,7 +12,7 @@ const Recruits = () => {
   const { token } = useTokenContext();
   const navigate = useNavigate();
 
-  const { programTabStatus, setProgramTabStatus, filteredRecruitment } = useRecruitList();
+  const { programTabStatus, setProgramTabStatus, filteredRecruitments } = useRecruitList();
 
   const goToNewApplicationFormPage = (recruitment) => {
     if (!token) {
@@ -69,10 +69,10 @@ const Recruits = () => {
         </div>
         {
           <div className={styles["recruitment-list"]} role="list">
-            {filteredRecruitment.length === 0 ? (
+            {filteredRecruitments.length === 0 ? (
               <div className={styles["empty-state-box"]}>해당하는 모집이 없습니다.</div>
             ) : (
-              filteredRecruitment.map((recruitment) => (
+              filteredRecruitments.map((recruitment) => (
                 <RecruitmentItem
                   key={recruitment.id}
                   recruitment={recruitment}

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -19,7 +19,7 @@ const BUTTON_LABEL = {
 
 const Recruits = () => {
   const { token } = useTokenContext();
-  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL.label);
+  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
   const navigate = useNavigate();
 
   const query = new URLSearchParams(useLocation().search);
@@ -32,13 +32,13 @@ const Recruits = () => {
       return new Date(b.startDateTime) - new Date(a.startDateTime);
     });
 
-    if (courseTabStatus === COURSE_TAB.ALL.label) {
+    if (courseTabStatus.label === COURSE_TAB.ALL.label) {
       return sortedRecruitmentItem;
     }
 
-    if (courseTabStatus === COURSE_TAB.WOOWA_TECH_COURSE.label) {
+    if (courseTabStatus.label === COURSE_TAB.WOOWA_TECH_COURSE.label) {
       return sortedRecruitmentItem.filter((recruitmentItem) =>
-        recruitmentItem.title.includes(courseTabStatus)
+        recruitmentItem.title.includes(courseTabStatus.label)
       );
     }
 
@@ -46,7 +46,7 @@ const Recruits = () => {
       const fullCourseNameArray = recruitmentItem.title.split(" ");
       const courseName = fullCourseNameArray.slice(0, fullCourseNameArray.length - 1);
 
-      return courseName.join(" ").trim() === courseTabStatus;
+      return courseName.join(" ").trim() === courseTabStatus.label;
     });
   }, [recruitment, selectedTab, courseTabStatus]);
 
@@ -80,22 +80,26 @@ const Recruits = () => {
   return (
     <>
       <div className={styles["program-introduce-box"]}>
-        <h1 className={styles["program-name"]}>프로그램 이름</h1>
-        <p className={styles["program-description"]}>프로그램 소개</p>
+        <h1 className={styles["program-name"]}>
+          {courseTabStatus.name === COURSE_TAB.ALL.name
+            ? "메인 소개 타이틀"
+            : courseTabStatus.label}
+        </h1>
+        <p className={styles["program-description"]}>{courseTabStatus.description}</p>
       </div>
 
       <div className={styles["recruitment-list-box"]}>
         <h2 className={styles["recruitment-list-title"]}>지원하기</h2>
         <div className={styles["course-tab-list"]}>
-          {COURSE_TAB_LIST.map(({ name, label }) => (
+          {COURSE_TAB_LIST.map((courseTabItem) => (
             <TabItem
-              key={name}
-              checked={label === courseTabStatus}
+              key={courseTabItem.name}
+              checked={courseTabItem.label === courseTabStatus.label}
               onClickTabItem={() => {
-                setCourseTabStatus(label);
+                setCourseTabStatus(courseTabItem);
               }}
             >
-              {label}
+              {courseTabItem.label}
             </TabItem>
           ))}
         </div>

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -67,7 +67,7 @@ const Recruits = () => {
             </TabItem>
           ))}
         </div>
-        {filteredRecruitment && (
+        {
           <div className={styles["recruitment-list"]} role="list">
             {filteredRecruitment.length === 0 ? (
               <div className={styles["empty-state-box"]}>해당하는 모집이 없습니다.</div>
@@ -82,7 +82,7 @@ const Recruits = () => {
               ))
             )}
           </div>
-        )}
+        }
       </div>
     </>
   );

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -46,7 +46,7 @@ const Recruits = () => {
       <div className={styles["program-introduce-box"]}>
         <h1 className={styles["program-name"]}>
           {programTabStatus.name === PROGRAM_TAB.ALL.name
-            ? "메인 소개 타이틀"
+            ? `우아한교육프로그램과\n함께할 개발자를 찾고 있어요!`
             : programTabStatus.label}
         </h1>
         <p className={styles["program-description"]}>{programTabStatus.description}</p>

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -1,43 +1,18 @@
-import { useMemo, useState } from "react";
 import { generatePath, useNavigate } from "react-router-dom";
+import useTokenContext from "../../hooks/useTokenContext";
+import useRecruitList from "./../../hooks/useRecruitList";
 import TabItem from "../../components/@common/TabItem/TabItem";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
-import { PATH, PARAM } from "../../constants/path";
-import { COURSE_TAB, COURSE_TAB_LIST, RECRUITS_TAB } from "../../constants/tab";
-import useRecruitmentContext from "../../hooks/useRecruitmentContext";
-import useTokenContext from "../../hooks/useTokenContext";
 import { generateQuery } from "../../utils/route/query";
+import { PATH, PARAM } from "../../constants/path";
+import { COURSE_TAB, COURSE_TAB_LIST } from "../../constants/tab";
 import styles from "./Recruits.module.css";
 
 const Recruits = () => {
   const { token } = useTokenContext();
-  const [courseTabStatus, setCourseTabStatus] = useState(COURSE_TAB.ALL);
   const navigate = useNavigate();
 
-  const { recruitment } = useRecruitmentContext();
-
-  const filteredRecruitment = useMemo(() => {
-    const sortedRecruitmentItem = recruitment[RECRUITS_TAB.ALL.name].sort((a, b) => {
-      return new Date(b.startDateTime) - new Date(a.startDateTime);
-    });
-
-    if (courseTabStatus.label === COURSE_TAB.ALL.label) {
-      return sortedRecruitmentItem;
-    }
-
-    if (courseTabStatus.label === COURSE_TAB.WOOWA_TECH_COURSE.label) {
-      return sortedRecruitmentItem.filter((recruitmentItem) =>
-        recruitmentItem.title.includes(courseTabStatus.label)
-      );
-    }
-
-    return sortedRecruitmentItem.filter((recruitmentItem) => {
-      const fullCourseNameArray = recruitmentItem.title.split(" ");
-      const courseName = fullCourseNameArray.slice(0, fullCourseNameArray.length - 1);
-
-      return courseName.join(" ").trim() === courseTabStatus.label;
-    });
-  }, [recruitment, courseTabStatus]);
+  const [courseTabStatus, setCourseTabStatus, filteredRecruitment] = useRecruitList();
 
   const goToNewApplicationFormPage = (recruitment) => {
     if (!token) {
@@ -92,7 +67,7 @@ const Recruits = () => {
             </TabItem>
           ))}
         </div>
-        {recruitment && (
+        {filteredRecruitment && (
           <div className={styles["recruitment-list"]} role="list">
             {filteredRecruitment.length === 0 ? (
               <div className={styles["empty-state-box"]}>해당하는 모집이 없습니다.</div>

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -8,12 +8,14 @@
 }
 
 .program-name {
-  font-size: 3rem;
+  font-size: 2.5rem;
   font-weight: bold;
+  white-space: pre-line;
 }
 
 .program-description {
-  font-size: 1.5rem;
+  font-size: 1.2rem;
+  white-space: pre-line;
 }
 
 .tab {
@@ -93,5 +95,27 @@
   .program-tab-list {
     gap: 1rem;
     margin-bottom: 1.5rem;
+  }
+}
+
+@media screen and (max-width: 512px) {
+  .program-introduce-box {
+    margin: 0 auto 3rem;
+  }
+
+  .program-name {
+    font-size: 2rem;
+    font-weight: bold;
+    white-space: pre-line;
+  }
+
+  .program-description {
+    font-size: 1rem;
+    white-space: pre-line;
+  }
+
+  .recruitment-list-title {
+    font-size: 1.5rem;
+    font-weight: bold;
   }
 }

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -62,7 +62,7 @@
   color: var(--gray-005);
 }
 
-.course-tab-list {
+.program-tab-list {
   display: flex;
   align-items: center;
   gap: 1.5rem;
@@ -90,7 +90,7 @@
     display: none;
   }
 
-  .course-tab-list {
+  .program-tab-list {
     gap: 1rem;
     margin-bottom: 1.5rem;
   }

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -3,7 +3,8 @@
   flex-direction: column;
   gap: 1rem;
 
-  margin-bottom: 4rem;
+  width: var(--pc-main-width);
+  margin: 0 auto 4rem;
 }
 
 .program-name {
@@ -72,6 +73,10 @@
 @media screen and (max-width: 800px) {
   .empty-state-box {
     font-size: 0.875rem;
+  }
+
+  .program-introduce-box {
+    width: calc(100vw - 1rem);
   }
 
   .recruitment-list-box {

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -66,6 +66,8 @@
   display: flex;
   align-items: center;
   gap: 1.5rem;
+
+  height: 4rem;
   margin-bottom: 1rem;
   overflow: auto;
 }

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -1,3 +1,20 @@
+.program-introduce-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  margin-bottom: 4rem;
+}
+
+.program-name {
+  font-size: 3rem;
+  font-weight: bold;
+}
+
+.program-description {
+  font-size: 1.5rem;
+}
+
 .tab {
   position: fixed;
   top: 4.5rem;
@@ -15,7 +32,16 @@
   font-weight: bold;
 }
 
+.recruitment-list-title {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
 .recruitment-list-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
   width: var(--pc-main-width);
   margin: 0 auto;
 }


### PR DESCRIPTION
Resolves #630 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?
- 각 교육 프로그램에 대한 소개 문구를 추가한다.

# 어떻게 해결했나요?
- 모집 목록 상단에 교육 프로그램 소개 영역을 추가했습니다.
- `constants/tab.ts`의 `COURSE_TAB`에 교육 프로그램 설명 속성 `description` 추가했습니다. 기존에는 `courseTabStatus` 상태가 RECRUITS_TAB 프로퍼티 객체 하나의 label을 가지고 있었는데요. 이번에 `description`을 추가하면서 RECRUITS_TAB 중 하나의 프로퍼티 객체를 상태로 가지도록 변경했습니다.
- [#610](https://github.com/woowacourse/service-apply/pull/610)에서 논의한대로
    - 모집 탭 영역 높이를 주어 스크롤 바와 탭 버튼이 겹치지 않도록 수정했습니다.
    - 모집 탭 선택 상태와 필터링 된 모집 목록을 생성하는 useRecruitList를 분리했습니다.

![image](https://user-images.githubusercontent.com/71116429/194039779-09640f4c-8648-4d23-b7f5-19d124f2f388.png)



# 어떤 부분에 집중하여 리뷰해야 할까요?
- 프로그램 소개 영역의 컨텐츠가 탭에 종속적으로 변경되어서 `constants/tab.ts`의 `COURSE_TAB`에 프로그램 소개글을 추가하는 방식을 선택했습니다. 지금과 같은 방식 괜찮은지 의견 주세요.
- 새로운 파일을 만들 때 ts로 작성하는 규칙이 있는 것으로 알아서 useRecruitList를 .tsx로 작성했는데요. useReruitList 내부에서 사용하는 useRecruitmentContext의 경우 아직 마이그레이션 되지 않아, 이후 마이그레이션 작업이 진행되면 다시 수정이 필요할 수 있을 것 같습니다.


---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
