### PR TITLE
feat(apply): remove some educational programs

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,19 +6,19 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no" />
     <meta
       name="keyword"
-      content="우아한테크코스, 프로그래밍, 개발자, 백엔드, 프론트엔드, Backend, Frontend, IOS, Android"
+      content="우아한형제들의 교육 프로그램, 우아한테크코스, 우아한테크캠프 Pro, 프로그래밍, 개발자, 백엔드, 프론트엔드, Backend, Frontend, IOS, Android"
     />
     <meta
       name="description"
       id="metaDesc"
-      content="우아한테크코스에서 개발자들을 위해 디자인된 강의를 수강해보세요."
+      content="우아한형제들의 교육 프로그램에서 개발자들을 위해 디자인된 강의를 수강해보세요."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="우아한테크코스 지원하기" />
+    <meta property="og:title" content="우아한형제들의 교육 프로그램 지원하기" />
     <meta
       property="og:description"
       id="metaOgDesc"
-      content="우아한테크코스에서 개발자들을 위해 디자인된 강의를 수강해보세요."
+      content="우아한형제들의 교육 프로그램에서 개발자들을 위해 디자인된 강의를 수강해보세요."
     />
     <meta
       property="og:image"
@@ -26,11 +26,11 @@
     />
     <meta property="og:url" content="https://apply.techcourse.co.kr/" />
     <meta name="twitter:card" content="website" />
-    <meta name="twitter:title" content="우아한테크코스 지원하기" />
+    <meta name="twitter:title" content="우아한형제들의 교육 프로그램 지원하기" />
     <meta
       name="twitter:description"
       id="metaTwitterDesc"
-      content="우아한테크코스에서 개발자들을 위해 디자인된 강의를 수강해보세요."
+      content="우아한형제들의 교육 프로그램에서 개발자들을 위해 디자인된 강의를 수강해보세요."
     />
     <meta
       name="twitter:image"
@@ -46,7 +46,7 @@
       rel="stylesheet"
       href="//cdn.jsdelivr.net/gh/lykmapipo/themify-icons@0.1.2/css/themify-icons.css"
     />
-    <title>우아한테크코스 지원하기</title>
+    <title>지원하기</title>
   </head>
   <body>
     <noscript>

--- a/frontend/src/components/MyApplicationItem/MyApplicationFormItem/MyApplicationFormItem.stories.tsx
+++ b/frontend/src/components/MyApplicationItem/MyApplicationFormItem/MyApplicationFormItem.stories.tsx
@@ -47,7 +47,7 @@ export const Recruiting = Template.bind({});
 Recruiting.args = {
   recruitment: {
     id: 3,
-    title: "우아한테크캠프 2기",
+    title: "우아한테크코스 2기",
     recruitable: true,
     term: {
       id: 1,
@@ -65,7 +65,7 @@ export const AfterRecruit = Template.bind({});
 AfterRecruit.args = {
   recruitment: {
     id: 3,
-    title: "우아한테크캠프 2기",
+    title: "우아한테크캠프 Pro 2기",
     recruitable: true,
     term: {
       id: 1,

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -28,11 +28,6 @@ export const PROGRAM_TAB = {
     label: "우아한테크코스",
     description: `일반 사용자용 서비스를 개발하는 회사가 필요로 하는 역량을 가진 개발자를 양성하기 위한 프로그램입니다.\n자기주도 학습, 현장 중심 경험, 깊이 있는 협업을 통해 성장하실 분들을 찾고 있어요.`,
   },
-  WOOWA_TECH_CAMP: {
-    name: "woowacamp",
-    label: "우아한테크캠프",
-    description: `다양한 미니 프로젝트를 통해 실제 서비스를 만들며 개발 지식을 익히는 교육형 인턴 과정입니다.\n프로그래밍 기본 지식과 개발자로 살고 싶은 열정이 있는 분들을 찾고 있어요.`,
-  },
   WOOWA_TECH_CAMP_PRO: {
     name: "woowacamppro",
     label: "우아한테크캠프 Pro",
@@ -50,6 +45,5 @@ export const RECRUITS_TAB_LIST = [
 export const PROGRAM_TAB_LIST = [
   PROGRAM_TAB.ALL,
   PROGRAM_TAB.WOOWA_TECH_COURSE,
-  PROGRAM_TAB.WOOWA_TECH_CAMP,
   PROGRAM_TAB.WOOWA_TECH_CAMP_PRO,
 ] as const;

--- a/frontend/src/mock/dummy.ts
+++ b/frontend/src/mock/dummy.ts
@@ -35,7 +35,7 @@ export const recruitmentDummy = [
   },
   {
     id: 4,
-    title: "우아한테크캠프 1기",
+    title: "우아한테크캠프 Pro 1기",
     recruitable: true,
     hidden: false,
     startDateTime: "2020-10-25T15:00:00" as ISO8601DateString,


### PR DESCRIPTION
Resolves #665 

# 해결하려는 문제가 무엇인가요?

- 교육 프로그램 탭에서 `우아한테크캠프`를 제거한다.

# 어떻게 해결했나요?

### before
<img width="500" alt="스크린샷 2022-10-12 오후 6 27 13" src="https://user-images.githubusercontent.com/19251499/195305352-269a4919-4244-4c65-a59c-6e459dadba75.png">

### after
<img width="500" alt="스크린샷 2022-10-12 오후 6 26 29" src="https://user-images.githubusercontent.com/19251499/195305168-0c286227-98d6-4e39-8f32-d6c828f1f395.png">

- tab.ts에서 `우아한테크캠프`부분을 삭제하였습니다. 
- meta 태그(index.html)를 수정하였습니다. 
- dummy or storybook에서 `우아한테크캠프`부분을 다른 텍스트로 수정하였습니다. 

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 해결하려는 문제가 잘 수정되었는지 리뷰해주세요.
- 현재의 컨벤션에서 개선되거나 수정할 만한 부분이 존재하는지 리뷰해주세요.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
