### PR TITLE
fix: navigate to the original page after logging in

### DIFF
--- a/frontend/src/pages/Login/Login.js
+++ b/frontend/src/pages/Login/Login.js
@@ -21,25 +21,34 @@ const Login = () => {
   const { login } = useAuth();
   const { form, errorMessage, handleChanges, handleCapsLockState, isEmpty } = useLoginForm();
 
+  const routeToApplicationRegister = (currentRecruitment) => {
+    navigate(
+      {
+        pathname: generatePath(PATH.APPLICATION_FORM, {
+          status: PARAM.APPLICATION_FORM_STATUS.NEW,
+        }),
+        search: generateQuery({ recruitmentId: currentRecruitment.id }),
+      },
+      {
+        state: {
+          currentRecruitment,
+        },
+      }
+    );
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
 
     try {
       await login(form);
 
-      const path = currentRecruitment
-        ? {
-            pathname: generatePath(PATH.APPLICATION_FORM, {
-              status: PARAM.APPLICATION_FORM_STATUS.NEW,
-            }),
-            search: generateQuery({ recruitmentId: currentRecruitment.id }),
-            state: {
-              currentRecruitment,
-            },
-          }
-        : PATH.RECRUITS;
+      if (!currentRecruitment) {
+        navigate({ pathname: PATH.RECRUITS });
+        return;
+      }
 
-      navigate(path);
+      routeToApplicationRegister(currentRecruitment);
     } catch (error) {
       alert(ERROR_MESSAGE.API.LOGIN_FAILURE);
     }


### PR DESCRIPTION
Resolves #658

# 해결하려는 문제가 무엇인가요?

- 로그인 페이지에서 특정 모집의 지원서 페이지로 이동하는 로직이 정상동작하지 않습니다. 
- https://github.com/woowacourse/service-apply/pull/622 에서 누락된 부분이 있었던 것으로 보입니다. 

# 어떻게 해결했나요?

- `navigate()`에 state를 전달하는 방식을 `react-router-dom` 라이브러리 변경사항에 맞추어 수정하였습니다. 

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 인자 전달 방법이 올바른지 확인해주세요
- 아래 케이스에 대해 확인했습니다. 혹시 추가로 확인해볼 시나리오나 기능 테스트에서 발견하는 이슈가 있다면 알려주세요 🙏
  - 로그인 하지 않은 상태 > 모집 목록에서 모집 클릭 > 로그인 페이지 이동 > 로그인 완료 후 클릭했던 모집의 지원서 페이지로 이동
  - 로그인 한 상태 > 모집 목록에서 모집 클릭 > 클릭한 모집의 지원서 페이지로 이동
  - 로그인 페이지로 이동 > 로그인 완료 후 모집 목록 페이지로 이동

## 참고 자료

- 
---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
