### PR TITLE
fix(apply): add the media query to the style of the my application page

### DIFF
--- a/frontend/src/components/@common/ModalWindow/ModalWindow.module.css
+++ b/frontend/src/components/@common/ModalWindow/ModalWindow.module.css
@@ -33,7 +33,7 @@
   overflow: hidden;
 }
 
-@media only screen and (max-width: 420px) {
+@media only screen and (max-width: 512px) {
   .box {
     bottom: 0;
     padding: 1rem;
@@ -45,7 +45,7 @@
   }
 }
 
-@media only screen and (min-width: 420px) {
+@media only screen and (min-width: 512px) {
   .box {
     left: 4rem;
     right: 4rem;

--- a/frontend/src/components/@common/Textarea/Textarea.module.css
+++ b/frontend/src/components/@common/Textarea/Textarea.module.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 513px) {
+@media screen and (min-width: 512px) {
   textarea {
     min-height: 200px !important;
   }

--- a/frontend/src/components/Footer/Footer.module.css
+++ b/frontend/src/components/Footer/Footer.module.css
@@ -63,7 +63,7 @@
   }
 }
 
-@media screen and (max-width: 513px) {
+@media screen and (max-width: 512px) {
   .logo {
     height: 1.5rem;
   }

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -142,7 +142,7 @@
   }
 }
 
-@media screen and (max-width: 513px) {
+@media screen and (max-width: 512px) {
   .logo {
     width: 1.25rem;
     margin-right: 0.25rem;

--- a/frontend/src/components/MyApplicationItem/RecruitmentDetail/RecruitmentDetail.module.css
+++ b/frontend/src/components/MyApplicationItem/RecruitmentDetail/RecruitmentDetail.module.css
@@ -10,7 +10,7 @@
   color: var(--gray-008);
 }
 
-@media screen and (max-width: 513px) {
+@media screen and (max-width: 512px) {
   .date {
     gap: 4px;
     font-size: 14px;

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
@@ -44,7 +44,7 @@
   width: 1rem;
 }
 
-@media screen and (max-width: 513px) {
+@media screen and (max-width: 512px) {
   .title {
     font-size: 1rem;
     min-width: 8rem;

--- a/frontend/src/pages/MyApplication/MyApplication.module.css
+++ b/frontend/src/pages/MyApplication/MyApplication.module.css
@@ -35,7 +35,7 @@
   font-weight: bold;
 }
 
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 512px) {
   .box {
     width: calc(100vw - 1rem);
   }

--- a/frontend/src/pages/MyApplication/MyApplication.module.css
+++ b/frontend/src/pages/MyApplication/MyApplication.module.css
@@ -1,5 +1,5 @@
 .box {
-  width: 50rem;
+  width: var(--pc-main-width);
   margin: 0 auto;
 }
 
@@ -33,4 +33,10 @@
   color: var(--gray-004);
   font-size: 1.25rem;
   font-weight: bold;
+}
+
+@media screen and (max-width: 420px) {
+  .box {
+    width: calc(100vw - 1rem);
+  }
 }


### PR DESCRIPTION
Resolves #668, #632
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 내 지원 현황 페이지의 box가 모바일일 때에도 PC 기준 너비를 그대로 유지해 가로 스크롤이 생기고 있습니다. 

# 어떻게 해결했나요?

- 모집 목록 페이지에서 사용하는 컨테이너의 너비값과 동일하게 맞췄습니다. 

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 기존 스타일 규칙과 맞지 않는 부분이 있을까요?  
- 우디 PR에서 대부분의 모바일 breakpoint를 420px로 맞춰 동일하게 적용하였습니다. 좀 더 넓은 너비를 기준으로 해야 할 것 같다면 의견 부탁드려요. 
- https://github.com/woowacourse/service-apply/issues/632 이슈도 같이 해결되는지, 따로 확인이 필요할지 삼성 브라우저 소유자분들 확인 부탁드립니다!

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
