### PR TITLE
refactor(css): refactor color system

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -26,7 +26,7 @@ html,
 body {
   height: 100%;
   background: var(--light-blue-gray);
-  color: var(--black-004);
+  color: var(--black-400);
 }
 
 ul,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -25,7 +25,7 @@
 html,
 body {
   height: 100%;
-  background: var(--light-blue-gray);
+  background: var(--gray-150);
   color: var(--gray-900);
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -26,7 +26,7 @@ html,
 body {
   height: 100%;
   background: var(--light-blue-gray);
-  color: var(--black-400);
+  color: var(--gray-900);
 }
 
 ul,

--- a/frontend/src/color.css
+++ b/frontend/src/color.css
@@ -1,5 +1,6 @@
 :root {
   --gray-100: #fafafa;
+  --gray-150: #f5f5f5;
   --gray-200: #eee;
   --gray-300: #ddd;
   --gray-400: #ccc;
@@ -10,10 +11,9 @@
   --gray-900: #333;
   --black: #000;
   --white: #fff;
-  --light-blue-gray: #f5f5f5;
-  --light-blue-green: #d5eaf1;
+  --blue-gray-100: #d5eaf1;
+  --blue-gray-500: #5f7997;
   --blue: #279cf6;
-  --blue-gray: #5f7997;
   --red: #ff0000;
   --green: #0eaf7a;
   --cyan: #2c3e50;

--- a/frontend/src/color.css
+++ b/frontend/src/color.css
@@ -17,5 +17,6 @@
   --blue-gray: #5f7997;
   --red: #ff0000;
   --green: #0eaf7a;
+  --cyan: #2c3e50;
   --dim: rgba(0, 0, 0, 0.4);
 }

--- a/frontend/src/color.css
+++ b/frontend/src/color.css
@@ -1,15 +1,15 @@
 :root {
-  --gray-001: #fafafa;
-  --gray-002: #eee;
-  --gray-003: #ddd;
-  --gray-004: #ccc;
-  --gray-005: #bbb;
-  --gray-006: #aaa;
-  --gray-007: #999;
-  --gray-008: #666;
-  --gray-009: #555;
-  --black-001: #000;
-  --black-004: #333;
+  --gray-100: #fafafa;
+  --gray-200: #eee;
+  --gray-300: #ddd;
+  --gray-400: #ccc;
+  --gray-500: #bbb;
+  --gray-600: #aaa;
+  --gray-700: #999;
+  --gray-800: #666;
+  --gray-900: #555;
+  --black-100: #000;
+  --black-400: #333;
   --white: #fff;
   --light-blue-gray: #f5f5f5;
   --light-blue-green: #d5eaf1;

--- a/frontend/src/color.css
+++ b/frontend/src/color.css
@@ -3,7 +3,6 @@
   --gray-200: #eee;
   --gray-300: #ddd;
   --gray-400: #ccc;
-  --gray-500: #bbb;
   --gray-600: #aaa;
   --gray-700: #999;
   --gray-800: #666;

--- a/frontend/src/color.css
+++ b/frontend/src/color.css
@@ -17,5 +17,5 @@
   --red: #ff0000;
   --green: #0eaf7a;
   --cyan: #2c3e50;
-  --dim: rgba(0, 0, 0, 0.4);
+  --tint: rgba(0, 0, 0, 0.4);
 }

--- a/frontend/src/color.css
+++ b/frontend/src/color.css
@@ -3,12 +3,12 @@
   --gray-200: #eee;
   --gray-300: #ddd;
   --gray-400: #ccc;
-  --gray-600: #aaa;
-  --gray-700: #999;
-  --gray-800: #666;
-  --gray-900: #555;
-  --black-100: #000;
-  --black-400: #333;
+  --gray-500: #aaa;
+  --gray-600: #999;
+  --gray-700: #666;
+  --gray-800: #555;
+  --gray-900: #333;
+  --black: #000;
   --white: #fff;
   --light-blue-gray: #f5f5f5;
   --light-blue-green: #d5eaf1;

--- a/frontend/src/components/@common/Button/Button.module.css
+++ b/frontend/src/components/@common/Button/Button.module.css
@@ -8,14 +8,14 @@
 }
 
 .contained {
-  background-color: var(--black-400);
+  background-color: var(--gray-900);
   color: var(--white);
 }
 
 .outlined {
-  color: var(--black-400);
+  color: var(--gray-900);
   background-color: var(--white);
-  border: 1px solid var(--black-400);
+  border: 1px solid var(--gray-900);
 }
 
 .outlined:enabled:hover {
@@ -23,12 +23,12 @@
 }
 
 .contained {
-  background-color: var(--black-400);
+  background-color: var(--gray-900);
   color: var(--white);
 }
 
 .cancel {
-  background: var(--gray-800);
+  background: var(--gray-700);
 }
 button:disabled {
   cursor: default;

--- a/frontend/src/components/@common/Button/Button.module.css
+++ b/frontend/src/components/@common/Button/Button.module.css
@@ -8,30 +8,30 @@
 }
 
 .contained {
-  background-color: var(--black-004);
+  background-color: var(--black-400);
   color: var(--white);
 }
 
 .outlined {
-  color: var(--black-004);
+  color: var(--black-400);
   background-color: var(--white);
-  border: 1px solid var(--black-004);
+  border: 1px solid var(--black-400);
 }
 
 .outlined:enabled:hover {
-  background-color: var(--gray-001);
+  background-color: var(--gray-100);
 }
 
 .contained {
-  background-color: var(--black-004);
+  background-color: var(--black-400);
   color: var(--white);
 }
 
 .cancel {
-  background: var(--gray-008);
+  background: var(--gray-800);
 }
 button:disabled {
   cursor: default;
-  background: var(--gray-004);
+  background: var(--gray-400);
   cursor: not-allowed;
 }

