### PR TITLE
refactor(apply): remove type ResponseDataWithMessage

### DIFF
--- a/frontend/src/api/applicationForms.ts
+++ b/frontend/src/api/applicationForms.ts
@@ -1,21 +1,20 @@
 import axios from "axios";
 import { Answer, ApplicationForm } from "../../types/domains/applicationForms";
-import { ResponseDataWithMessage, RequestWithToken } from "../../types/utility";
+import { MyApplicationType } from "../../types/domains/recruitments";
+import { RequestWithToken } from "../../types/utility";
 import { headers } from "./api";
 
 export type FetchMyApplicationFormsRequest = string;
 
-export type FetchMyApplicationFormsResponseData = ResponseDataWithMessage<
-  { recruitmentId: number; submitted: boolean }[]
->;
+export type FetchMyApplicationFormsResponseData = MyApplicationType[];
 
 export type FetchFormRequest = RequestWithToken<{ recruitmentId: string | null }>;
 
-export type FetchFormResponseData = ResponseDataWithMessage<ApplicationForm>;
+export type FetchFormResponseData = ApplicationForm;
 
 export type CreateFormRequest = RequestWithToken<{ recruitmentId: string | null }>;
 
-export type CreateFormResponseData = ResponseDataWithMessage<ApplicationForm>;
+export type CreateFormResponseData = ApplicationForm;
 
 export type UpdateFormRequest = RequestWithToken<{
   data: {

--- a/frontend/src/api/recruitments.ts
+++ b/frontend/src/api/recruitments.ts
@@ -6,14 +6,14 @@ import {
   Recruitment,
   RecruitmentItem,
 } from "../../types/domains/recruitments";
-import { RequestWithToken, ResponseDataWithMessage } from "../../types/utility";
+import { RequestWithToken } from "../../types/utility";
 import { headers } from "./api";
 
 export type FetchRecruitmentItemsRequest = number;
 
-export type FetchRecruitmentItemsResponseData = ResponseDataWithMessage<RecruitmentItem[]>;
+export type FetchRecruitmentItemsResponseData = RecruitmentItem[];
 
-export type FetchRecruitmentsResponseData = ResponseDataWithMessage<Recruitment[]>;
+export type FetchRecruitmentsResponseData = Recruitment[];
 
 export type FetchMyMissionsRequest = RequestWithToken<{
   recruitmentId: number;
@@ -24,14 +24,14 @@ export type FetchMyMissionJudgmentRequest = RequestWithToken<{
   missionId: number;
 }>;
 
-export type FetchMyMissionsResponseData = ResponseDataWithMessage<Mission[]>;
+export type FetchMyMissionsResponseData = Mission[];
 
 export type FetchAssignmentRequest = RequestWithToken<{
   recruitmentId: number;
   missionId: number;
 }>;
 
-export type FetchAssignmentResponseData = ResponseDataWithMessage<Assignment>;
+export type FetchAssignmentResponseData = Assignment;
 
 export type PostAssignmentRequest = RequestWithToken<{
   recruitmentId: number;
@@ -39,7 +39,7 @@ export type PostAssignmentRequest = RequestWithToken<{
   assignmentData: AssignmentData;
 }>;
 
-export type PostAssignmentResponseData = ResponseDataWithMessage<Assignment>;
+export type PostAssignmentResponseData = Assignment;
 
 export type PatchAssignmentRequest = RequestWithToken<{
   recruitmentId: number;

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { headers } from "./api";
 import { formatDate } from "../utils/format/date";
-import { RequestWithToken, ResponseDataWithMessage } from "../../types/utility";
+import { RequestWithToken } from "../../types/utility";
 import { User } from "../../types/domains/user";
 
 type FetchRegisterRequest = Omit<User, "id"> & {
@@ -9,11 +9,11 @@ type FetchRegisterRequest = Omit<User, "id"> & {
   authenticationCode: string;
 };
 
-type FetchRegisterResponseData = ResponseDataWithMessage<string>;
+type FetchRegisterResponseData = string;
 
 type FetchLoginRequest = Pick<User, "email" | "password">;
 
-type FetchLoginResponseData = ResponseDataWithMessage<string>;
+type FetchLoginResponseData = string;
 
 type FetchPasswordFindRequest = Pick<User, "name" | "email" | "password" | "birthday">;
 
@@ -29,7 +29,7 @@ type FetchPasswordEditResponseData = void;
 
 type FetchUserInfoRequest = RequestWithToken;
 
-type FetchUserInfoResponseData = ResponseDataWithMessage<Omit<User, "password">>;
+type FetchUserInfoResponseData = Omit<User, "password">;
 
 type FetchUserInfoEditRequest = RequestWithToken<{ phoneNumber: string }>;
 

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -31,8 +31,8 @@ export const ERROR_MESSAGE = {
     SUBMIT_APPLICATION: "입력된 정보가 올바르지 않습니다. 다시 확인해 주세요.",
     FIND_PASSWORD: "입력된 정보가 올바르지 않습니다. 다시 확인해 주세요.",
     EDIT_PASSWORD: "입력된 정보가 올바르지 않습니다. 다시 확인해 주세요.",
-    LOAD_APPLICATION_FORM: "지원서를 불러오는데 실패했습니다. 잠시 후 다시 시도해 주세요.",
-    SAVE_APPLICATION_FORM: "지원서를 저장하는데 실패했습니다. 잠시 후 다시 시도해 주세요.",
+    LOAD_APPLICATION_FORM: "지원서를 불러오는 데 실패했습니다. 잠시 후 다시 시도해 주세요.",
+    SAVE_APPLICATION_FORM: "지원서를 저장하는 데 실패했습니다. 잠시 후 다시 시도해 주세요.",
   },
   ACCESS: {
     REQUIRED_LOGIN: "로그인이 필요합니다.",

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -31,6 +31,8 @@ export const ERROR_MESSAGE = {
     SUBMIT_APPLICATION: "입력된 정보가 올바르지 않습니다. 다시 확인해 주세요.",
     FIND_PASSWORD: "입력된 정보가 올바르지 않습니다. 다시 확인해 주세요.",
     EDIT_PASSWORD: "입력된 정보가 올바르지 않습니다. 다시 확인해 주세요.",
+    LOAD_APPLICATION_FORM: "지원서를 불러오는데 실패했습니다. 잠시 후 다시 시도해 주세요.",
+    SAVE_APPLICATION_FORM: "지원서를 저장하는데 실패했습니다. 잠시 후 다시 시도해 주세요.",
   },
   ACCESS: {
     REQUIRED_LOGIN: "로그인이 필요합니다.",

--- a/frontend/src/hooks/useApplicationRegisterForm.js
+++ b/frontend/src/hooks/useApplicationRegisterForm.js
@@ -113,10 +113,8 @@ const useApplicationRegisterForm = ({
     );
   };
 
-  const handleLoadFormError = (error) => {
-    if (!error) return;
-    // TODO: 서버 에러응답을 클라이언트에서 분기처리하여 메시지 표시한다.
-    alert(error.response.data.message);
+  const handleLoadFormError = () => {
+    alert(ERROR_MESSAGE.API.LOAD_APPLICATION_FORM);
     navigate(PATH.RECRUITS);
   };
 
@@ -129,7 +127,7 @@ const useApplicationRegisterForm = ({
       setForm({ referenceUrl });
       setModifiedDateTime(formatDateTime(new Date(modifiedDateTime)));
     } catch (error) {
-      handleLoadFormError(error);
+      handleLoadFormError();
     }
   };
 

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -11,7 +11,7 @@ import CheckBox from "../../components/form/CheckBox/CheckBox";
 import Form from "../../components/form/Form/Form";
 import ApplicationPreviewModal from "../../components/ApplicationPreviewModal/ApplicationPreviewModal";
 import { FORM } from "../../constants/form";
-import { SUCCESS_MESSAGE } from "../../constants/messages";
+import { ERROR_MESSAGE, SUCCESS_MESSAGE } from "../../constants/messages";
 import { PATH, PARAM } from "../../constants/path";
 import useApplicationRegisterForm, {
   APPLICATION_REGISTER_FORM_NAME,
@@ -71,11 +71,8 @@ const ApplicationRegister = () => {
     );
   };
 
-  const handleSaveError = (error) => {
-    if (!error) return;
-
-    // TODO: 서버 에러응답을 클라이언트에서 분기처리하여 메시지 표시한다.
-    alert(error.response.data.message);
+  const handleSaveError = () => {
+    alert(ERROR_MESSAGE.API.LOAD_APPLICATION_FORM);
   };
 
   const save = async ({ referenceUrl, answers }) => {
@@ -94,7 +91,7 @@ const ApplicationRegister = () => {
       alert(SUCCESS_MESSAGE.API.SUBMIT_APPLICATION);
       navigate(PATH.HOME, { replace: true });
     } catch (error) {
-      handleSaveError(error);
+      handleSaveError();
     }
   };
 
@@ -114,7 +111,7 @@ const ApplicationRegister = () => {
       alert(SUCCESS_MESSAGE.API.SAVE_APPLICATION);
       reloadToEdit();
     } catch (error) {
-      handleSaveError(error);
+      handleSaveError();
     }
   };
 

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -72,7 +72,7 @@ const ApplicationRegister = () => {
   };
 
   const handleSaveError = () => {
-    alert(ERROR_MESSAGE.API.LOAD_APPLICATION_FORM);
+    alert(ERROR_MESSAGE.API.SAVE_APPLICATION_FORM);
   };
 
   const save = async ({ referenceUrl, answers }) => {

--- a/frontend/src/pages/MyApplication/MyApplication.tsx
+++ b/frontend/src/pages/MyApplication/MyApplication.tsx
@@ -54,8 +54,7 @@ const MyApplication = () => {
   useEffect(() => {
     try {
       const fetchMyRecruitments = async () => {
-        const response = await fetchMyApplicationForms(token);
-        const myApplication = response.data as unknown as MyApplicationType[];
+        const { data: myApplication } = await fetchMyApplicationForms(token);
         setMyApplications(myApplication);
       };
 

--- a/frontend/types/utility.ts
+++ b/frontend/types/utility.ts
@@ -1,8 +1,3 @@
 export type RequestWithToken<T = {}> = { token: string } & T;
 
-export type ResponseDataWithMessage<T> = {
-  message: string;
-  body: T;
-};
-
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
Resolves #686 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 실제 응답 형식과 달라 혼란을 유발하는 타입인 `ResponseDataWithMessage`를 변경합니다.

# 어떻게 해결했나요?

- `ResponseDataWithMessage` 타입을 제거했습니다.
- 지원서 조회 및 저장 관련 에러 메시지를 상수로 정의하고 에러 발생 시, 새로 정의한 에러 메시지로 안내하도록 로직을 수정했습니다.

이렇게 수정하게 된 이유는 아래와 같습니다.

## 1. 왜 message가 없는 응답 데이터를 돌려받고 있는 걸까?
백엔드에서는 rest docs와 같이 일부 응답에서 message와 body를 가지는 객체를 돌려주고 있습니다. 그에 맞추어 작성하면 기존에 작성한 `ResponseDataWithMessage` 타입은 적절합니다.
그러나 요청 후 응답을 확인해보면 response.data.body로 돌아올 것이라 예상한 데이터가 response.data로 돌아오고 있습니다.

그 이유는 **axios.interceptor의 성공 응답 처리에서, 응답 데이터에 'body'라는 프로퍼티가 있다면, response.data를 response.data.body로 바꾸도록 설정했기 때문**이었습니다.
따라서 성공 케이스일 때 response.data에 message와 body가 함께 들어있는 경우는 없습니다.

## 2. response.data.message는 언제 쓰는 걸까?
실제로 response.data.message를 사용하는 경우는 'TODO: 서버 에러 응답을 클라이언트에서 분기 처리하여 메시지 표시한다.' 가 적혀 있는 handleLoadFormError(useApplicationRegisterForm.js), handleSaveError(ApplicationRegister.js) 두 함수입니다. 

이 두 함수는 상수 정의된 에러 메시지를 이용하고 있는 다른 에러 핸들링 함수들과 달리, error.response.data.message로 응답 데이터의 메시지를 불러와 사용하고 있었습니다.
그 중 handleSaveError는 응답에서 message를 돌려주지 않음에도(rest docs로 확인) 위와 같이 message를 사용하고 있었습니다.

위와 같은 이유로 
1. `ResponseDataWithMessage`를 수정하기보다는 제거하는 방향이 맞다고 생각했고, 
2. TODO를 고려하고 에러 핸들링 로직의 일관성을 맞추고자, 에러 메시지를 새로 정의하고 에러 핸들링 로직을 수정했습니다.

전체적인 흐름을 봤을 때, 이전 버전부터 응답으로 돌아오는 message를 쓰는 일이 거의 없었고, 쓰지 않고 코드를 작성하려고 한 것으로 파악했는데요. 서버에서 돌려주는 응답에서 message를 제거하는 것도 하나의 방법이 될 것 같습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- response.data.message가 다른 이유로 필요한데 제가 놓친 게 아닐까 싶기도 하네요. message를 살려둘 필요는 없는지 확인 부탁 드립니다.
- 원래는 타입을 수정하려고 했는데, 원인을 파악하다 보니 타입을 제거하는 방향으로 진행되었습니다. 더 나은 개선 방향이 있다면 제안해주세요.

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
