### PR TITLE
refactor: change default value of dialog confirm button success to close dialog

### DIFF
--- a/src/main/kotlin/support/views/Buttons.kt
+++ b/src/main/kotlin/support/views/Buttons.kt
@@ -107,7 +107,7 @@ fun createSuccessButtonWithDialog(
 fun createContrastButtonWithDialog(
     text: String,
     message: String,
-    clickListener: ClickListener,
+    clickListener: ClickListener
 ): Button {
     return createContrastButton(text) { createConfirmDialog(message, clickListener) }
 }

--- a/src/main/kotlin/support/views/Buttons.kt
+++ b/src/main/kotlin/support/views/Buttons.kt
@@ -95,16 +95,48 @@ fun createContrastSmallButton(text: String, clickListener: ClickListener): Butto
     }
 }
 
-fun createSuccessButtonWithDialog(text: String, message: String, clickListener: ClickListener): Button {
-    return createSuccessSmallButton(text) { createConfirmDialog(message, clickListener) }
+fun createSuccessButtonWithDialog(
+    text: String,
+    message: String,
+    successListener: () -> Unit = { UI.getCurrent().page.reload() },
+    clickListener: ClickListener
+): Button {
+    return createSuccessSmallButton(text) { createConfirmDialog(message, clickListener, successListener) }
 }
 
-fun createContrastButtonWithDialog(text: String, message: String, clickListener: ClickListener): Button {
+fun createContrastButtonWithDialog(
+    text: String,
+    message: String,
+    clickListener: ClickListener,
+): Button {
     return createContrastButton(text) { createConfirmDialog(message, clickListener) }
 }
 
-fun createDeleteButtonWithDialog(message: String, clickListener: ClickListener): Button {
-    return createErrorSmallButton("삭제") { createConfirmDialog(message, clickListener) }
+fun createDeleteButtonWithDialog(
+    message: String,
+    successListener: () -> Unit = { UI.getCurrent().page.reload() },
+    clickListener: ClickListener
+): Button {
+    return createErrorSmallButton("삭제") { createConfirmDialog(message, clickListener, successListener) }
+}
+
+private fun createConfirmDialog(
+    text: String,
+    confirmListener: ClickListener,
+    successListener: () -> Unit,
+    cancelListener: ClickListener = {}
+): Dialog {
+    return Dialog(Text(text)).apply {
+        add(
+            HorizontalLayout(
+                createCancelButton(cancelListener),
+                createConfirmButton(confirmListener, successListener)
+            ).apply {
+                justifyContentMode = FlexComponent.JustifyContentMode.CENTER
+            }
+        )
+        open()
+    }
 }
 
 private fun createConfirmDialog(
@@ -132,10 +164,13 @@ private fun Dialog.createCancelButton(clickListener: ClickListener): Button {
     }
 }
 
-private fun Dialog.createConfirmButton(clickListener: ClickListener): Button {
+private fun Dialog.createConfirmButton(
+    clickListener: ClickListener,
+    successListener: () -> Unit = { close() }
+): Button {
     return createPrimaryButton("확인") {
         runCatching { clickListener(it) }
-            .onSuccess { UI.getCurrent().page.reload() }
+            .onSuccess { successListener() }
             .onFailure { e -> createNotification(e.localizedMessage) }
     }
 }


### PR DESCRIPTION
Co-authored-by: asebn1 <asebn121@gmail.com>

Resolves #674 

# 해결하려는 문제가 무엇인가요?
- `createContrastButtonWithDialog` 에서 확인버튼을 누른후, 성공 로직 실행 후에 페이지가 자동으로 reload 됩니다.
    
    ```kotlin
    private fun Dialog.createConfirmButton(clickListener: ClickListener): Button {
        return createPrimaryButton("확인") {
            runCatching { clickListener(it) }
                .onSuccess { UI.getCurrent().page.reload() } // success 후 reload가 고정
                .onFailure { e -> createNotification(e.localizedMessage) }
        }
    }
    ```
    
- reload 되면서 이미 선택해놓은 탭이 아닌 첫 화면으로 돌아가게 됩니다.


# 어떻게 해결했나요?

- 기존의 `createContrastButtonWithDialog` 를 사용하는 부분에게 영향을 주지 않으면서 저희가 사용하는 전체 자동 채점 버튼만 reload를 막으려고 했습니다.
- Dialog 에서 확인버튼을 누른후, 성공 로직 실행 후에 실행할 로직을 주입받게 했습니다.
- default를 그냥 페이지를 닫도록 했고, reload가 필요한 경우에만 reload를 넣어주도록 했습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 실제로 버튼을 누르면 reload가 안되는지 확인해주세요.
- button 수정으로 인해 다른 button에 영향이 가는지 확인해주세요.


---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