--- a/frontend/src/components/@common/Description/Description.module.css
+++ b/frontend/src/components/@common/Description/Description.module.css
@@ -3,5 +3,5 @@
   flex-direction: column;
   margin: 0.375rem 0;
   font-size: 0.875rem;
-  color: var(--gray-800);
+  color: var(--gray-700);
 }

--- a/frontend/src/components/@common/Description/Description.module.css
+++ b/frontend/src/components/@common/Description/Description.module.css
@@ -3,5 +3,5 @@
   flex-direction: column;
   margin: 0.375rem 0;
   font-size: 0.875rem;
-  color: var(--gray-008);
+  color: var(--gray-800);
 }

--- a/frontend/src/components/@common/MessageTextInput/MessageTextInput.module.css
+++ b/frontend/src/components/@common/MessageTextInput/MessageTextInput.module.css
@@ -15,7 +15,7 @@
 
 .length-limit {
   align-self: flex-end;
-  color: var(--gray-700);
+  color: var(--gray-600);
   font-size: 0.875rem;
 }
 

--- a/frontend/src/components/@common/MessageTextInput/MessageTextInput.module.css
+++ b/frontend/src/components/@common/MessageTextInput/MessageTextInput.module.css
@@ -15,7 +15,7 @@
 
 .length-limit {
   align-self: flex-end;
-  color: var(--gray-007);
+  color: var(--gray-700);
   font-size: 0.875rem;
 }
 

--- a/frontend/src/components/@common/MessageTextarea/MessageTextarea.module.css
+++ b/frontend/src/components/@common/MessageTextarea/MessageTextarea.module.css
@@ -13,7 +13,7 @@
 
 .length-limit {
   align-self: flex-end;
-  color: var(--gray-007);
+  color: var(--gray-700);
   font-size: 13px;
   margin-bottom: 4px;
 }

--- a/frontend/src/components/@common/MessageTextarea/MessageTextarea.module.css
+++ b/frontend/src/components/@common/MessageTextarea/MessageTextarea.module.css
@@ -13,7 +13,7 @@
 
 .length-limit {
   align-self: flex-end;
-  color: var(--gray-700);
+  color: var(--gray-600);
   font-size: 13px;
   margin-bottom: 4px;
 }

--- a/frontend/src/components/@common/ModalPortal/ModalPortal.module.css
+++ b/frontend/src/components/@common/ModalPortal/ModalPortal.module.css
@@ -20,6 +20,6 @@
 .dimmer-box {
   position: fixed;
   inset: 0;
-  background-color: var(--dim);
+  background-color: var(--tint);
   animation: dissolve 0.3s forwards;
 }

--- a/frontend/src/components/@common/ModalWindow/ModalWindow.module.css
+++ b/frontend/src/components/@common/ModalWindow/ModalWindow.module.css
@@ -29,7 +29,7 @@
   z-index: var(--modal-window-z-index);
   display: flex;
   flex-direction: column;
-  background-color: white;
+  background-color: var(--white);
   overflow: hidden;
 }
 

--- a/frontend/src/components/@common/Radio/Radio.module.css
+++ b/frontend/src/components/@common/Radio/Radio.module.css
@@ -29,5 +29,5 @@ input[type="radio"] + .custom-radio {
 }
 
 input[type="radio"]:checked + .custom-radio {
-  background: var(--black-400);
+  background: var(--gray-900);
 }

--- a/frontend/src/components/@common/Radio/Radio.module.css
+++ b/frontend/src/components/@common/Radio/Radio.module.css
@@ -22,12 +22,12 @@ input[type="radio"] + .custom-radio {
   width: 1.25rem;
   height: 1.25rem;
   border-radius: 1.25rem;
-  border: 3px solid var(--gray-004);
+  border: 3px solid var(--gray-400);
   background: var(--white);
   margin-right: 0.25rem;
   transition-duration: 0.2s;
 }
 
 input[type="radio"]:checked + .custom-radio {
-  background: var(--black-004);
+  background: var(--black-400);
 }

--- a/frontend/src/components/@common/StatusIndicator/StatusIndicator.module.css
+++ b/frontend/src/components/@common/StatusIndicator/StatusIndicator.module.css
@@ -12,12 +12,12 @@
   appearance: none;
   user-select: none;
 
