### PR TITLE
feat(judgment): implement the function to apply and retrieve judgment results

### DIFF
--- a/src/docs/asciidoc/judgment.adoc
+++ b/src/docs/asciidoc/judgment.adoc
@@ -4,6 +4,10 @@
 
 operation::judgment-judge-example-post[snippets='http-request,http-response']
 
+== 예제 테스트 결과 조회
+
+operation::judgment-judge-example-get[snippets='http-request,http-response']
+
 == 자동 채점 성공
 
 operation::judgment-success-result-post[snippets='http-request,http-response']

--- a/src/main/kotlin/apply/application/AssignmentDtos.kt
+++ b/src/main/kotlin/apply/application/AssignmentDtos.kt
@@ -15,7 +15,7 @@ data class AssignmentRequest(
 
     @field:Pattern(
         regexp = "https://github\\.com(/[\\w\\-]+){2}/pull/[1-9]\\d*",
-        message = "올바른 형식의 URL이어야 합니다"
+        message = "올바른 형식의 Pull Request URL이어야 합니다"
     )
     val pullRequestUrl: String,
 

--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -149,7 +149,6 @@ class EvaluationTargetService(
 
     fun grade(evaluationTargetId: Long, request: EvaluationTargetData) {
         val evaluationTarget = evaluationTargetRepository.getById(evaluationTargetId)
-
         val evaluationAnswers = request.evaluationItemScores
             .map { EvaluationAnswer(it.score, it.id) }
             .toMutableList()

--- a/src/main/kotlin/apply/application/GradingService.kt
+++ b/src/main/kotlin/apply/application/GradingService.kt
@@ -11,11 +11,13 @@ import apply.domain.judgmentitem.JudgmentItemRepository
 import apply.domain.judgmentitem.getByMissionId
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
+import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionalEventListener
 
 @Transactional
+@Service
 class GradingService(
     private val evaluationTargetRepository: EvaluationTargetRepository,
     private val missionRepository: MissionRepository,

--- a/src/main/kotlin/apply/application/GradingService.kt
+++ b/src/main/kotlin/apply/application/GradingService.kt
@@ -1,0 +1,50 @@
+package apply.application
+
+import apply.domain.assignment.AssignmentRepository
+import apply.domain.assignment.getById
+import apply.domain.evaluationtarget.EvaluationTargetRepository
+import apply.domain.evaluationtarget.getByEvaluationIdAndUserId
+import apply.domain.judgment.JudgmentStartedEvent
+import apply.domain.judgment.JudgmentSucceededEvent
+import apply.domain.judgment.JudgmentTouchedEvent
+import apply.domain.judgmentitem.JudgmentItemRepository
+import apply.domain.judgmentitem.getByMissionId
+import apply.domain.mission.MissionRepository
+import apply.domain.mission.getById
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Transactional
+class GradingService(
+    private val evaluationTargetRepository: EvaluationTargetRepository,
+    private val missionRepository: MissionRepository,
+    private val judgmentItemRepository: JudgmentItemRepository,
+    private val assignmentRepository: AssignmentRepository
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(condition = "#event.type.evaluable")
+    fun grade(event: JudgmentStartedEvent) {
+        grade(event.assignmentId, 0)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(condition = "#event.type.evaluable")
+    fun grade(event: JudgmentTouchedEvent) {
+        grade(event.assignmentId, event.passCount)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(condition = "#event.type.evaluable")
+    fun grade(event: JudgmentSucceededEvent) {
+        grade(event.assignmentId, event.passCount)
+    }
+
+    private fun grade(assignmentId: Long, score: Int) {
+        val assignment = assignmentRepository.getById(assignmentId)
+        val mission = missionRepository.getById(assignment.missionId)
+        val judgmentItem = judgmentItemRepository.getByMissionId(mission.id)
+        val target = evaluationTargetRepository.getByEvaluationIdAndUserId(mission.evaluationId, assignment.userId)
+        target.updateScore(judgmentItem.evaluationItemId, score)
+    }
+}

--- a/src/main/kotlin/apply/application/JudgmentAllService.kt
+++ b/src/main/kotlin/apply/application/JudgmentAllService.kt
@@ -1,0 +1,27 @@
+package apply.application
+
+import apply.domain.assignment.AssignmentRepository
+import apply.domain.judgment.JudgmentType
+import apply.domain.judgmentitem.JudgmentItemRepository
+import apply.domain.mission.MissionRepository
+import apply.domain.mission.getByEvaluationId
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+@Service
+class JudgmentAllService(
+    private val judgmentService: JudgmentService,
+    private val missionRepository: MissionRepository,
+    private val judgmentItemRepository: JudgmentItemRepository,
+    private val assignmentRepository: AssignmentRepository
+) {
+    @Async
+    fun judgeAll(evaluationId: Long) {
+        val mission = missionRepository.getByEvaluationId(evaluationId)
+        check(judgmentItemRepository.existsByMissionId(mission.id)) { "자동 채점을 실행할 수 없습니다." }
+        val assignments = assignmentRepository.findAllByMissionId(mission.id)
+        assignments.forEach {
+            runCatching { judgmentService.judge(mission, it, JudgmentType.REAL) }
+        }
+    }
+}

--- a/src/main/kotlin/apply/application/JudgmentDtos.kt
+++ b/src/main/kotlin/apply/application/JudgmentDtos.kt
@@ -66,8 +66,13 @@ data class JudgmentData(
     val startedDateTime: LocalDateTime?,
     val id: Long
 ) {
-    constructor(id: Long?, evaluationItemId: Long?, assignmentId: Long?, judgmentRecord: JudgmentRecord?) : this(
-        evaluationItemId ?: 0L,
+    constructor(
+        id: Long? = null,
+        evaluationItemId: Long,
+        assignmentId: Long? = null,
+        judgmentRecord: JudgmentRecord? = null
+    ) : this(
+        evaluationItemId,
         assignmentId ?: 0L,
         judgmentRecord?.commit?.hash,
         judgmentRecord?.status,

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -20,6 +20,7 @@ import apply.domain.mission.Mission
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getByEvaluationId
 import apply.domain.mission.getById
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -55,10 +56,12 @@ class JudgmentService(
         return judge(mission, assignment, JudgmentType.REAL)
     }
 
+    @Async
     fun judgeAll(missionId: Long) {
         judgeAll(missionRepository.getById(missionId))
     }
 
+    @Async
     fun judgeAllByEvaluationId(evaluationId: Long) {
         judgeAll(missionRepository.getByEvaluationId(evaluationId))
     }

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -4,26 +4,20 @@ import apply.domain.assignment.Assignment
 import apply.domain.assignment.AssignmentRepository
 import apply.domain.assignment.getById
 import apply.domain.assignment.getByUserIdAndMissionId
-import apply.domain.evaluationtarget.EvaluationAnswer
 import apply.domain.evaluationtarget.EvaluationTargetRepository
-import apply.domain.evaluationtarget.getByEvaluationIdAndUserId
 import apply.domain.evaluationtarget.getById
 import apply.domain.judgment.AssignmentArchive
 import apply.domain.judgment.Commit
 import apply.domain.judgment.Judgment
 import apply.domain.judgment.JudgmentRepository
-import apply.domain.judgment.JudgmentSucceededEvent
-import apply.domain.judgment.JudgmentTouchedEvent
 import apply.domain.judgment.JudgmentType
 import apply.domain.judgment.getById
 import apply.domain.judgmentitem.JudgmentItemRepository
-import apply.domain.judgmentitem.getByMissionId
 import apply.domain.mission.Mission
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.event.TransactionalEventListener
 
 @Transactional
 @Service
@@ -54,26 +48,6 @@ class JudgmentService(
         val judgment = judgmentRepository.getById(judgmentId)
         judgment.success(Commit(request.commit), request.passCount, request.totalCount)
         judgmentRepository.save(judgment)
-    }
-
-    @TransactionalEventListener(condition = "#event.type.name() == 'REAL'")
-    fun changeAnswer(event: JudgmentTouchedEvent) {
-        val assignment = assignmentRepository.getById(event.assignmentId)
-        val mission = missionRepository.getById(assignment.missionId)
-        val judgmentItem = judgmentItemRepository.getByMissionId(mission.id)
-        val evaluationTarget = evaluationTargetRepository
-            .getByEvaluationIdAndUserId(mission.evaluationId, assignment.userId)
-        evaluationTarget.addEvaluationAnswer(EvaluationAnswer(event.passCount, judgmentItem.evaluationItemId))
-    }
-
-    @TransactionalEventListener(condition = "#event.type.name() == 'REAL'")
-    fun changeAnswer(event: JudgmentSucceededEvent) {
-        val assignment = assignmentRepository.getById(event.assignmentId)
-        val mission = missionRepository.getById(assignment.missionId)
-        val judgmentItem = judgmentItemRepository.getByMissionId(mission.id)
-        val evaluationTarget = evaluationTargetRepository
-            .getByEvaluationIdAndUserId(mission.evaluationId, assignment.userId)
-        evaluationTarget.addEvaluationAnswer(EvaluationAnswer(event.passCount, judgmentItem.evaluationItemId))
     }
 
     fun fail(judgmentId: Long, request: FailJudgmentRequest) {

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -20,7 +20,6 @@ import apply.domain.judgmentitem.getByMissionId
 import apply.domain.mission.Mission
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
-import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionalEventListener
@@ -56,12 +55,13 @@ class JudgmentService(
         judgmentRepository.save(judgment)
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener(condition = "#event.type.name() == 'REAL'")
     fun changeAnswer(event: JudgmentSucceededEvent) {
         val assignment = assignmentRepository.getById(event.assignmentId)
         val mission = missionRepository.getById(assignment.missionId)
         val judgmentItem = judgmentItemRepository.getByMissionId(mission.id)
-        val evaluationTarget = evaluationTargetRepository.getByEvaluationIdAndUserId(mission.evaluationId, assignment.userId)
+        val evaluationTarget = evaluationTargetRepository
+            .getByEvaluationIdAndUserId(mission.evaluationId, assignment.userId)
         evaluationTarget.addEvaluationAnswer(EvaluationAnswer(event.passCount, judgmentItem.evaluationItemId))
     }
 

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -18,6 +18,7 @@ import apply.domain.judgmentitem.JudgmentItemRepository
 import apply.domain.judgmentitem.getByMissionId
 import apply.domain.mission.Mission
 import apply.domain.mission.MissionRepository
+import apply.domain.mission.getByEvaluationId
 import apply.domain.mission.getById
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -55,10 +56,17 @@ class JudgmentService(
     }
 
     fun judgeAll(missionId: Long) {
-        val mission = missionRepository.getById(missionId)
-        val assignments = assignmentRepository.findAllByMissionId(missionId)
-        for (assignment in assignments) {
-            runCatching { judge(mission, assignment, JudgmentType.REAL) }
+        judgeAll(missionRepository.getById(missionId))
+    }
+
+    fun judgeAllByEvaluationId(evaluationId: Long) {
+        judgeAll(missionRepository.getByEvaluationId(evaluationId))
+    }
+
+    private fun judgeAll(mission: Mission) {
+        val assignments = assignmentRepository.findAllByMissionId(mission.id)
+        assignments.forEach {
+            runCatching { judge(mission, it, JudgmentType.REAL) }
         }
     }
 
@@ -83,7 +91,7 @@ class JudgmentService(
     private fun find(userId: Long, missionId: Long, judgmentType: JudgmentType): LastJudgmentResponse? {
         val assignment = assignmentRepository.getByUserIdAndMissionId(userId, missionId)
         val judgment = judgmentRepository.findByAssignmentIdAndType(assignment.id, judgmentType)
-        return judgment?.let { LastJudgmentResponse(assignment.pullRequestUrl, judgment.lastRecord) }
+        return judgment?.let { LastJudgmentResponse(assignment.pullRequestUrl, it.lastRecord) }
     }
 
     @Transactional

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -48,6 +48,12 @@ class JudgmentService(
         return LastJudgmentResponse(assignment.pullRequestUrl, judgment.lastRecord)
     }
 
+    fun findExample(userId: Long, missionId: Long): LastJudgmentResponse? {
+        val assignment = assignmentRepository.getByUserIdAndMissionId(userId, missionId)
+        val judgment = judgmentRepository.findByAssignmentIdAndType(assignment.id, JudgmentType.EXAMPLE)
+        return judgment?.let { LastJudgmentResponse(assignment.pullRequestUrl, judgment.lastRecord) }
+    }
+
     fun success(judgmentId: Long, request: SuccessJudgmentRequest) {
         val judgment = judgmentRepository.getById(judgmentId)
         judgment.success(Commit(request.commit), request.passCount, request.totalCount)

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -79,11 +79,13 @@ class JudgmentService(
     fun fail(judgmentId: Long, request: FailJudgmentRequest) {
         val judgment = judgmentRepository.getById(judgmentId)
         judgment.fail(Commit(request.commit), request.message)
+        judgmentRepository.save(judgment)
     }
 
     fun cancel(judgmentId: Long, request: CancelJudgmentRequest) {
         val judgment = judgmentRepository.getById(judgmentId)
         judgment.cancel(Commit(request.commit), request.message)
+        judgmentRepository.save(judgment)
     }
 
     fun judgeReal(assignmentId: Long): LastJudgmentResponse {

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -80,14 +80,13 @@ class JudgmentService(
     @Transactional
     fun success(judgmentId: Long, request: SuccessJudgmentRequest) {
         val judgment = judgmentRepository.getById(judgmentId)
-        judgment.success(Commit(request.commit), request.passCount, request.totalCount)
-
         val assignment = assignmentRepository.getById(judgment.assignmentId)
         val mission = missionRepository.getById(assignment.missionId)
         val judgmentItem = judgmentItemRepository.getByMissionId(mission.id)
         val evaluationTarget =
             evaluationTargetRepository.getByEvaluationIdAndUserId(mission.evaluationId, assignment.userId)
 
+        judgment.success(Commit(request.commit), request.passCount, request.totalCount)
         evaluationTarget.addEvaluationAnswer(EvaluationAnswer(request.passCount, judgmentItem.evaluationItemId))
     }
 

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -64,8 +64,16 @@ class JudgmentService(
     }
 
     fun findExample(userId: Long, missionId: Long): LastJudgmentResponse? {
+        return find(userId, missionId, JudgmentType.EXAMPLE)
+    }
+
+    fun findReal(userId: Long, missionId: Long): LastJudgmentResponse? {
+        return find(userId, missionId, JudgmentType.REAL)
+    }
+
+    private fun find(userId: Long, missionId: Long, judgmentType: JudgmentType): LastJudgmentResponse? {
         val assignment = assignmentRepository.getByUserIdAndMissionId(userId, missionId)
-        val judgment = judgmentRepository.findByAssignmentIdAndType(assignment.id, JudgmentType.EXAMPLE)
+        val judgment = judgmentRepository.findByAssignmentIdAndType(assignment.id, judgmentType)
         return judgment?.let { LastJudgmentResponse(assignment.pullRequestUrl, judgment.lastRecord) }
     }
 

--- a/src/main/kotlin/apply/application/JudgmentService.kt
+++ b/src/main/kotlin/apply/application/JudgmentService.kt
@@ -67,9 +67,9 @@ class JudgmentService(
     }
 
     fun judge(mission: Mission, assignment: Assignment, judgmentType: JudgmentType): LastJudgmentResponse {
+        val commit = assignmentArchive.getLastCommit(assignment.pullRequestUrl, mission.period.endDateTime)
         var judgment = judgmentRepository.findByAssignmentIdAndType(assignment.id, judgmentType)
             ?: judgmentRepository.save(Judgment(assignment.id, judgmentType))
-        val commit = assignmentArchive.getLastCommit(assignment.pullRequestUrl, mission.period.endDateTime)
         judgment.start(commit)
         judgment = judgmentRepository.save(judgment)
         return LastJudgmentResponse(assignment.pullRequestUrl, judgment.lastRecord)

--- a/src/main/kotlin/apply/application/MissionDtos.kt
+++ b/src/main/kotlin/apply/application/MissionDtos.kt
@@ -103,9 +103,16 @@ data class MyMissionResponse(
     val submitted: Boolean,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
-    val status: MissionStatus
+    val status: MissionStatus,
+    val runnable: Boolean,
+    val judgment: LastJudgmentResponse?
 ) {
-    constructor(mission: Mission, submitted: Boolean) : this(
+    constructor(
+        mission: Mission,
+        submitted: Boolean = false,
+        runnable: Boolean = false,
+        judgment: LastJudgmentResponse? = null
+    ) : this(
         mission.id,
         mission.title,
         mission.description,
@@ -113,37 +120,9 @@ data class MyMissionResponse(
         submitted,
         mission.period.startDateTime,
         mission.period.endDateTime,
-        mission.status
-    )
-}
-
-data class MissionJudgmentResponse(
-    val id: Long,
-    val title: String,
-    val description: String,
-    val submittable: Boolean,
-    val submitted: Boolean,
-    val startDateTime: LocalDateTime,
-    val endDateTime: LocalDateTime,
-    val status: MissionStatus,
-    val isAutomation: Boolean,
-    val judgment: LastJudgmentResponse?,
-) {
-    constructor(
-        myMissionResponse: MyMissionResponse,
-        lastJudgmentResponse: LastJudgmentResponse?,
-        isAutomation: Boolean
-    ) : this(
-        myMissionResponse.id,
-        myMissionResponse.title,
-        myMissionResponse.description,
-        myMissionResponse.submittable,
-        myMissionResponse.submitted,
-        myMissionResponse.startDateTime,
-        myMissionResponse.endDateTime,
-        myMissionResponse.status,
-        isAutomation,
-        lastJudgmentResponse
+        mission.status,
+        runnable,
+        judgment
     )
 }
 

--- a/src/main/kotlin/apply/application/MissionDtos.kt
+++ b/src/main/kotlin/apply/application/MissionDtos.kt
@@ -117,6 +117,36 @@ data class MyMissionResponse(
     )
 }
 
+data class MissionJudgmentResponse(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val submittable: Boolean,
+    val submitted: Boolean,
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime,
+    val status: MissionStatus,
+    val isAutomation: Boolean,
+    val judgment: LastJudgmentResponse?,
+) {
+    constructor(
+        myMissionResponse: MyMissionResponse,
+        lastJudgmentResponse: LastJudgmentResponse?,
+        isAutomation: Boolean
+    ) : this(
+        myMissionResponse.id,
+        myMissionResponse.title,
+        myMissionResponse.description,
+        myMissionResponse.submittable,
+        myMissionResponse.submitted,
+        myMissionResponse.startDateTime,
+        myMissionResponse.endDateTime,
+        myMissionResponse.status,
+        isAutomation,
+        lastJudgmentResponse
+    )
+}
+
 data class JudgmentItemData(
     var id: Long = 0L,
     var testName: String = "",

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -1,10 +1,8 @@
 package apply.application
 
-import apply.domain.assignment.AssignmentRepository
 import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluation.getById
 import apply.domain.evaluationitem.EvaluationItemRepository
-import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.judgmentitem.JudgmentItem
 import apply.domain.judgmentitem.JudgmentItemRepository
 import apply.domain.mission.Mission
@@ -19,9 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 class MissionService(
     private val missionRepository: MissionRepository,
     private val evaluationRepository: EvaluationRepository,
-    private val evaluationTargetRepository: EvaluationTargetRepository,
     private val evaluationItemRepository: EvaluationItemRepository,
-    private val assignmentRepository: AssignmentRepository,
     private val judgmentItemRepository: JudgmentItemRepository
 ) {
     fun save(request: MissionData): MissionResponse {
@@ -96,16 +92,6 @@ class MissionService(
         val evaluationsById = evaluationRepository.findAllByRecruitmentId(recruitmentId).associateBy { it.id }
         val missions = missionRepository.findAllByEvaluationIdIn(evaluationsById.keys)
         return missions.map { MissionAndEvaluationResponse(it, evaluationsById.getValue(it.evaluationId)) }
-    }
-
-    fun findAllByUserIdAndRecruitmentId(userId: Long, recruitmentId: Long): List<MyMissionResponse> {
-        val evaluationIds = evaluationRepository.findAllByRecruitmentId(recruitmentId).map { it.id }
-        val includedEvaluationIds = evaluationIds
-            .filter { evaluationTargetRepository.existsByUserIdAndEvaluationId(userId, it) }
-        val assignments = assignmentRepository.findAllByUserId(userId)
-        return missionRepository.findAllByEvaluationIdIn(includedEvaluationIds)
-            .filterNot { it.hidden }
-            .map { mission -> MyMissionResponse(mission, assignments.any { it.missionId == mission.id }) }
     }
 
     fun deleteById(id: Long) {

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswers.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswers.kt
@@ -17,9 +17,9 @@ class EvaluationAnswers(
     val answers: List<EvaluationAnswer>
         get() = _answers
 
-    fun add(evaluationAnswer: EvaluationAnswer) {
-        _answers.removeIf { it.evaluationItemId == evaluationAnswer.evaluationItemId }
-        _answers.add(evaluationAnswer)
+    fun add(evaluationItemId: Long, score: Int) {
+        _answers.removeIf { it.evaluationItemId == evaluationItemId }
+        _answers.add(EvaluationAnswer(score, evaluationItemId))
     }
 
     fun allZero(): Boolean = answers.all { it.score == 0 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswers.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationAnswers.kt
@@ -18,6 +18,7 @@ class EvaluationAnswers(
         get() = _answers
 
     fun add(evaluationAnswer: EvaluationAnswer) {
+        _answers.removeIf { it.evaluationItemId == evaluationAnswer.evaluationItemId }
         _answers.add(evaluationAnswer)
     }
 

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
@@ -51,4 +51,8 @@ class EvaluationTarget(
         this.evaluationAnswers = evaluationAnswers
         this.note = note
     }
+
+    fun addEvaluationAnswer(evaluationAnswer: EvaluationAnswer) {
+        evaluationAnswers.add(evaluationAnswer)
+    }
 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTarget.kt
@@ -52,7 +52,7 @@ class EvaluationTarget(
         this.note = note
     }
 
-    fun addEvaluationAnswer(evaluationAnswer: EvaluationAnswer) {
-        evaluationAnswers.add(evaluationAnswer)
+    fun updateScore(evaluationItemId: Long, score: Int) {
+        evaluationAnswers.add(evaluationItemId, score)
     }
 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -15,7 +15,7 @@ interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
     fun findAllByEvaluationId(evaluationId: Long): List<EvaluationTarget>
     fun deleteByUserIdIn(userIds: Collection<Long>)
     fun deleteByEvaluationIdAndUserIdIn(evaluationId: Long, userIds: Collection<Long>)
-    fun findAllByEvaluationIdAndUserIdIn(evaluationId: Long, userIds: Set<Long>): List<EvaluationTarget>
+    fun findAllByEvaluationIdAndUserIdIn(evaluationId: Long, userIds: Collection<Long>): List<EvaluationTarget>
     fun findAllByEvaluationIdAndEvaluationStatus(
         evaluationId: Long,
         evaluationStatus: EvaluationStatus

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -3,12 +3,12 @@ package apply.domain.evaluationtarget
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.repository.findByIdOrNull
 
-fun EvaluationTargetRepository.getById(id: Long): EvaluationTarget = findByIdOrNull(id)
-    ?: throw NoSuchElementException("평가 대상자가 존재하지 않습니다. id: $id")
-
 fun EvaluationTargetRepository.getByEvaluationIdAndUserId(evaluationId: Long, userId: Long) =
     findByEvaluationIdAndUserId(evaluationId, userId)
         ?: throw NoSuchElementException("평가 대상자가 존재하지 않습니다. evaluationId: $evaluationId, userId: $userId")
+
+fun EvaluationTargetRepository.getById(id: Long): EvaluationTarget = findByIdOrNull(id)
+    ?: throw NoSuchElementException("평가 대상자가 존재하지 않습니다. id: $id")
 
 interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
     fun findByEvaluationIdAndUserId(evaluationId: Long, userId: Long): EvaluationTarget?

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -21,5 +21,5 @@ interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
         evaluationStatus: EvaluationStatus
     ): List<EvaluationTarget>
 
-    fun existsByUserIdAndEvaluationId(userId: Long, evaluationId: Long): Boolean
+    fun findAllByUserIdAndEvaluationIdIn(userId: Long, evaluationIds: Collection<Long>): List<EvaluationTarget>
 }

--- a/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
+++ b/src/main/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepository.kt
@@ -6,6 +6,10 @@ import org.springframework.data.repository.findByIdOrNull
 fun EvaluationTargetRepository.getById(id: Long): EvaluationTarget = findByIdOrNull(id)
     ?: throw NoSuchElementException("평가 대상자가 존재하지 않습니다. id: $id")
 
+fun EvaluationTargetRepository.getByEvaluationIdAndUserId(evaluationId: Long, userId: Long) =
+    findByEvaluationIdAndUserId(evaluationId, userId)
+        ?: throw NoSuchElementException("평가 대상자가 존재하지 않습니다. evaluationId: $evaluationId, userId: $userId")
+
 interface EvaluationTargetRepository : JpaRepository<EvaluationTarget, Long> {
     fun findByEvaluationIdAndUserId(evaluationId: Long, userId: Long): EvaluationTarget?
     fun findAllByEvaluationId(evaluationId: Long): List<EvaluationTarget>

--- a/src/main/kotlin/apply/domain/judgment/Judgment.kt
+++ b/src/main/kotlin/apply/domain/judgment/Judgment.kt
@@ -40,7 +40,7 @@ class Judgment(
         get() = records.maxByOrNull { it.startedDateTime } ?: throw NoSuchElementException()
 
     fun start(commit: Commit) {
-        check(canStart()) { "자동 채점을 시작할 수 없습니다." }
+        check(canStart()) { "예제 테스트를 실행할 수 없습니다." }
         val record = findRecord(commit) ?: createRecord(commit)
         if (record.touchable) {
             record.touch()

--- a/src/main/kotlin/apply/domain/judgment/Judgment.kt
+++ b/src/main/kotlin/apply/domain/judgment/Judgment.kt
@@ -44,6 +44,9 @@ class Judgment(
         val record = findRecord(commit) ?: createRecord(commit)
         if (record.touchable) {
             record.touch()
+            registerEvent(
+                JudgmentTouchedEvent(id, assignmentId, type, record.result.passCount, record.result.totalCount)
+            )
         } else {
             record.start()
             registerEvent(JudgmentStartedEvent(id, assignmentId, type, commit))

--- a/src/main/kotlin/apply/domain/judgment/Judgment.kt
+++ b/src/main/kotlin/apply/domain/judgment/Judgment.kt
@@ -7,6 +7,7 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.ForeignKey
 import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
@@ -22,7 +23,7 @@ class Judgment(
     records: List<JudgmentRecord> = emptyList(),
     id: Long = 0L
 ) : BaseRootEntity<Judgment>(id) {
-    @OneToMany(cascade = [CascadeType.PERSIST, CascadeType.REMOVE])
+    @OneToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE], fetch = FetchType.EAGER)
     @JoinColumn(
         name = "judgment_id", nullable = false, updatable = false,
         foreignKey = ForeignKey(name = "fk_judgment_record_judgment_id_ref_judgment_id")

--- a/src/main/kotlin/apply/domain/judgment/Judgment.kt
+++ b/src/main/kotlin/apply/domain/judgment/Judgment.kt
@@ -72,11 +72,13 @@ class Judgment(
     fun fail(commit: Commit, message: String) {
         val record = getRecord(commit)
         record.applyResult(JudgmentResult(message = message, status = JudgmentStatus.FAILED))
+        registerEvent(JudgmentFailedEvent(id, assignmentId, type))
     }
 
     fun cancel(commit: Commit, message: String) {
         val record = getRecord(commit)
         record.applyResult(JudgmentResult(message = message, status = JudgmentStatus.CANCELLED))
+        registerEvent(JudgmentCancelledEvent(id, assignmentId, type))
     }
 
     private fun getRecord(commit: Commit): JudgmentRecord = findRecord(commit)

--- a/src/main/kotlin/apply/domain/judgment/Judgment.kt
+++ b/src/main/kotlin/apply/domain/judgment/Judgment.kt
@@ -44,9 +44,8 @@ class Judgment(
         val record = findRecord(commit) ?: createRecord(commit)
         if (record.touchable) {
             record.touch()
-            registerEvent(
-                JudgmentTouchedEvent(id, assignmentId, type, record.result.passCount, record.result.totalCount)
-            )
+            val event = JudgmentTouchedEvent(id, assignmentId, type, record.result.passCount, record.result.totalCount)
+            registerEvent(event)
         } else {
             record.start()
             registerEvent(JudgmentStartedEvent(id, assignmentId, type, commit))
@@ -59,8 +58,7 @@ class Judgment(
     }
 
     private fun createRecord(commit: Commit): JudgmentRecord {
-        return JudgmentRecord(commit)
-            .also { records.add(it) }
+        return JudgmentRecord(commit).also { records.add(it) }
     }
 
     fun success(commit: Commit, passCount: Int, totalCount: Int) {

--- a/src/main/kotlin/apply/domain/judgment/Judgment.kt
+++ b/src/main/kotlin/apply/domain/judgment/Judgment.kt
@@ -63,6 +63,7 @@ class Judgment(
     fun success(commit: Commit, passCount: Int, totalCount: Int) {
         val record = getRecord(commit)
         record.applyResult(JudgmentResult(passCount, totalCount, status = JudgmentStatus.SUCCEEDED))
+        registerEvent(JudgmentSucceededEvent(id, assignmentId, type, passCount, totalCount))
     }
 
     fun fail(commit: Commit, message: String) {

--- a/src/main/kotlin/apply/domain/judgment/JudgmentEvents.kt
+++ b/src/main/kotlin/apply/domain/judgment/JudgmentEvents.kt
@@ -6,3 +6,11 @@ data class JudgmentStartedEvent(
     val type: JudgmentType,
     val commit: Commit
 )
+
+data class JudgmentSucceededEvent(
+    val judgmentId: Long,
+    val assignmentId: Long,
+    val type: JudgmentType,
+    val passCount: Int,
+    val totalCount: Int
+)

--- a/src/main/kotlin/apply/domain/judgment/JudgmentEvents.kt
+++ b/src/main/kotlin/apply/domain/judgment/JudgmentEvents.kt
@@ -22,3 +22,15 @@ data class JudgmentSucceededEvent(
     val passCount: Int,
     val totalCount: Int
 )
+
+data class JudgmentFailedEvent(
+    val judgmentId: Long,
+    val assignmentId: Long,
+    val type: JudgmentType
+)
+
+data class JudgmentCancelledEvent(
+    val judgmentId: Long,
+    val assignmentId: Long,
+    val type: JudgmentType
+)

--- a/src/main/kotlin/apply/domain/judgment/JudgmentEvents.kt
+++ b/src/main/kotlin/apply/domain/judgment/JudgmentEvents.kt
@@ -7,6 +7,14 @@ data class JudgmentStartedEvent(
     val commit: Commit
 )
 
+data class JudgmentTouchedEvent(
+    val judgmentId: Long,
+    val assignmentId: Long,
+    val type: JudgmentType,
+    val passCount: Int,
+    val totalCount: Int
+)
+
 data class JudgmentSucceededEvent(
     val judgmentId: Long,
     val assignmentId: Long,

--- a/src/main/kotlin/apply/domain/judgment/JudgmentRepository.kt
+++ b/src/main/kotlin/apply/domain/judgment/JudgmentRepository.kt
@@ -8,5 +8,5 @@ fun JudgmentRepository.getById(id: Long): Judgment = findByIdOrNull(id)
 
 interface JudgmentRepository : JpaRepository<Judgment, Long> {
     fun findByAssignmentIdAndType(assignmentId: Long, type: JudgmentType): Judgment?
-    fun findAllByAssignmentIdInAndType(assignmentId: Collection<Long>, type: JudgmentType): List<Judgment>
+    fun findAllByAssignmentIdInAndType(assignmentIds: Collection<Long>, type: JudgmentType): List<Judgment>
 }

--- a/src/main/kotlin/apply/domain/judgment/JudgmentRepository.kt
+++ b/src/main/kotlin/apply/domain/judgment/JudgmentRepository.kt
@@ -8,4 +8,5 @@ fun JudgmentRepository.getById(id: Long): Judgment = findByIdOrNull(id)
 
 interface JudgmentRepository : JpaRepository<Judgment, Long> {
     fun findByAssignmentIdAndType(assignmentId: Long, type: JudgmentType): Judgment?
+    fun findAllByAssignmentIdInAndType(assignmentId: Collection<Long>, type: JudgmentType): List<Judgment>
 }

--- a/src/main/kotlin/apply/domain/judgment/JudgmentType.kt
+++ b/src/main/kotlin/apply/domain/judgment/JudgmentType.kt
@@ -1,5 +1,5 @@
 package apply.domain.judgment
 
-enum class JudgmentType {
-    EXAMPLE, REAL
+enum class JudgmentType(val evaluable: Boolean) {
+    EXAMPLE(false), REAL(true)
 }

--- a/src/main/kotlin/apply/domain/judgmentitem/JudgmentItemRepository.kt
+++ b/src/main/kotlin/apply/domain/judgmentitem/JudgmentItemRepository.kt
@@ -7,7 +7,7 @@ fun JudgmentItemRepository.getByMissionId(missionId: Long): JudgmentItem = findB
 
 interface JudgmentItemRepository : JpaRepository<JudgmentItem, Long> {
     fun findByMissionId(missionId: Long): JudgmentItem?
-    fun findAllByMissionIdIn(missionId: Collection<Long>): List<JudgmentItem>
+    fun findAllByMissionIdIn(missionIds: Collection<Long>): List<JudgmentItem>
     fun deleteByMissionId(missionId: Long)
     fun existsByMissionId(missionId: Long): Boolean
 }

--- a/src/main/kotlin/apply/domain/judgmentitem/JudgmentItemRepository.kt
+++ b/src/main/kotlin/apply/domain/judgmentitem/JudgmentItemRepository.kt
@@ -7,6 +7,7 @@ fun JudgmentItemRepository.getByMissionId(missionId: Long): JudgmentItem = findB
 
 interface JudgmentItemRepository : JpaRepository<JudgmentItem, Long> {
     fun findByMissionId(missionId: Long): JudgmentItem?
+    fun findAllByMissionIdIn(missionId: Collection<Long>): List<JudgmentItem>
     fun deleteByMissionId(missionId: Long)
     fun existsByMissionId(missionId: Long): Boolean
 }

--- a/src/main/kotlin/apply/domain/mission/MissionRepository.kt
+++ b/src/main/kotlin/apply/domain/mission/MissionRepository.kt
@@ -3,6 +3,9 @@ package apply.domain.mission
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.repository.findByIdOrNull
 
+fun MissionRepository.getByEvaluationId(evaluationId: Long): Mission = findByEvaluationId(evaluationId)
+    ?: throw NoSuchElementException("과제가 존재하지 않습니다. evaluationId: $evaluationId")
+
 fun MissionRepository.getById(id: Long): Mission = findByIdOrNull(id)
     ?: throw NoSuchElementException("과제가 존재하지 않습니다. id: $id")
 

--- a/src/main/kotlin/apply/infra/github/GitHubClient.kt
+++ b/src/main/kotlin/apply/infra/github/GitHubClient.kt
@@ -48,7 +48,7 @@ class GitHubClient(
 
     private fun extract(pullRequestUrl: String): List<String> {
         val result = PULL_REQUEST_URL_PATTERN.find(pullRequestUrl)
-            ?: throw IllegalArgumentException("올바른 형식의 Pull Request URL이어야 합니다")
+            ?: throw IllegalArgumentException("올바른 형식의 Pull Request URL이어야 합니다.")
         return result.destructured.toList()
     }
 

--- a/src/main/kotlin/apply/infra/github/GitHubClient.kt
+++ b/src/main/kotlin/apply/infra/github/GitHubClient.kt
@@ -40,7 +40,7 @@ class GitHubClient(
 
     private fun extract(pullRequestUrl: String): List<String> {
         val result = PULL_REQUEST_URL_PATTERN.find(pullRequestUrl)
-            ?: throw IllegalArgumentException("올바른 형식의 URL이어야 합니다")
+            ?: throw IllegalArgumentException("올바른 형식의 Pull Request URL이어야 합니다")
         return result.destructured.toList()
     }
 

--- a/src/main/kotlin/apply/security/AccessorResolver.kt
+++ b/src/main/kotlin/apply/security/AccessorResolver.kt
@@ -11,7 +11,7 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-private const val BASIC = "Basic"
+private const val BASIC: String = "Basic"
 
 @Component
 class AccessorResolver(
@@ -27,14 +27,14 @@ class AccessorResolver(
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
     ) {
-        val token = extractBearerToken(webRequest)
+        val token = extractBasicToken(webRequest)
         val decoded = token.decode(StandardCharsets.UTF_8)
         if (!isAuthenticated(decoded, parameter)) {
             throw LoginFailedException()
         }
     }
 
-    private fun extractBearerToken(request: NativeWebRequest): String {
+    private fun extractBasicToken(request: NativeWebRequest): String {
         val authorization = request.getHeader(AUTHORIZATION) ?: throw LoginFailedException()
         val (tokenType, token) = authorization.split(" ")
         if (tokenType != BASIC) {

--- a/src/main/kotlin/apply/ui/admin/selections/EvaluationTargetFormDialog.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/EvaluationTargetFormDialog.kt
@@ -6,7 +6,7 @@ import apply.application.EvaluationTargetData
 import apply.application.EvaluationTargetService
 import apply.application.JudgmentData
 import apply.application.JudgmentService
-import apply.domain.judgment.JudgmentType
+import apply.application.MyMissionService
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.dialog.Dialog
@@ -23,6 +23,7 @@ import support.views.createPrimaryButton
 class EvaluationTargetFormDialog(
     private val evaluationTargetService: EvaluationTargetService,
     assignmentService: AssignmentService,
+    myMissionService: MyMissionService,
     private val judgmentService: JudgmentService,
     private val evaluationTargetId: Long,
     reloadComponents: () -> Unit
@@ -34,8 +35,7 @@ class EvaluationTargetFormDialog(
     }
     private val evaluationTargetForm: BindingFormLayout<EvaluationTargetData>
     private val assignment: AssignmentData? = assignmentService.findByEvaluationTargetId(evaluationTargetId)
-    private val judgment: JudgmentData? =
-        judgmentService.findByEvaluationTargetId(evaluationTargetId, JudgmentType.REAL)
+    private val judgment: JudgmentData? = myMissionService.findLastRealJudgmentByEvaluationTargetId(evaluationTargetId)
 
     init {
         val response = evaluationTargetService.getGradeEvaluation(evaluationTargetId)

--- a/src/main/kotlin/apply/ui/admin/selections/JudgmentForm.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/JudgmentForm.kt
@@ -38,7 +38,7 @@ class JudgmentForm(
     private fun createJudgmentRequestButton(): Button {
         return createContrastButton("실행") {
             try {
-                judgmentService.judgeRealByAssignmentId(judgmentData.assignmentId)
+                judgmentService.judgeReal(judgmentData.assignmentId)
                 createNotification("자동 채점이 실행되었습니다.")
             } catch (e: Exception) {
                 createNotification(e.localizedMessage)

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -11,6 +11,7 @@ import apply.application.EvaluationTargetService
 import apply.application.ExcelService
 import apply.application.JudgmentAllService
 import apply.application.JudgmentService
+import apply.application.MyMissionService
 import apply.application.RecruitmentItemService
 import apply.application.RecruitmentService
 import apply.domain.applicationform.ApplicationForm
@@ -52,14 +53,15 @@ import support.views.downloadFile
 
 @Route(value = "admin/selections", layout = BaseLayout::class)
 class SelectionView(
-    private val applicantService: ApplicantService,
     private val recruitmentService: RecruitmentService,
     private val recruitmentItemService: RecruitmentItemService,
+    private val applicantService: ApplicantService,
     private val evaluationService: EvaluationService,
     private val evaluationTargetService: EvaluationTargetService,
     private val assignmentService: AssignmentService,
     private val judgmentService: JudgmentService,
     private val judgmentAllService: JudgmentAllService,
+    private val myMissionService: MyMissionService,
     private val excelService: ExcelService,
     private val evaluationTargetCsvService: EvaluationTargetCsvService
 ) : VerticalLayout(), HasUrlParameter<Long> {
@@ -174,7 +176,13 @@ class SelectionView(
     private fun createEvaluationButtonRenderer(): Renderer<EvaluationTargetResponse> {
         return ComponentRenderer { response ->
             createPrimarySmallButton("평가하기") {
-                EvaluationTargetFormDialog(evaluationTargetService, assignmentService, judgmentService, response.id) {
+                EvaluationTargetFormDialog(
+                    evaluationTargetService,
+                    assignmentService,
+                    myMissionService,
+                    judgmentService,
+                    response.id
+                ) {
                     selectedTabIndex = tabs.selectedIndex
                     removeAll()
                     add(createTitle(), createContent())
@@ -277,7 +285,6 @@ class SelectionView(
                 )
                 items.plusElement(referenceItem)
             }
-
             else -> items
         }
     }

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -223,7 +223,6 @@ class SelectionView(
 
     private fun createJudgeAllButton(tabs: Tabs): Button {
         return createContrastButtonWithDialog("전체 자동 채점하기", "자동 채점을 실행하시겠습니까?") {
-            println(selectedEvaluation(tabs))
             val evaluation = selectedEvaluation(tabs)
             judgmentService.judgeAllByEvaluationId(evaluation.id)
             selectedTabIndex = tabs.selectedIndex

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -9,6 +9,7 @@ import apply.application.EvaluationTargetCsvService
 import apply.application.EvaluationTargetResponse
 import apply.application.EvaluationTargetService
 import apply.application.ExcelService
+import apply.application.JudgmentAllService
 import apply.application.JudgmentService
 import apply.application.RecruitmentItemService
 import apply.application.RecruitmentService
@@ -58,6 +59,7 @@ class SelectionView(
     private val evaluationTargetService: EvaluationTargetService,
     private val assignmentService: AssignmentService,
     private val judgmentService: JudgmentService,
+    private val judgmentAllService: JudgmentAllService,
     private val excelService: ExcelService,
     private val evaluationTargetCsvService: EvaluationTargetCsvService
 ) : VerticalLayout(), HasUrlParameter<Long> {
@@ -203,7 +205,7 @@ class SelectionView(
 
     private fun createLoadButton(tabs: Tabs): Button {
         return createPrimaryButton("평가 대상자 불러오기") {
-            val evaluation = selectedEvaluation(tabs)
+            val evaluation = tabs.findEvaluation() ?: return@createPrimaryButton
             evaluationTargetService.load(evaluation.id)
             selectedTabIndex = tabs.selectedIndex
             removeAll()
@@ -223,19 +225,13 @@ class SelectionView(
 
     private fun createJudgeAllButton(tabs: Tabs): Button {
         return createContrastButtonWithDialog("전체 자동 채점하기", "자동 채점을 실행하시겠습니까?") {
-            val evaluation = selectedEvaluation(tabs)
-            judgmentService.judgeAllByEvaluationId(evaluation.id)
-            selectedTabIndex = tabs.selectedIndex
-            removeAll()
-            add(
-                createTitle(),
-                createContent()
-            )
+            val evaluation = tabs.findEvaluation() ?: return@createContrastButtonWithDialog
+            judgmentAllService.judgeAll(evaluation.id)
         }
     }
 
-    private fun selectedEvaluation(tabs: Tabs): EvaluationSelectData {
-        return evaluations.first { it.title == tabs.selectedTab.label }
+    private fun Tabs.findEvaluation(): EvaluationSelectData? {
+        return evaluations.find { it.title == selectedTab.label }
     }
 
     private fun createEvaluationFileUpload(): Upload {

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -10,7 +10,6 @@ import apply.application.EvaluationTargetResponse
 import apply.application.EvaluationTargetService
 import apply.application.ExcelService
 import apply.application.JudgmentService
-import apply.application.MissionService
 import apply.application.RecruitmentItemService
 import apply.application.RecruitmentService
 import apply.domain.applicationform.ApplicationForm
@@ -60,8 +59,7 @@ class SelectionView(
     private val assignmentService: AssignmentService,
     private val judgmentService: JudgmentService,
     private val excelService: ExcelService,
-    private val evaluationTargetCsvService: EvaluationTargetCsvService,
-    private val missionService: MissionService,
+    private val evaluationTargetCsvService: EvaluationTargetCsvService
 ) : VerticalLayout(), HasUrlParameter<Long> {
     private var recruitmentId: Long = 0L
     private var evaluations: List<EvaluationSelectData> =
@@ -98,7 +96,7 @@ class SelectionView(
             HorizontalLayout(
                 createLoadButton(tabs),
                 createResultDownloadButton(),
-                createJudgeAllButton()
+                createJudgeAllButton(tabs)
             )
         ).apply {
             setWidthFull()
@@ -205,7 +203,7 @@ class SelectionView(
 
     private fun createLoadButton(tabs: Tabs): Button {
         return createPrimaryButton("평가 대상자 불러오기") {
-            val evaluation = evaluations.first { it.title == tabs.selectedTab.label }
+            val evaluation = selectedEvaluation(tabs)
             evaluationTargetService.load(evaluation.id)
             selectedTabIndex = tabs.selectedIndex
             removeAll()
@@ -223,10 +221,22 @@ class SelectionView(
         }
     }
 
-    private fun createJudgeAllButton(): Button {
+    private fun createJudgeAllButton(tabs: Tabs): Button {
         return createContrastButtonWithDialog("전체 자동 채점하기", "자동 채점을 실행하시겠습니까?") {
-            // TODO: 전체 자동 채점 기능 구현
+            println(selectedEvaluation(tabs))
+            val evaluation = selectedEvaluation(tabs)
+            judgmentService.judgeAllByEvaluationId(evaluation.id)
+            selectedTabIndex = tabs.selectedIndex
+            removeAll()
+            add(
+                createTitle(),
+                createContent()
+            )
         }
+    }
+
+    private fun selectedEvaluation(tabs: Tabs): EvaluationSelectData {
+        return evaluations.first { it.title == tabs.selectedTab.label }
     }
 
     private fun createEvaluationFileUpload(): Upload {
@@ -272,6 +282,7 @@ class SelectionView(
                 )
                 items.plusElement(referenceItem)
             }
+
             else -> items
         }
     }

--- a/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
@@ -51,6 +51,16 @@ class JudgmentRestController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @GetMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-real")
+    fun findReal(
+        @PathVariable recruitmentId: Long,
+        @PathVariable missionId: Long,
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
+        val response = judgmentService.findReal(user.id, missionId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
     @PostMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-all")
     fun judgeAll(
         @PathVariable recruitmentId: Long,

--- a/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
@@ -39,7 +39,7 @@ class JudgmentRestController(
         @PathVariable missionId: Long,
         @LoginUser user: User
     ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
-        val response = judgmentService.findExample(user.id, missionId)
+        val response = judgmentService.findLastExampleJudgment(user.id, missionId)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 

--- a/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
@@ -2,6 +2,7 @@ package apply.ui.api
 
 import apply.application.CancelJudgmentRequest
 import apply.application.FailJudgmentRequest
+import apply.application.JudgmentAllService
 import apply.application.JudgmentService
 import apply.application.LastJudgmentResponse
 import apply.application.SuccessJudgmentRequest
@@ -19,7 +20,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api")
 @RestController
 class JudgmentRestController(
-    private val judgmentService: JudgmentService
+    private val judgmentService: JudgmentService,
+    private val judgmentAllService: JudgmentAllService
 ) {
     @PostMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-example")
     fun judgeExample(
@@ -39,36 +41,6 @@ class JudgmentRestController(
     ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
         val response = judgmentService.findExample(user.id, missionId)
         return ResponseEntity.ok(ApiResponse.success(response))
-    }
-
-    @PostMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-real")
-    fun judgeReal(
-        @PathVariable recruitmentId: Long,
-        @PathVariable missionId: Long,
-        @LoginUser(administrator = true) user: User
-    ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
-        val response = judgmentService.judgeReal(user.id, missionId)
-        return ResponseEntity.ok(ApiResponse.success(response))
-    }
-
-    @GetMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-real")
-    fun findReal(
-        @PathVariable recruitmentId: Long,
-        @PathVariable missionId: Long,
-        @LoginUser(administrator = true) user: User
-    ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
-        val response = judgmentService.findReal(user.id, missionId)
-        return ResponseEntity.ok(ApiResponse.success(response))
-    }
-
-    @PostMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-all")
-    fun judgeAll(
-        @PathVariable recruitmentId: Long,
-        @PathVariable missionId: Long,
-        @LoginUser(administrator = true) user: User
-    ): ResponseEntity<Unit> {
-        judgmentService.judgeAll(missionId)
-        return ResponseEntity.ok().build()
     }
 
     @PostMapping("/judgments/{judgmentId}/success")
@@ -98,6 +70,25 @@ class JudgmentRestController(
         @Accessor("lambda") ignored: Unit
     ): ResponseEntity<Unit> {
         judgmentService.cancel(judgmentId, request)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/evaluations/{evaluationId}/assignments/{assignmentId}/judgments/judge-real")
+    fun judgeReal(
+        @PathVariable evaluationId: Long,
+        @PathVariable assignmentId: Long,
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
+        val response = judgmentService.judgeReal(assignmentId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PostMapping("/evaluations/{evaluationId}/judgments/judge-all")
+    fun judgeAll(
+        @PathVariable evaluationId: Long,
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<Unit> {
+        judgmentAllService.judgeAll(evaluationId)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
@@ -51,12 +51,22 @@ class JudgmentRestController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @PostMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-all")
+    fun judgeAll(
+        @PathVariable recruitmentId: Long,
+        @PathVariable missionId: Long,
+        @LoginUser(administrator = true) user: User
+    ): ResponseEntity<Unit> {
+        judgmentService.judgeAll(missionId)
+        return ResponseEntity.ok().build()
+    }
+
     @PostMapping("/judgments/{judgmentId}/success")
     fun success(
         @PathVariable judgmentId: Long,
         @RequestBody request: SuccessJudgmentRequest,
         @Accessor("lambda") ignored: Unit
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         judgmentService.success(judgmentId, request)
         return ResponseEntity.ok().build()
     }
@@ -66,7 +76,7 @@ class JudgmentRestController(
         @PathVariable judgmentId: Long,
         @RequestBody request: FailJudgmentRequest,
         @Accessor("lambda") ignored: Unit
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         judgmentService.fail(judgmentId, request)
         return ResponseEntity.ok().build()
     }
@@ -76,7 +86,7 @@ class JudgmentRestController(
         @PathVariable judgmentId: Long,
         @RequestBody request: CancelJudgmentRequest,
         @Accessor("lambda") ignored: Unit
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         judgmentService.cancel(judgmentId, request)
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
+++ b/src/main/kotlin/apply/ui/api/JudgmentRestController.kt
@@ -9,6 +9,7 @@ import apply.domain.user.User
 import apply.security.Accessor
 import apply.security.LoginUser
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -27,6 +28,16 @@ class JudgmentRestController(
         @LoginUser user: User
     ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
         val response = judgmentService.judgeExample(user.id, missionId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-example")
+    fun findExample(
+        @PathVariable recruitmentId: Long,
+        @PathVariable missionId: Long,
+        @LoginUser user: User
+    ): ResponseEntity<ApiResponse<LastJudgmentResponse>> {
+        val response = judgmentService.findExample(user.id, missionId)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 

--- a/src/main/kotlin/apply/ui/api/MissionRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MissionRestController.kt
@@ -1,11 +1,11 @@
 package apply.ui.api
 
-import apply.application.JudgmentService
 import apply.application.MissionAndEvaluationResponse
 import apply.application.MissionData
-import apply.application.MissionJudgmentResponse
 import apply.application.MissionResponse
 import apply.application.MissionService
+import apply.application.MyMissionResponse
+import apply.application.MyMissionService
 import apply.domain.user.User
 import apply.security.LoginUser
 import org.springframework.http.ResponseEntity
@@ -22,7 +22,7 @@ import support.toUri
 @RestController
 class MissionRestController(
     private val missionService: MissionService,
-    private val judgmentService: JudgmentService
+    private val missionQueryService: MyMissionService
 ) {
     @PostMapping
     fun save(
@@ -58,10 +58,8 @@ class MissionRestController(
     fun findMyMissionsByRecruitmentId(
         @PathVariable recruitmentId: Long,
         @LoginUser user: User
-    ): ResponseEntity<ApiResponse<List<MissionJudgmentResponse>>> {
-        val missionResponses = missionService.findAllByUserIdAndRecruitmentId(user.id, recruitmentId)
-        val judgmentResponses = missionResponses.associateWith { judgmentService.findExample(user.id, it.id) }
-        val responses = judgmentResponses.map { MissionJudgmentResponse(it.key, it.value, it.value != null) }
+    ): ResponseEntity<ApiResponse<List<MyMissionResponse>>> {
+        val responses = missionQueryService.findAllByUserIdAndRecruitmentId(user.id, recruitmentId)
         return ResponseEntity.ok(ApiResponse.success(responses))
     }
 

--- a/src/main/kotlin/apply/ui/api/MissionRestController.kt
+++ b/src/main/kotlin/apply/ui/api/MissionRestController.kt
@@ -60,9 +60,8 @@ class MissionRestController(
         @LoginUser user: User
     ): ResponseEntity<ApiResponse<List<MissionJudgmentResponse>>> {
         val missionResponses = missionService.findAllByUserIdAndRecruitmentId(user.id, recruitmentId)
-        val judgmentResponses = missionResponses.associateBy({ it }, { judgmentService.findExample(user.id, it.id) })
+        val judgmentResponses = missionResponses.associateWith { judgmentService.findExample(user.id, it.id) }
         val responses = judgmentResponses.map { MissionJudgmentResponse(it.key, it.value, it.value != null) }
-
         return ResponseEntity.ok(ApiResponse.success(responses))
     }
 

--- a/src/main/kotlin/apply/ui/api/UserRestController.kt
+++ b/src/main/kotlin/apply/ui/api/UserRestController.kt
@@ -79,16 +79,16 @@ class UserRestController(
         @RequestParam keyword: String,
         @LoginUser(administrator = true) user: User
     ): ResponseEntity<ApiResponse<List<UserResponse>>> {
-        val users = userService.findAllByKeyword(keyword)
-        return ResponseEntity.ok(ApiResponse.success(users))
+        val responses = userService.findAllByKeyword(keyword)
+        return ResponseEntity.ok(ApiResponse.success(responses))
     }
 
     @GetMapping("/me")
     fun getMyInformation(
         @LoginUser user: User
     ): ResponseEntity<ApiResponse<UserResponse>> {
-        val user = userService.getInformation(user.id)
-        return ResponseEntity.ok(ApiResponse.success(user))
+        val response = userService.getInformation(user.id)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @PatchMapping("/information")

--- a/src/test/kotlin/apply/MissionFixtures.kt
+++ b/src/test/kotlin/apply/MissionFixtures.kt
@@ -4,7 +4,6 @@ import apply.application.EvaluationSelectData
 import apply.application.JudgmentItemData
 import apply.application.LastJudgmentResponse
 import apply.application.MissionData
-import apply.application.MissionJudgmentResponse
 import apply.application.MissionResponse
 import apply.application.MyMissionResponse
 import apply.domain.mission.Mission
@@ -81,24 +80,11 @@ fun createMyMissionResponse(
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
     missionStatus: MissionStatus = MissionStatus.SUBMITTING,
-    id: Long = 0L
-): MyMissionResponse {
-    return MyMissionResponse(id, title, description, submittable, submitted, startDateTime, endDateTime, missionStatus)
-}
-
-fun createMissionJudgmentResponse(
-    title: String = MISSION_TITLE,
-    description: String = MISSION_DESCRIPTION,
-    submittable: Boolean = true,
-    submitted: Boolean = true,
-    startDateTime: LocalDateTime = START_DATE_TIME,
-    endDateTime: LocalDateTime = END_DATE_TIME,
-    missionStatus: MissionStatus = MissionStatus.SUBMITTING,
-    isAutomation: Boolean = true,
+    runnable: Boolean = true,
     judgment: LastJudgmentResponse? = createLastJudgmentResponse(),
     id: Long = 0L
-): MissionJudgmentResponse {
-    return MissionJudgmentResponse(
+): MyMissionResponse {
+    return MyMissionResponse(
         id,
         title,
         description,
@@ -107,7 +93,7 @@ fun createMissionJudgmentResponse(
         startDateTime,
         endDateTime,
         missionStatus,
-        isAutomation,
+        runnable,
         judgment
     )
 }

--- a/src/test/kotlin/apply/MissionFixtures.kt
+++ b/src/test/kotlin/apply/MissionFixtures.kt
@@ -2,7 +2,9 @@ package apply
 
 import apply.application.EvaluationSelectData
 import apply.application.JudgmentItemData
+import apply.application.LastJudgmentResponse
 import apply.application.MissionData
+import apply.application.MissionJudgmentResponse
 import apply.application.MissionResponse
 import apply.application.MyMissionResponse
 import apply.domain.mission.Mission
@@ -82,4 +84,30 @@ fun createMyMissionResponse(
     id: Long = 0L
 ): MyMissionResponse {
     return MyMissionResponse(id, title, description, submittable, submitted, startDateTime, endDateTime, missionStatus)
+}
+
+fun createMissionJudgmentResponse(
+    title: String = MISSION_TITLE,
+    description: String = MISSION_DESCRIPTION,
+    submittable: Boolean = true,
+    submitted: Boolean = true,
+    startDateTime: LocalDateTime = START_DATE_TIME,
+    endDateTime: LocalDateTime = END_DATE_TIME,
+    missionStatus: MissionStatus = MissionStatus.SUBMITTING,
+    isAutomation: Boolean = true,
+    judgment: LastJudgmentResponse? = createLastJudgmentResponse(),
+    id: Long = 0L
+): MissionJudgmentResponse {
+    return MissionJudgmentResponse(
+        id,
+        title,
+        description,
+        submittable,
+        submitted,
+        startDateTime,
+        endDateTime,
+        missionStatus,
+        isAutomation,
+        judgment
+    )
 }

--- a/src/test/kotlin/apply/application/JudgmentIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentIntegrationTest.kt
@@ -1,0 +1,101 @@
+package apply.application
+
+import apply.createAssignment
+import apply.createCommit
+import apply.createJudgmentItem
+import apply.createMission
+import apply.domain.assignment.AssignmentRepository
+import apply.domain.judgment.AssignmentArchive
+import apply.domain.judgment.JudgmentRepository
+import apply.domain.judgment.JudgmentStatus
+import apply.domain.judgment.JudgmentType
+import apply.domain.judgmentitem.JudgmentItemRepository
+import apply.domain.mission.MissionRepository
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import support.test.IntegrationTest
+import support.test.spec.afterRootTest
+
+@MockkBean(AssignmentArchive::class)
+@IntegrationTest
+class JudgmentIntegrationTest(
+    private val judgmentService: JudgmentService,
+    private val missionRepository: MissionRepository,
+    private val judgmentItemRepository: JudgmentItemRepository,
+    private val assignmentRepository: AssignmentRepository,
+    private val judgmentRepository: JudgmentRepository,
+    private val assignmentArchive: AssignmentArchive
+) : BehaviorSpec({
+    Given("과제 제출물을 제출할 수 있는 특정 과제에 대한 과제 제출물이 있는 경우") {
+        val userId = 1L
+        val mission = missionRepository.save(createMission(submittable = true))
+        judgmentItemRepository.save(createJudgmentItem(mission.id))
+        assignmentRepository.save(createAssignment(userId, mission.id))
+        val commit = createCommit()
+
+        every { assignmentArchive.getLastCommit(any(), any()) } returns commit
+
+        When("해당 과제 제출물의 예제 테스트를 실행하면") {
+            val actual = judgmentService.judgeExample(userId, mission.id)
+
+            Then("마지막 커밋에 대한 자동 채점 기록을 확인할 수 있고 자동 채점이 저장된다") {
+                assertSoftly(actual) {
+                    commitHash shouldBe commit.hash
+                    status shouldBe JudgmentStatus.STARTED
+                    passCount shouldBe 0
+                    totalCount shouldBe 0
+                }
+                judgmentRepository.findAll().shouldHaveSize(1)
+            }
+        }
+    }
+
+    Given("특정 과제 제출물에 대한 마지막 커밋이 없어 예외가 발생하는 경우") {
+        val userId = 1L
+        val mission = missionRepository.save(createMission(submittable = true))
+        judgmentItemRepository.save(createJudgmentItem(mission.id))
+        val assignment = assignmentRepository.save(createAssignment(userId, mission.id))
+
+        every { assignmentArchive.getLastCommit(any(), any()) } throws RuntimeException()
+
+        When("해당 과제 제출물의 예제 테스트를 실행하면") {
+            Then("예외가 발생하고 자동 채점이 저장되지 않는다") {
+                shouldThrowAny {
+                    judgmentService.judgeExample(userId, mission.id)
+                }
+                judgmentRepository.findAll().shouldBeEmpty()
+            }
+        }
+
+        When("해당 과제 제출물의 본 자동 채점을 실행하면") {
+            Then("예외가 발생하고 자동 채점이 저장되지 않는다") {
+                shouldThrowAny {
+                    judgmentService.judgeReal(assignment.id)
+                }
+                judgmentRepository.findAll().shouldBeEmpty()
+            }
+        }
+
+        When("해당 과제 제출물의 자동 채점을 실행하면") {
+            Then("예외가 발생하고 자동 채점이 저장되지 않는다") {
+                shouldThrowAny {
+                    judgmentService.judge(mission, assignment, JudgmentType.REAL)
+                }
+                judgmentRepository.findAll().shouldBeEmpty()
+            }
+        }
+    }
+
+    afterRootTest {
+        judgmentRepository.deleteAll()
+        assignmentRepository.deleteAll()
+        judgmentItemRepository.deleteAll()
+        missionRepository.deleteAll()
+    }
+})

--- a/src/test/kotlin/apply/application/JudgmentIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentIntegrationTest.kt
@@ -117,7 +117,8 @@ class JudgmentIntegrationTest(
         val commit = createCommit()
         judgmentRepository.save(
             createJudgment(
-                assignment.id, EXAMPLE, listOf(
+                assignment.id, EXAMPLE,
+                listOf(
                     createJudgmentRecord(
                         commit,
                         JudgmentResult(passCount = 9, totalCount = 10, status = SUCCEEDED),
@@ -152,7 +153,8 @@ class JudgmentIntegrationTest(
         val commit = createCommit()
         judgmentRepository.save(
             createJudgment(
-                assignment.id, REAL, listOf(
+                assignment.id, REAL,
+                listOf(
                     createJudgmentRecord(
                         commit,
                         JudgmentResult(passCount = 9, totalCount = 10, status = SUCCEEDED),

--- a/src/test/kotlin/apply/application/JudgmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentServiceTest.kt
@@ -322,9 +322,14 @@ class JudgmentServiceTest : BehaviorSpec({
         When("예제 자동 채점 결과를 조회하면") {
             val actual = judgmentService.findExample(1L, 1L)
 
-            Then("예제 자동 채점 결과를 돌려준다") {
+            Then("예제 자동 채점 결과를 확인할 수 있다") {
                 actual.shouldNotBeNull()
-                actual.status shouldBe SUCCEEDED
+                assertSoftly(actual) {
+                    commitHash shouldBe COMMIT_HASH
+                    passCount shouldBe 9
+                    totalCount shouldBe 10
+                    status shouldBe SUCCEEDED
+                }
             }
         }
     }
@@ -349,9 +354,14 @@ class JudgmentServiceTest : BehaviorSpec({
         When("본 자동 채점 결과를 조회하면") {
             val actual = judgmentService.findExample(1L, 1L)
 
-            Then("본 자동 채점 결과를 돌려준다") {
+            Then("본 자동 채점 결과를 확인할 수 있다") {
                 actual.shouldNotBeNull()
-                actual.status shouldBe SUCCEEDED
+                assertSoftly(actual) {
+                    commitHash shouldBe COMMIT_HASH
+                    passCount shouldBe 9
+                    totalCount shouldBe 10
+                    status shouldBe SUCCEEDED
+                }
             }
         }
     }
@@ -365,7 +375,7 @@ class JudgmentServiceTest : BehaviorSpec({
         When("예제 자동 채점 결과를 조회하면") {
             val actual = judgmentService.findExample(1L, 1L)
 
-            Then("null을 돌려준다") {
+            Then("null을 반환한다") {
                 actual.shouldBeNull()
             }
         }

--- a/src/test/kotlin/apply/application/JudgmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentServiceTest.kt
@@ -53,7 +53,12 @@ class JudgmentServiceTest : BehaviorSpec({
     val assignmentArchive = mockk<AssignmentArchive>()
 
     val judgmentService = JudgmentService(
-        judgmentRepository, assignmentRepository, missionRepository, judgmentItemRepository, evaluationTargetRepository, assignmentArchive
+        judgmentRepository,
+        assignmentRepository,
+        missionRepository,
+        judgmentItemRepository,
+        evaluationTargetRepository,
+        assignmentArchive
     )
 
     Given("과제 제출물을 제출할 수 없는 과제가 있는 경우") {
@@ -289,7 +294,7 @@ class JudgmentServiceTest : BehaviorSpec({
         every { judgmentRepository.save(any()) } returns judgment
 
         When("전체 자동 채점을 요청하면") {
-            Then("정상으로 동작한다") {
+            Then("모든 과제 제출물들의 본 자동 채점을 실행한다") {
                 shouldNotThrowAny {
                     judgmentService.judgeAll(mission.id)
                 }

--- a/src/test/kotlin/apply/application/JudgmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentServiceTest.kt
@@ -26,6 +26,7 @@ import apply.domain.judgmentitem.JudgmentItemRepository
 import apply.domain.mission.MissionRepository
 import apply.domain.mission.getById
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.nulls.shouldBeNull
@@ -252,6 +253,38 @@ class JudgmentServiceTest : BehaviorSpec({
                     status shouldBe STARTED
                     passCount shouldBe 0
                     totalCount shouldBe 0
+                }
+            }
+        }
+    }
+
+    Given("특정 과제의 과제 제출물들이 존재하는 경우") {
+        val mission = createMission(id = 1L, submittable = true)
+        val assignment = createAssignment(missionId = mission.id, id = 1L)
+        val assignments = listOf(assignment)
+        val judgment = createJudgment(
+            assignmentId = assignment.id,
+            type = REAL,
+            records = listOf(
+                createJudgmentRecord(
+                    commit = createCommit("commit1"),
+                    startedDateTime = now().minusMinutes(5)
+                )
+            )
+        )
+        val commit = createCommit("commit2")
+
+        every { missionRepository.getById(any()) } returns mission
+        every { assignmentRepository.findAllByMissionId(mission.id) } returns assignments
+        every { judgmentItemRepository.existsByMissionId(any()) } returns true
+        every { judgmentRepository.findByAssignmentIdAndType(any(), any()) } returns judgment
+        every { assignmentArchive.getLastCommit(any(), any()) } returns commit
+        every { judgmentRepository.save(any()) } returns judgment
+
+        When("전체 자동 채점을 요청하면") {
+            Then("정상으로 동작한다") {
+                shouldNotThrowAny {
+                    judgmentService.judgeAll(mission.id)
                 }
             }
         }

--- a/src/test/kotlin/apply/application/JudgmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentServiceTest.kt
@@ -399,11 +399,9 @@ class JudgmentServiceTest : BehaviorSpec({
         When("해당 커밋의 자동 채점이 성공하면") {
             judgmentService.success(judgment.id, createSuccessJudgmentRequest(commit = commit.hash))
 
-            Then("자동 채점 기록의 상태가 성공으로 변경된다") {
+            Then("자동 채점 기록의 상태가 성공으로 변경되고 점수가 입력된다") {
                 record.commit shouldBe commit
                 record.status shouldBe SUCCEEDED
-            }
-            Then("점수가 반영된다") {
                 evaluationTarget.evaluationAnswers.countTotalScore() shouldBe record.result.passCount
             }
         }

--- a/src/test/kotlin/apply/application/JudgmentServiceTest.kt
+++ b/src/test/kotlin/apply/application/JudgmentServiceTest.kt
@@ -10,7 +10,6 @@ import apply.createMission
 import apply.domain.assignment.AssignmentRepository
 import apply.domain.assignment.getById
 import apply.domain.assignment.getByUserIdAndMissionId
-import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.judgment.AssignmentArchive
 import apply.domain.judgment.JudgmentRepository
 import apply.domain.judgment.JudgmentResult
@@ -38,7 +37,6 @@ class JudgmentServiceTest : BehaviorSpec({
     val assignmentRepository = mockk<AssignmentRepository>()
     val missionRepository = mockk<MissionRepository>()
     val judgmentItemRepository = mockk<JudgmentItemRepository>()
-    val evaluationTargetRepository = mockk<EvaluationTargetRepository>()
     val assignmentArchive = mockk<AssignmentArchive>()
 
     val judgmentService = JudgmentService(
@@ -46,7 +44,6 @@ class JudgmentServiceTest : BehaviorSpec({
         assignmentRepository,
         missionRepository,
         judgmentItemRepository,
-        evaluationTargetRepository,
         assignmentArchive
     )
 
@@ -279,7 +276,7 @@ class JudgmentServiceTest : BehaviorSpec({
         every { judgmentRepository.findByAssignmentIdAndType(any(), any()) } returns judgment
 
         When("예제 자동 채점 결과를 조회하면") {
-            val actual = judgmentService.findExample(1L, 1L)
+            val actual = judgmentService.findLastExampleJudgment(1L, 1L)
 
             Then("예제 자동 채점 결과를 확인할 수 있다") {
                 actual.shouldNotBeNull()
@@ -311,7 +308,7 @@ class JudgmentServiceTest : BehaviorSpec({
         every { judgmentRepository.findByAssignmentIdAndType(any(), any()) } returns judgment
 
         When("본 자동 채점 결과를 조회하면") {
-            val actual = judgmentService.findExample(1L, 1L)
+            val actual = judgmentService.findLastExampleJudgment(1L, 1L)
 
             Then("본 자동 채점 결과를 확인할 수 있다") {
                 actual.shouldNotBeNull()
@@ -332,7 +329,7 @@ class JudgmentServiceTest : BehaviorSpec({
         every { judgmentRepository.findByAssignmentIdAndType(any(), any()) } returns null
 
         When("예제 자동 채점 결과를 조회하면") {
-            val actual = judgmentService.findExample(1L, 1L)
+            val actual = judgmentService.findLastExampleJudgment(1L, 1L)
 
             Then("null을 반환한다") {
                 actual.shouldBeNull()

--- a/src/test/kotlin/apply/application/MissionServiceTest.kt
+++ b/src/test/kotlin/apply/application/MissionServiceTest.kt
@@ -1,14 +1,11 @@
 package apply.application
 
-import apply.createAssignment
 import apply.createEvaluation
 import apply.createMission
 import apply.createMissionData
 import apply.createMissionResponse
-import apply.domain.assignment.AssignmentRepository
 import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluationitem.EvaluationItemRepository
-import apply.domain.evaluationtarget.EvaluationTargetRepository
 import apply.domain.judgmentitem.JudgmentItemRepository
 import apply.domain.mission.MissionRepository
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -27,17 +24,13 @@ import support.test.spec.afterRootTest
 class MissionServiceTest : BehaviorSpec({
     val missionRepository = mockk<MissionRepository>()
     val evaluationRepository = mockk<EvaluationRepository>()
-    val evaluationTargetRepository = mockk<EvaluationTargetRepository>()
     val evaluationItemRepository = mockk<EvaluationItemRepository>()
-    val assignmentRepository = mockk<AssignmentRepository>()
     val judgmentItemRepository = mockk<JudgmentItemRepository>()
 
     val missionService = MissionService(
         missionRepository,
         evaluationRepository,
-        evaluationTargetRepository,
         evaluationItemRepository,
-        assignmentRepository,
         judgmentItemRepository
     )
 
@@ -98,34 +91,6 @@ class MissionServiceTest : BehaviorSpec({
                 actual shouldContainExactlyInAnyOrder listOf(
                     MissionAndEvaluationResponse(mission1, evaluation1),
                     MissionAndEvaluationResponse(mission2, evaluation2)
-                )
-            }
-        }
-    }
-
-    Given("과제 및 평가 대상자가 있는 평가가 있고 해당 평가 대상자가 제출한 과제 제출물이 있는 경우") {
-        val mission1 = createMission(id = 1L, hidden = false)
-        val mission2 = createMission(id = 2L, hidden = false)
-        val recruitmentId = 1L
-        val userId = 1L
-
-        every { evaluationRepository.findAllByRecruitmentId(any()) } returns listOf(
-            createEvaluation(recruitmentId = recruitmentId, id = 1L),
-            createEvaluation(recruitmentId = recruitmentId, id = 2L)
-        )
-        every { evaluationTargetRepository.existsByUserIdAndEvaluationId(any(), any()) } returns true
-        every { missionRepository.findAllByEvaluationIdIn(any()) } returns listOf(mission1, mission2)
-        every { assignmentRepository.findAllByUserId(any()) } returns listOf(
-            createAssignment(id = userId, missionId = mission1.id)
-        )
-
-        When("해당 사용자의 특정 모집에 대한 모든 과제를 조회하면") {
-            val actual = missionService.findAllByUserIdAndRecruitmentId(userId, recruitmentId)
-
-            Then("과제 및 과제 제출물이 제출되었는지 확인할 수 있다") {
-                actual shouldContainExactlyInAnyOrder listOf(
-                    MyMissionResponse(mission1, true),
-                    MyMissionResponse(mission2, false)
                 )
             }
         }

--- a/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
+++ b/src/test/kotlin/apply/domain/evaluationtarget/EvaluationTargetRepositoryTest.kt
@@ -6,7 +6,6 @@ import apply.domain.evaluationtarget.EvaluationStatus.PASS
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.inspectors.forAll
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeZero
 import io.kotest.matchers.shouldBe
@@ -31,13 +30,6 @@ class EvaluationTargetRepositoryTest(
         expect("특정 평가의 평가 대상자를 조회한다") {
             val actual = evaluationTargetRepository.findAllByEvaluationId(evaluationId)
             actual shouldHaveSize 2
-        }
-
-        expect("특정 회원이 특정 평가의 평가 대상자인지 확인한다") {
-            listOf(1L, 2L).forAll { userId ->
-                val actual = evaluationTargetRepository.existsByUserIdAndEvaluationId(userId, evaluationId)
-                actual.shouldBeTrue()
-            }
         }
     }
 

--- a/src/test/kotlin/apply/infra/github/GitHubClientTest.kt
+++ b/src/test/kotlin/apply/infra/github/GitHubClientTest.kt
@@ -26,8 +26,14 @@ class GitHubClientTest(
     }
 
     "해당 커밋이 없으면 예외가 발생한다" {
-        shouldThrow<RuntimeException> {
+        shouldThrow<IllegalArgumentException> {
             gitHubClient.getLastCommit(PULL_REQUEST_URL, createLocalDateTime(2018))
+        }
+    }
+
+    "PR이 없으면 예외가 발생한다" {
+        shouldThrow<IllegalArgumentException> {
+            gitHubClient.getLastCommit("https://github.com/woowacourse/service-apply/pull/1", now)
         }
     }
 })

--- a/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
@@ -43,7 +43,7 @@ class JudgmentRestControllerTest : RestControllerTest() {
     @Test
     fun `예제 테스트 결과를 조회한다`() {
         val response = createLastJudgmentResponse()
-        every { judgmentService.findExample(any(), any()) } returns response
+        every { judgmentService.findLastExampleJudgment(any(), any()) } returns response
 
         mockMvc.get("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-example", 1L, 1L) {
             bearer("valid_token")

--- a/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
@@ -1,5 +1,6 @@
 package apply.ui.api
 
+import apply.application.JudgmentAllService
 import apply.application.JudgmentService
 import apply.createCancelJudgmentRequest
 import apply.createFailJudgmentRequest
@@ -20,6 +21,9 @@ import support.test.web.servlet.bearer
 class JudgmentRestControllerTest : RestControllerTest() {
     @MockkBean
     private lateinit var judgmentService: JudgmentService
+
+    @MockkBean
+    private lateinit var judgmentAllService: JudgmentAllService
 
     @Test
     fun `예제 테스트를 실행한다`() {
@@ -52,43 +56,6 @@ class JudgmentRestControllerTest : RestControllerTest() {
     }
 
     @Test
-    fun `본 자동 채점을 실행한다`() {
-        val response = createLastJudgmentResponse()
-        every { judgmentService.judgeReal(any(), any()) } returns response
-
-        mockMvc.post("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-real", 1L, 1L) {
-            bearer("valid_token")
-        }.andExpect {
-            status { isOk }
-            content { success(response) }
-        }
-    }
-
-    @Test
-    fun `본 자동 채점 결과를 조회한다`() {
-        val response = createLastJudgmentResponse()
-        every { judgmentService.findReal(any(), any()) } returns response
-
-        mockMvc.get("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-real", 1L, 1L) {
-            bearer("valid_token")
-        }.andExpect {
-            status { isOk }
-            content { success(response) }
-        }
-    }
-
-    @Test
-    fun `전체 자동 채점을 실행한다`() {
-        every { judgmentService.judgeAll(any()) } returns Unit
-
-        mockMvc.post("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-all", 1L, 1L) {
-            bearer("valid_token")
-        }.andExpect {
-            status { isOk }
-        }
-    }
-
-    @Test
     fun `자동 채점 성공 결과를 반영한다`() {
         every { judgmentService.success(any(), any()) } just Runs
 
@@ -97,7 +64,7 @@ class JudgmentRestControllerTest : RestControllerTest() {
         }.andExpect {
             status { isOk }
         }.andDo {
-            handle(document("judgment-success-result-post"))
+            handle(document("judgment-success-post"))
         }
     }
 
@@ -110,7 +77,7 @@ class JudgmentRestControllerTest : RestControllerTest() {
         }.andExpect {
             status { isOk }
         }.andDo {
-            handle(document("judgment-fail-result-post"))
+            handle(document("judgment-fail-post"))
         }
     }
 
@@ -123,7 +90,31 @@ class JudgmentRestControllerTest : RestControllerTest() {
         }.andExpect {
             status { isOk }
         }.andDo {
-            handle(document("judgment-cancel-result-post"))
+            handle(document("judgment-cancel-post"))
+        }
+    }
+
+    @Test
+    fun `본 자동 채점을 실행한다`() {
+        val response = createLastJudgmentResponse()
+        every { judgmentService.judgeReal(any()) } returns response
+
+        mockMvc.post("/api/evaluations/{evaluationId}/assignments/{assignmentId}/judgments/judge-real", 1L, 1L) {
+            bearer("valid_token")
+        }.andExpect {
+            status { isOk }
+            content { success(response) }
+        }
+    }
+
+    @Test
+    fun `전체 자동 채점을 실행한다`() {
+        every { judgmentAllService.judgeAll(any()) } just Runs
+
+        mockMvc.post("/api/evaluations/{evaluationId}/judgments/judge-all", 1L) {
+            bearer("valid_token")
+        }.andExpect {
+            status { isOk }
         }
     }
 }

--- a/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
@@ -65,7 +65,7 @@ class JudgmentRestControllerTest : RestControllerTest() {
     }
 
     @Test
-    fun `다건의 자동 채점을 실행한다`() {
+    fun `전체 자동 채점을 실행한다`() {
         every { judgmentService.judgeAll(any()) } returns Unit
 
         mockMvc.post("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-all", 1L, 1L) {

--- a/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
@@ -12,6 +12,7 @@ import io.mockk.just
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import support.test.web.servlet.bearer
 
@@ -32,6 +33,21 @@ class JudgmentRestControllerTest : RestControllerTest() {
             content { success(response) }
         }.andDo {
             handle(document("judgment-judge-example-post"))
+        }
+    }
+
+    @Test
+    fun `예제 테스트 결과를 조회한다`() {
+        val response = createLastJudgmentResponse()
+        every { judgmentService.findExample(any(), any()) } returns response
+
+        mockMvc.get("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-example", 1L, 1L) {
+            bearer("valid_token")
+        }.andExpect {
+            status { isOk }
+            content { success(response) }
+        }.andDo {
+            handle(document("judgment-judge-example-get"))
         }
     }
 

--- a/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
@@ -65,6 +65,17 @@ class JudgmentRestControllerTest : RestControllerTest() {
     }
 
     @Test
+    fun `다건의 자동 채점을 실행한다`() {
+        every { judgmentService.judgeAll(any()) } returns Unit
+
+        mockMvc.post("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-all", 1L, 1L) {
+            bearer("valid_token")
+        }.andExpect {
+            status { isOk }
+        }
+    }
+
+    @Test
     fun `자동 채점 성공 결과를 반영한다`() {
         every { judgmentService.success(any(), any()) } just Runs
 

--- a/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/JudgmentRestControllerTest.kt
@@ -65,6 +65,19 @@ class JudgmentRestControllerTest : RestControllerTest() {
     }
 
     @Test
+    fun `본 자동 채점 결과를 조회한다`() {
+        val response = createLastJudgmentResponse()
+        every { judgmentService.findReal(any(), any()) } returns response
+
+        mockMvc.get("/api/recruitments/{recruitmentId}/missions/{missionId}/judgments/judge-real", 1L, 1L) {
+            bearer("valid_token")
+        }.andExpect {
+            status { isOk }
+            content { success(response) }
+        }
+    }
+
+    @Test
     fun `전체 자동 채점을 실행한다`() {
         every { judgmentService.judgeAll(any()) } returns Unit
 

--- a/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
@@ -1,12 +1,16 @@
 package apply.ui.api
 
+import apply.application.JudgmentService
 import apply.application.MissionAndEvaluationResponse
 import apply.application.MissionService
 import apply.createEvaluation
+import apply.createLastJudgmentResponse
 import apply.createMission
 import apply.createMissionData
+import apply.createMissionJudgmentResponse
 import apply.createMissionResponse
 import apply.createMyMissionResponse
+import apply.domain.judgment.JudgmentStatus
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.Runs
 import io.mockk.every
@@ -23,6 +27,9 @@ import support.test.web.servlet.bearer
 class MissionRestControllerTest : RestControllerTest() {
     @MockkBean
     private lateinit var missionService: MissionService
+
+    @MockkBean
+    private lateinit var judgmentService: JudgmentService
 
     @Test
     fun `과제를 추가한다`() {
@@ -69,14 +76,30 @@ class MissionRestControllerTest : RestControllerTest() {
 
     @Test
     fun `나의 과제들을 조회한다`() {
-        val responses = listOf(createMyMissionResponse(id = 1L), createMyMissionResponse(id = 2L))
-        every { missionService.findAllByUserIdAndRecruitmentId(any(), any()) } returns responses
+        val missionResponses =
+            listOf(createMyMissionResponse(id = 1L), createMyMissionResponse(id = 2L), createMyMissionResponse(id = 3L))
+        val lastJudgmentResponses =
+            listOf(
+                null,
+                createLastJudgmentResponse(),
+                createLastJudgmentResponse(passCount = 9, totalCount = 10, status = JudgmentStatus.SUCCEEDED)
+            )
+        val expected = listOf(
+            createMissionJudgmentResponse(id = 1L, isAutomation = false, judgment = lastJudgmentResponses[0]),
+            createMissionJudgmentResponse(id = 2L, isAutomation = true, judgment = lastJudgmentResponses[1]),
+            createMissionJudgmentResponse(id = 3L, isAutomation = true, judgment = lastJudgmentResponses[2])
+        )
+
+        every { missionService.findAllByUserIdAndRecruitmentId(any(), any()) } returns missionResponses
+        every { judgmentService.findExample(any(), 1L) } returns lastJudgmentResponses[0]
+        every { judgmentService.findExample(any(), 2L) } returns lastJudgmentResponses[1]
+        every { judgmentService.findExample(any(), 3L) } returns lastJudgmentResponses[2]
 
         mockMvc.get("/api/recruitments/{recruitmentId}/missions/me", 1L) {
             bearer("valid_token")
         }.andExpect {
             status { isOk }
-            content { success(responses) }
+            content { success(expected) }
         }.andDo {
             handle(document("mission-me-get"))
         }

--- a/src/test/kotlin/support/test/context/event/Events.kt
+++ b/src/test/kotlin/support/test/context/event/Events.kt
@@ -1,0 +1,19 @@
+package support.test.context.event
+
+import org.springframework.context.event.EventListener
+
+class Events {
+    private val _events: MutableList<Any> = mutableListOf()
+    val events: List<Any>
+        get() = _events
+
+    @EventListener
+    internal fun addEvent(event: Any) {
+        _events.add(event)
+    }
+
+    inline fun <reified T : Any> events(): List<T> = events.filterIsInstance(T::class.java)
+    inline fun <reified T : Any> count(): Int = events<T>().count()
+    inline fun <reified T : Any> first(): T = events<T>().first()
+    fun clear() = _events.clear()
+}

--- a/src/test/kotlin/support/test/context/event/RecordEventsConfiguration.kt
+++ b/src/test/kotlin/support/test/context/event/RecordEventsConfiguration.kt
@@ -1,0 +1,15 @@
+package support.test.context.event
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot 2.4.2 이후 `@RecordApplicationEvents`로 대체
+ */
+@TestConfiguration
+class RecordEventsConfiguration {
+    @Bean
+    fun applicationEvents(): Events {
+        return Events()
+    }
+}


### PR DESCRIPTION
Resolves #637, resolves #638 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

1. (관리자) 전체 채점 기능 추가
2. (관리자) 자동 채점 단건 결과 조회 기능
3. (지원자) 자동 채점 단건 결과 조회 기능 추가
4. 본 자동 채점 결과를 평가에 반영 추가
5. '내 과제 조회'시 응답에 자동 채점 결과를 추가.
6. Github API 요청 예외 발생 시 예외 메세지가 그대로 전달되는 문제.

# 어떻게 해결했나요?

1. (관리자) 전체 채점 기능
   - 반복문을 통해 모든 과제 제출물에 대한 자동 채점을 요청합니다.
   - 클래스를 분리하여 매 요청마다 트랜잭션을 열고 닫도록 처리하였습니다.
      - Judgment에서 발행하는`Event`를 기반으로 자동 채점 API을 요청합니다.
   - 반복문 도중 발생하는 예외로 인해 전체 채점이 중단되지 않도록 `runCatching()`을 이용하였습니다.
2. (관리자) 자동 채점 단건 결과 조회 기능
   - 평가대상자의 ID 값을 기반으로 **마지막** 채점 기록을 반환합니다.
   - 과제, 자동 채점 항목, 과제 제출물이 존재하지 않거나 자동 채점을 요청한 적이 없는 경우 `null`을 반환합니다.
3. (지원자) 자동 채점 단건 결과 조회 기능
   - 지원자 ID와 과제 ID 값을 기반으로 **마지막** 채점 기록을 반환합니다.
   - 제출한 과제 제출물이 존재하지 않거나 자동 채점을 요청한 적이 없는 경우 `null`을 반환합니다.
4. 본 자동 채점 결과를 평가에 반영
   - 본 자동 채점 결과(성공, 실패, 취소)시 평가 항목 점수에 반영합니다. (기존에는 `judgment`에 저장만 했습니다.)
   - 재채점 요청시 기존 점수를 초기화합니다.
5. '내 과제 조회'시 응답에 자동 채점 결과를 추가.
   - 기존 Mission Response DTO에 자동 채점 결과에 대한 정보를 덧붙여 반환합니다.
   - 지원자 ID와 평가 ID 값을 기반으로 **마지막** 채점 기록을 반환합니다.
   - **과제가 자동 채점의 대상이 아니라면** `runnable`을 false로 지정합니다.
   - 제출한 과제 제출물이 존재하지 않거나 자동 채점을 요청한 적이 없는 경우 `null`을 반환합니다.
6. Github API 요청 시 발생하는 예외 처리.
   - Github API 요청 시 4XX 혹은 5XX 응답을 받는 경우 예외가 발생하는 부분을 처리하였습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 자동 채점 요청부터 채점 결과 반영까지의 흐름 상, 고려하지 못한 논리적 오류가 있는 부분이 있다면 알려주세요.
- 전체 자동 채점 요청 시, 트랜잭션과 관련하여 개선할 수 있는 방법이 있다면 알려주세요.
- 테스트 이름이 적절하지 않은 부분이 있다면 알려주세요.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
