### PR TITLE
feat(apply): change the description of the reference url

### DIFF
--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -152,11 +152,11 @@ const ApplicationRegister = () => {
             type="url"
             description={
               <div className={styles["description-url"]}>
-                작성한 몰입 경험과 관련된 개인 블로그, GitHub, 그 외 증빙 자료 등이 있다면
-                입력해주세요.
+                작성한 몰입 경험과 관련된 개인 블로그, GitHub, 그 외 증빙 자료 등이 있다면 입력해
+                주세요.
                 <div className={styles["description-url-small"]}>
                   여러 개가 있는 경우 Notion이나 Google 문서 등을 사용하여 하나로 묶어 주세요.
-                  링크를 공유하실 때는 해당 링크가 공개 권한으로 접근 가능한지 확인해주세요.
+                  링크를 공유하실 때는 해당 링크가 공개 권한으로 접근 가능한지 확인해 주세요.
                 </div>
               </div>
             }

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -156,7 +156,7 @@ const ApplicationRegister = () => {
                 입력해주세요.
                 <div className={styles["description-url-small"]}>
                   여러 개가 있는 경우 Notion이나 Google 문서 등을 사용하여 하나로 묶어 주세요.
-                  링크를 공유하실 때에는 해당 링크가 공개 권한으로 접근 가능한지 확인해주세요.
+                  링크를 공유하실 때는 해당 링크가 공개 권한으로 접근 가능한지 확인해주세요.
                 </div>
               </div>
             }

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -152,10 +152,11 @@ const ApplicationRegister = () => {
             type="url"
             description={
               <div className={styles["description-url"]}>
-                자신을 드러낼 수 있는 개인 블로그, GitHub, 포트폴리오 주소 등이 있다면 입력해
-                주세요.
+                작성한 몰입 경험과 관련된 개인 블로그, GitHub, 그 외 증빙 자료 등이 있다면
+                입력해주세요.
                 <div className={styles["description-url-small"]}>
-                  여러 개가 있는 경우 Notion, Google 문서 등을 사용하여 하나로 묶어 주세요.
+                  여러 개가 있는 경우 Notion이나 Google 문서 등을 사용하여 하나로 묶어 주세요.
+                  링크를 공유하실 때에는 해당 링크가 공개 권한으로 접근 가능한지 확인해주세요.
                 </div>
               </div>
             }


### PR DESCRIPTION
Resolves #616 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?
- 포트폴리오 대신 증빙 자료로 문구를 변경한다.

# 어떻게 해결했나요?
- 아래와 같이 지원서의 URL 입력란 설명 문구를 변경했습니다.
[AS-IS] 자신을 드러낼 수 있는 개인 블로그, GitHub, 포트폴리오 주소 등이 있다면 입력해
주세요. 여러 개가 있는 경우 Notion, Google 문서 등을 사용하여 하나로 묶어 주세요.
[TO-BE] 작성한 몰입 경험과 관련된 개인 블로그, GitHub, 그 외 증빙 자료 등이 있다면 입력해주세요. 여러 개가 있는 경우 Notion이나 Google 문서 등을 사용하여 하나로 묶어 주세요. 링크를 공유하실 때에는 해당 링크가 공개 권한으로 접근 가능한지 확인해주세요.

## 변경 전
![image](https://user-images.githubusercontent.com/71116429/194047180-8c1559b7-6592-4488-8abd-681d78285bcd.png)

## 변경 후
![image](https://user-images.githubusercontent.com/71116429/194046643-f28b4a26-3d45-4de3-b580-66fad8cd15ee.png)


# 어떤 부분에 집중하여 리뷰해야 할까요?
- 설명 문구가 맞게 변경되었는지 확인해주세요.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