-  background: var(--gray-002);
-  color: var(--gray-006);
+  background: var(--gray-200);
+  color: var(--gray-600);
   font-weight: bold;
 }
 
 .active {
-  background-color: var(--gray-002);
+  background-color: var(--gray-200);
   color: var(--blue);
 }

--- a/frontend/src/components/@common/StatusIndicator/StatusIndicator.module.css
+++ b/frontend/src/components/@common/StatusIndicator/StatusIndicator.module.css
@@ -13,7 +13,7 @@
   user-select: none;
 
   background: var(--gray-200);
-  color: var(--gray-600);
+  color: var(--gray-500);
   font-weight: bold;
 }
 

--- a/frontend/src/components/@common/TabItem/TabItem.module.css
+++ b/frontend/src/components/@common/TabItem/TabItem.module.css
@@ -12,6 +12,6 @@
 
 .checked {
   font-weight: 600;
-  background-color: var(--light-blue-green);
+  background-color: var(--blue-gray-100);
   border-radius: 50px;
 }

--- a/frontend/src/components/@common/TextInput/TextInput.module.css
+++ b/frontend/src/components/@common/TextInput/TextInput.module.css
@@ -1,6 +1,6 @@
 .text-input {
   padding: 0.625rem 0.875rem;
-  border: 1px solid var(--gray-005);
+  border: 1px solid var(--gray-500);
   border-radius: 0.25rem;
   transition-duration: 0.5s;
   font-size: 1rem;
@@ -13,5 +13,5 @@
 .text-input:read-only,
 .text-input:disabled {
   cursor: default;
-  background: var(--gray-003);
+  background: var(--gray-300);
 }

--- a/frontend/src/components/@common/TextInput/TextInput.module.css
+++ b/frontend/src/components/@common/TextInput/TextInput.module.css
@@ -1,6 +1,6 @@
 .text-input {
   padding: 0.625rem 0.875rem;
-  border: 1px solid var(--gray-500);
+  border: 1px solid var(--gray-400);
   border-radius: 0.25rem;
   transition-duration: 0.5s;
   font-size: 1rem;

--- a/frontend/src/components/@common/Textarea/Textarea.module.css
+++ b/frontend/src/components/@common/Textarea/Textarea.module.css
@@ -6,7 +6,7 @@
 
 .text-input {
   padding: 12px;
-  border: 1px solid var(--gray-006);
+  border: 1px solid var(--gray-600);
   border-radius: 4px;
   transition-duration: 0.5s;
   line-height: 30px;

--- a/frontend/src/components/@common/Textarea/Textarea.module.css
+++ b/frontend/src/components/@common/Textarea/Textarea.module.css
@@ -6,7 +6,7 @@
 
 .text-input {
   padding: 12px;
-  border: 1px solid var(--gray-600);
+  border: 1px solid var(--gray-500);
   border-radius: 4px;
   transition-duration: 0.5s;
   line-height: 30px;

--- a/frontend/src/components/@common/Tooltip/Tooltip.module.css
+++ b/frontend/src/components/@common/Tooltip/Tooltip.module.css
@@ -33,7 +33,7 @@
   margin-left: 1.2rem;
   font-size: 0.75rem;
   list-style: square;
-  color: var(--black-400);
+  color: var(--gray-900);
 }
 
 .tooltip-modal-container:after {

--- a/frontend/src/components/@common/Tooltip/Tooltip.module.css
+++ b/frontend/src/components/@common/Tooltip/Tooltip.module.css
@@ -11,7 +11,7 @@
   height: fit-content;
   padding: 0.5rem 0.25rem;
   border-radius: 10px;
-  background-color: var(--gray-003);
+  background-color: var(--gray-300);
   z-index: var(--tooltip-z-index);
 }
 
@@ -26,14 +26,14 @@
   position: absolute;
   bottom: 2rem;
   right: 0;
-  box-shadow: 3px 3px 5px var(--gray-005);
+  box-shadow: 3px 3px 5px var(--gray-500);
 }
 
 .tooltip-text {
   margin-left: 1.2rem;
   font-size: 0.75rem;
   list-style: square;
-  color: var(--black-004);
+  color: var(--black-400);
 }
 
 .tooltip-modal-container:after {
@@ -41,7 +41,7 @@
   position: absolute;
   bottom: -9px;
   right: 5px;
-  border-top: 10px solid var(--gray-003);
+  border-top: 10px solid var(--gray-300);
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
 }

--- a/frontend/src/components/@common/Tooltip/Tooltip.module.css
+++ b/frontend/src/components/@common/Tooltip/Tooltip.module.css
@@ -26,7 +26,7 @@
   position: absolute;
   bottom: 2rem;
   right: 0;
-  box-shadow: 3px 3px 5px var(--gray-500);
+  box-shadow: 3px 3px 5px var(--gray-400);
 }
 
 .tooltip-text {

--- a/frontend/src/components/ApplicationPreviewModal/ApplicationPreviewModal.module.css
+++ b/frontend/src/components/ApplicationPreviewModal/ApplicationPreviewModal.module.css
@@ -39,12 +39,12 @@
 }
 
 .application-item-description {
-  color: var(--gray-008);
+  color: var(--gray-800);
   margin-bottom: 0.5rem;
 }
 
 .application-item-answer-length {
-  color: var(--gray-007);
+  color: var(--gray-700);
   align-self: flex-end;
 }
 

--- a/frontend/src/components/ApplicationPreviewModal/ApplicationPreviewModal.module.css
+++ b/frontend/src/components/ApplicationPreviewModal/ApplicationPreviewModal.module.css
@@ -39,12 +39,12 @@
 }
 
 .application-item-description {
-  color: var(--gray-800);
+  color: var(--gray-700);
   margin-bottom: 0.5rem;
 }
 
 .application-item-answer-length {
-  color: var(--gray-700);
+  color: var(--gray-600);
   align-self: flex-end;
 }
 

--- a/frontend/src/components/Footer/Footer.module.css
+++ b/frontend/src/components/Footer/Footer.module.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   padding: 3rem 0;
-  background: var(--black-400);
+  background: var(--gray-900);
   color: var(--white);
   user-select: none;
 }

--- a/frontend/src/components/Footer/Footer.module.css
+++ b/frontend/src/components/Footer/Footer.module.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   padding: 3rem 0;
-  background: var(--black-004);
+  background: var(--black-400);
   color: var(--white);
   user-select: none;
 }

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -25,7 +25,7 @@
   font-size: 1.375rem;
   display: flex;
   align-items: center;
-  color: var(--black-400);
+  color: var(--gray-900);
 }
 
 .logo {
@@ -43,7 +43,7 @@
 
 .link-container,
 .link-container button {
-  color: var(--gray-800);
+  color: var(--gray-700);
 }
 
 .member-menu-container {
@@ -133,7 +133,7 @@
   width: 1px;
   height: 1.25rem;
   margin: 0 0.75rem;
-  background-color: var(--gray-800);
+  background-color: var(--gray-700);
 }
 
 @media screen and (max-width: 800px) {

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -11,7 +11,7 @@
   justify-content: center;
   align-items: center;
   background: var(--white);
-  border-bottom: 1px solid var(--gray-003);
+  border-bottom: 1px solid var(--gray-300);
   z-index: var(--header-z-index);
 }
 
@@ -25,7 +25,7 @@
   font-size: 1.375rem;
   display: flex;
   align-items: center;
-  color: var(--black-004);
+  color: var(--black-400);
 }
 
 .logo {
@@ -43,7 +43,7 @@
 
 .link-container,
 .link-container button {
-  color: var(--gray-008);
+  color: var(--gray-800);
 }
 
 .member-menu-container {
@@ -90,7 +90,7 @@
   right: 0;
   width: 10rem;
   background-color: var(--white);
-  border: 1px solid var(--gray-003);
+  border: 1px solid var(--gray-300);
   z-index: var(--tooltip-z-index);
 }
 
@@ -100,7 +100,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-bottom: 1px solid var(--gray-003);
+  border-bottom: 1px solid var(--gray-300);
   font-weight: 400;
   cursor: pointer;
   user-select: none;
@@ -133,7 +133,7 @@
   width: 1px;
   height: 1.25rem;
   margin: 0 0.75rem;
-  background-color: var(--gray-008);
+  background-color: var(--gray-800);
 }
 
 @media screen and (max-width: 800px) {

--- a/frontend/src/components/InquiryFloatingButton/InquiryFloatingButton.module.css
+++ b/frontend/src/components/InquiryFloatingButton/InquiryFloatingButton.module.css
@@ -8,13 +8,13 @@
   padding-left: 1rem;
   border-radius: 4.5rem;
   background-color: var(--white);
-  box-shadow: 0 0 5px var(--gray-004);
+  box-shadow: 0 0 5px var(--gray-400);
   cursor: pointer;
 }
 
 .inquire-text {
   font-weight: 600;
-  color: var(--black-004);
+  color: var(--black-400);
 }
 
 .kakao-icon-box {
@@ -24,7 +24,7 @@
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 50%;
-  background-color: var(--black-001);
+  background-color: var(--black-100);
 }
 
 @media screen and (max-width: 512px) {

--- a/frontend/src/components/InquiryFloatingButton/InquiryFloatingButton.module.css
+++ b/frontend/src/components/InquiryFloatingButton/InquiryFloatingButton.module.css
@@ -14,7 +14,7 @@
 
 .inquire-text {
   font-weight: 600;
-  color: var(--black-400);
+  color: var(--gray-900);
 }
 
 .kakao-icon-box {
@@ -24,7 +24,7 @@
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 50%;
-  background-color: var(--black-100);
+  background-color: var(--black);
 }
 
 @media screen and (max-width: 512px) {

--- a/frontend/src/components/MyApplicationItem/MissionDetail/MissionDetail.module.css
+++ b/frontend/src/components/MyApplicationItem/MissionDetail/MissionDetail.module.css
@@ -10,6 +10,6 @@
   display: flex;
   gap: 0.25rem;
   margin-left: auto;
-  color: var(--gray-007);
+  color: var(--gray-700);
   font-size: 0.815rem;
 }

--- a/frontend/src/components/MyApplicationItem/MissionDetail/MissionDetail.module.css
+++ b/frontend/src/components/MyApplicationItem/MissionDetail/MissionDetail.module.css
@@ -10,6 +10,6 @@
   display: flex;
   gap: 0.25rem;
   margin-left: auto;
-  color: var(--gray-700);
+  color: var(--gray-600);
   font-size: 0.815rem;
 }

--- a/frontend/src/components/MyApplicationItem/MyApplicationButtons/ApplicationButtons.module.css
+++ b/frontend/src/components/MyApplicationItem/MyApplicationButtons/ApplicationButtons.module.css
@@ -7,7 +7,7 @@
 }
 
 .apply-button {
-  background-color: var(--black-400);
+  background-color: var(--gray-900);
 }
 
 @media screen and (max-width: 800px) {

--- a/frontend/src/components/MyApplicationItem/MyApplicationButtons/ApplicationButtons.module.css
+++ b/frontend/src/components/MyApplicationItem/MyApplicationButtons/ApplicationButtons.module.css
@@ -7,7 +7,7 @@
 }
 
 .apply-button {
-  background-color: var(--black-004);
+  background-color: var(--black-400);
 }
 
 @media screen and (max-width: 800px) {

--- a/frontend/src/components/MyApplicationItem/MyApplicationButtons/ApplicationButtons.module.css
+++ b/frontend/src/components/MyApplicationItem/MyApplicationButtons/ApplicationButtons.module.css
@@ -1,9 +1,9 @@
 .refresh-button {
-  background-color: var(--blue-gray);
+  background-color: var(--blue-gray-500);
 }
 
 .judgment-button {
-  background-color: var(--blue-gray);
+  background-color: var(--blue-gray-500);
 }
 
 .apply-button {

--- a/frontend/src/components/MyApplicationItem/MyApplicationItem.module.css
+++ b/frontend/src/components/MyApplicationItem/MyApplicationItem.module.css
@@ -8,7 +8,7 @@
   padding: 1.25rem 1.5rem 1rem;
   margin-bottom: 1.25rem;
   background-color: var(--white);
-  border: 1px solid var(--gray-003);
+  border: 1px solid var(--gray-300);
 }
 
 .text-container {
@@ -19,7 +19,7 @@
 }
 
 .auto-judgment-detail-contour {
-  border: 0.5px solid var(--gray-003);
+  border: 0.5px solid var(--gray-300);
 }
 
 .button-container {

--- a/frontend/src/components/MyApplicationItem/RecruitmentDetail/RecruitmentDetail.module.css
+++ b/frontend/src/components/MyApplicationItem/RecruitmentDetail/RecruitmentDetail.module.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--gray-800);
+  color: var(--gray-700);
 }
 
 @media screen and (max-width: 512px) {

--- a/frontend/src/components/MyApplicationItem/RecruitmentDetail/RecruitmentDetail.module.css
+++ b/frontend/src/components/MyApplicationItem/RecruitmentDetail/RecruitmentDetail.module.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--gray-008);
+  color: var(--gray-800);
 }
 
 @media screen and (max-width: 512px) {

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
@@ -7,7 +7,7 @@
   padding: 1.5rem 1rem;
 
   background-color: var(--white);
-  color: var(--gray-004);
+  color: var(--gray-400);
   cursor: default;
 }
 
@@ -17,7 +17,7 @@
 }
 
 .content-wrapper.active:hover {
-  background-color: var(--gray-002);
+  background-color: var(--gray-200);
   transition: 300ms ease-in-out;
 }
 
@@ -31,7 +31,7 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 1rem;
-  color: var(--gray-008);
+  color: var(--gray-800);
 }
 
 .icon {

--- a/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
+++ b/frontend/src/components/RecruitmentItem/RecruitmentItem.module.css
@@ -31,7 +31,7 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 1rem;
-  color: var(--gray-800);
+  color: var(--gray-700);
 }
 
 .icon {

--- a/frontend/src/components/form/BirthField/BirthField.module.css
+++ b/frontend/src/components/form/BirthField/BirthField.module.css
@@ -17,7 +17,7 @@
   height: 2.5rem;
   padding: 0 0.875rem;
   font-size: 1rem;
-  border: 1px solid var(--gray-600);
+  border: 1px solid var(--gray-500);
   border-radius: 0.25rem;
 }
 

--- a/frontend/src/components/form/BirthField/BirthField.module.css
+++ b/frontend/src/components/form/BirthField/BirthField.module.css
@@ -17,7 +17,7 @@
   height: 2.5rem;
   padding: 0 0.875rem;
   font-size: 1rem;
-  border: 1px solid var(--gray-500);
+  border: 1px solid var(--gray-600);
   border-radius: 0.25rem;
 }
 

--- a/frontend/src/components/form/BirthField/BirthField.module.css
+++ b/frontend/src/components/form/BirthField/BirthField.module.css
@@ -17,12 +17,12 @@
   height: 2.5rem;
   padding: 0 0.875rem;
   font-size: 1rem;
-  border: 1px solid var(--gray-005);
+  border: 1px solid var(--gray-500);
   border-radius: 0.25rem;
 }
 
 .input:read-only {
-  background-color: var(--gray-003);
+  background-color: var(--gray-300);
 }
 
 .rule-field {

--- a/frontend/src/components/form/CheckBox/CheckBox.module.css
+++ b/frontend/src/components/form/CheckBox/CheckBox.module.css
@@ -29,12 +29,12 @@ input[type="checkbox"] + .custom-checkbox::before {
   height: 1.5rem;
   margin-right: 0.375rem;
   border-radius: 1.5rem;
-  border: 1px solid var(--gray-600);
+  border: 1px solid var(--gray-500);
   background: var(--white);
   transition-duration: 0.2s;
 }
 
 input[type="checkbox"]:checked + .custom-checkbox::before {
-  background: var(--black-400);
+  background: var(--gray-900);
   color: var(--white);
 }

--- a/frontend/src/components/form/CheckBox/CheckBox.module.css
+++ b/frontend/src/components/form/CheckBox/CheckBox.module.css
@@ -29,12 +29,12 @@ input[type="checkbox"] + .custom-checkbox::before {
   height: 1.5rem;
   margin-right: 0.375rem;
   border-radius: 1.5rem;
-  border: 1px solid var(--gray-006);
+  border: 1px solid var(--gray-600);
   background: var(--white);
   transition-duration: 0.2s;
 }
 
 input[type="checkbox"]:checked + .custom-checkbox::before {
-  background: var(--black-004);
+  background: var(--black-400);
   color: var(--white);
 }

--- a/frontend/src/components/form/EmailField/EmailField.module.css
+++ b/frontend/src/components/form/EmailField/EmailField.module.css
@@ -43,7 +43,7 @@
 
 .authenticated {
   font-size: 2rem;
-  background-color: var(--black-400);
+  background-color: var(--gray-900);
   color: var(--white);
   display: flex;
   justify-content: center;
@@ -53,7 +53,7 @@
 }
 
 .timer {
-  color: var(--gray-800);
+  color: var(--gray-700);
   font-size: 0.75rem;
   position: absolute;
   top: 0.25rem;

--- a/frontend/src/components/form/EmailField/EmailField.module.css
+++ b/frontend/src/components/form/EmailField/EmailField.module.css
@@ -43,7 +43,7 @@
 
 .authenticated {
   font-size: 2rem;
-  background-color: var(--black-004);
+  background-color: var(--black-400);
   color: var(--white);
   display: flex;
   justify-content: center;
@@ -53,7 +53,7 @@
 }
 
 .timer {
-  color: var(--gray-008);
+  color: var(--gray-800);
   font-size: 0.75rem;
   position: absolute;
   top: 0.25rem;

--- a/frontend/src/components/form/SummaryCheckField/SummaryCheckField.module.css
+++ b/frontend/src/components/form/SummaryCheckField/SummaryCheckField.module.css
@@ -12,7 +12,7 @@
   margin: 0;
   padding: 0.75rem;
   max-height: 140px;
-  border: 1px solid var(--gray-006);
+  border: 1px solid var(--gray-600);
   border-radius: 0.25rem;
   transition-duration: 0.5s;
 }

--- a/frontend/src/components/form/SummaryCheckField/SummaryCheckField.module.css
+++ b/frontend/src/components/form/SummaryCheckField/SummaryCheckField.module.css
@@ -12,7 +12,7 @@
   margin: 0;
   padding: 0.75rem;
   max-height: 140px;
-  border: 1px solid var(--gray-600);
+  border: 1px solid var(--gray-500);
   border-radius: 0.25rem;
   transition-duration: 0.5s;
 }

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -33,11 +33,6 @@ export const PROGRAM_TAB = {
     label: "우아한테크캠프 Pro",
     description: `경력이 있는 재직자를 대상으로 유지보수하기 좋은 코드를 학습하는 교육 프로그램입니다.\n일반 사용자용 서비스 회사가 필요로 하는 역량을 더 쌓고 싶은 분들을 찾고 있어요.`,
   },
-  EMPTY_PROGRAM: {
-    name: "emptyprogram",
-    label: "Empty State UI 확인용",
-    description: "...",
-  },
 } as const;
 
 export const RECRUITS_TAB_LIST = [
@@ -51,5 +46,4 @@ export const PROGRAM_TAB_LIST = [
   PROGRAM_TAB.ALL,
   PROGRAM_TAB.WOOWA_TECH_COURSE,
   PROGRAM_TAB.WOOWA_TECH_CAMP_PRO,
-  PROGRAM_TAB.EMPTY_PROGRAM,
 ] as const;

--- a/frontend/src/constants/tab.ts
+++ b/frontend/src/constants/tab.ts
@@ -33,6 +33,11 @@ export const PROGRAM_TAB = {
     label: "우아한테크캠프 Pro",
     description: `경력이 있는 재직자를 대상으로 유지보수하기 좋은 코드를 학습하는 교육 프로그램입니다.\n일반 사용자용 서비스 회사가 필요로 하는 역량을 더 쌓고 싶은 분들을 찾고 있어요.`,
   },
+  EMPTY_PROGRAM: {
+    name: "emptyprogram",
+    label: "Empty State UI 확인용",
+    description: "...",
+  },
 } as const;
 
 export const RECRUITS_TAB_LIST = [
@@ -46,4 +51,5 @@ export const PROGRAM_TAB_LIST = [
   PROGRAM_TAB.ALL,
   PROGRAM_TAB.WOOWA_TECH_COURSE,
   PROGRAM_TAB.WOOWA_TECH_CAMP_PRO,
+  PROGRAM_TAB.EMPTY_PROGRAM,
 ] as const;

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
@@ -10,7 +10,7 @@
 
   font-size: 1.125rem;
   font-weight: normal;
-  color: var(--gray-007);
+  color: var(--gray-700);
 }
 
 .label-bold label {
@@ -32,13 +32,13 @@
 
 .description-url {
   font-size: 1rem;
-  color: var(--gray-009);
+  color: var(--gray-900);
 }
 
 .description-url-small {
   margin-top: 0.25rem;
   font-size: 0.875rem;
-  color: var(--gray-008);
+  color: var(--gray-800);
 }
 
 .box-agree {

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.module.css
@@ -10,7 +10,7 @@
 
   font-size: 1.125rem;
   font-weight: normal;
-  color: var(--gray-700);
+  color: var(--gray-600);
 }
 
 .label-bold label {
@@ -32,13 +32,13 @@
 
 .description-url {
   font-size: 1rem;
-  color: var(--gray-900);
+  color: var(--gray-800);
 }
 
 .description-url-small {
   margin-top: 0.25rem;
   font-size: 0.875rem;
-  color: var(--gray-800);
+  color: var(--gray-700);
 }
 
 .box-agree {

--- a/frontend/src/pages/Login/Login.module.css
+++ b/frontend/src/pages/Login/Login.module.css
@@ -1,7 +1,7 @@
 .find-password {
   text-decoration: none;
   font-size: 0.875rem;
-  color: #2c3e50;
+  color: var(--cyan);
   margin-left: auto;
 }
 

--- a/frontend/src/pages/MyApplication/MyApplication.module.css
+++ b/frontend/src/pages/MyApplication/MyApplication.module.css
@@ -25,12 +25,12 @@
 .recruitment-mission-contour {
   margin: 1.625rem 0;
   border: none;
-  border-top: 1.5px solid var(--gray-002);
+  border-top: 1.5px solid var(--gray-200);
 }
 
 .application-category {
   margin-bottom: 1rem;
-  color: var(--gray-004);
+  color: var(--gray-400);
   font-size: 1.25rem;
   font-weight: bold;
 }

--- a/frontend/src/pages/MyPage/MyPage.module.css
+++ b/frontend/src/pages/MyPage/MyPage.module.css
@@ -22,14 +22,14 @@
 
 .info-title {
   flex: 1;
-  color: var(--gray-007);
+  color: var(--gray-700);
   text-align: right;
   padding: 0.5rem 0;
 }
 
 .info-data {
   flex: 5;
-  border-bottom: 1px solid var(--gray-006);
+  border-bottom: 1px solid var(--gray-600);
   padding: 0.5rem;
 }
 

--- a/frontend/src/pages/MyPage/MyPage.module.css
+++ b/frontend/src/pages/MyPage/MyPage.module.css
@@ -22,14 +22,14 @@
 
 .info-title {
   flex: 1;
-  color: var(--gray-700);
+  color: var(--gray-600);
   text-align: right;
   padding: 0.5rem 0;
 }
 
 .info-data {
   flex: 5;
-  border-bottom: 1px solid var(--gray-600);
+  border-bottom: 1px solid var(--gray-500);
   padding: 0.5rem;
 }
 

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -30,7 +30,7 @@
 }
 
 .active a {
-  color: var(--black-400);
+  color: var(--gray-900);
   font-weight: bold;
 }
 
@@ -60,7 +60,7 @@
   padding: 2rem 0;
 
   font-weight: 700;
-  color: var(--gray-600);
+  color: var(--gray-500);
 }
 
 .program-tab-list {

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -60,7 +60,7 @@
   padding: 2rem 0;
 
   font-weight: 700;
-  color: var(--gray-500);
+  color: var(--gray-600);
 }
 
 .program-tab-list {

--- a/frontend/src/pages/Recruits/Recruits.module.css
+++ b/frontend/src/pages/Recruits/Recruits.module.css
@@ -30,7 +30,7 @@
 }
 
 .active a {
-  color: var(--black-004);
+  color: var(--black-400);
   font-weight: bold;
 }
 
@@ -60,7 +60,7 @@
   padding: 2rem 0;
 
   font-weight: 700;
-  color: var(--gray-005);
+  color: var(--gray-500);
 }
 
 .program-tab-list {


### PR DESCRIPTION
Resolves #643
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 사용하는 색상 팔레트 정리
- CSS 네이밍 규칙 정리
- CSS 네이밍 적용
- 과제 제출, 내 지원 현황 제외하고 모든 영역에 수정 사항 반영

# 어떻게 해결했나요?

## CSS 네이밍 규칙 정리

- 리터럴 색상 이름과 숫자 눈금을 조합한다.
  - 리터럴 색상 이름은 [tailwind의 기본 팔레트](https://tailwindcss.com/docs/customizing-colors#default-color-palette) 색상 이름을 참고한다.
  - 숫자는 100 단위로 하며, 필요에 의해 50 단위로 추가한다.
  - 밝은 색상부터 어두운 색상 순으로 50 ~ 900으로 네이밍한다.
  - 예) `red-50`, `orange-900`
- 만약 비슷한 계통의 색상이 없다면 숫자 눈금을 생략할 수 있다.
  - 새로운 색상이 추가되어, 비슷한 계통의 색깔이 두개 이상이 되면 숫자 눈금을 추가한다. 이 때 팔레트 생성기를 참고하여 적절한 숫자를 정한다.
  - 팔레트 생성기: [palettte](https://palettte.app/), [Color Box](https://colorbox.io/) 등
- 추상적인 이름은 사용하지 않는다.
  - 추상적인 이름은 `primary`, `secondary`, `danger` 등을 의미한다.
  - 추후 우아한테크코스에 컬러 스킴이 생기면 변경될 수 있다.
  - 추상적인 이름을 추가하는 경우 해당 색상에 해당하는 css variable을 추상적인 이름을 가진 css variable에 재할당한다.
  - 예) `--danger: var(--red)`

## 사용하는 색상 팔레트 정리

<img src="https://user-images.githubusercontent.com/44823900/201584175-7fe398f4-3f74-49ac-80a2-7ed743b9b743.png" alt="color palette" width="400px">

### before
```css
--gray-001: #fafafa;
--gray-002: #eee;
--gray-003: #ddd;
--gray-004: #ccc;
--gray-005: #bbb;
--gray-006: #aaa;
--gray-007: #999;
--gray-008: #666;
--gray-009: #555;
--black-001: #000;
--black-004: #333;
--white: #fff;
--light-blue-gray: #f5f5f5;
--light-blue-green: #d5eaf1;
--blue: #279cf6;
--blue-gray: #5f7997;
--red: #ff0000;
--green: #0eaf7a;
--dim: rgba(0, 0, 0, 0.4);
```

### after
```css
--gray-100: #fafafa;
--gray-150: #f5f5f5;
--gray-200: #eee;
--gray-300: #ddd;
--gray-400: #ccc;
--gray-500: #aaa;
--gray-600: #999;
--gray-700: #666;
--gray-800: #555;
--gray-900: #333;
--black: #000;
--white: #fff;
--blue-gray-100: #d5eaf1;
--blue-gray-500: #5f7997;
--blue: #279cf6;
--red: #ff0000;
--green: #0eaf7a;
--cyan: #2c3e50;
--tint: rgba(0, 0, 0, 0.4);
```

# 어떤 부분에 집중하여 리뷰해야 할까요?

- CSS 네이밍 규칙이 적절한지

## 참고 자료

### 네이밍 방식 1. Abstract ([material ui](https://material.io/design/color/the-color-system.html))

> Material Design 컬러 시스템은 의미 있는 방식으로 UI에 색상을 적용하는 데 도움이 됩니다. 이 시스템에서는 브랜드를 나타내는 기본 색상과 보조 색상을 선택합니다. 그런 다음 각 색상의 어둡고 밝은 변형을 다양한 방식으로 UI에 적용할 수 있습니다.
> 
- `primary` `secondary` `tertiary`
- `background` `surface`
- `error`
- `transparent`
- `current`

### 네이밍 방식 2. 색 기반 ([tailwind css](https://tailwindcss.com/docs/customizing-colors#default-color-palette))

> Tailwind는 기본적으로 리터럴 색상 이름(빨간색, 녹색 등)과 숫자 눈금(50은 밝음, 900은 어두움)을 사용합니다. 이것이 대부분의 프로젝트에 가장 적합한 선택이라고 생각하며 `primary` 또는 `danger`과 같은 추상적인 이름을 사용하는 것보다 유지 관리가 더 쉽다는 것을 알게 되었습니다. 우리는 대부분의 프로젝트에서 기본 네이밍 컨벤션을 고수하고 정말 좋은 이유가 있는 경우에만 추상적인 이름을 사용하는 것을 추천합니다.
> 
- `white` `black`
- `red` `green` `yellow`
    1. 기존: `red-001` `red-002`
    5. tailwind css 스타일: `red-100` `red-200`
- `transparent`
- `current`
- …

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
