### PR TITLE
fix(apply): make grid layout fill full height

### DIFF
--- a/src/main/kotlin/apply/application/EvaluationTargetService.kt
+++ b/src/main/kotlin/apply/application/EvaluationTargetService.kt
@@ -27,23 +27,20 @@ class EvaluationTargetService(
     private val memberRepository: MemberRepository,
     private val cheaterRepository: CheaterRepository,
 ) {
-    fun findAllByEvaluationId(evaluationId: Long): List<EvaluationTarget> =
-        evaluationTargetRepository.findAllByEvaluationId(evaluationId)
-
     fun findAllByEvaluationIdAndKeyword(
         evaluationId: Long,
         keyword: String = "",
     ): List<EvaluationTargetResponse> {
-        val evaluationTargets = findAllByEvaluationId(evaluationId)
-        val membersById = memberRepository
-            .findAllByIdInAndKeyword(evaluationTargets.map(EvaluationTarget::memberId), keyword)
-            .associateBy { it.id }
-        return evaluationTargets
+        val targetsByMemberId = evaluationTargetRepository
+            .findAllByEvaluationId(evaluationId)
+            .associateBy { it.memberId }
+        return memberRepository
+            .findAllByIdInAndKeyword(targetsByMemberId.keys, keyword)
             .map {
-                val member = requireNotNull(membersById[it.memberId])
-                when (member.status) {
-                    MemberStatus.ACTIVE -> EvaluationTargetResponse(it, member)
-                    else -> EvaluationTargetResponse(it, member.id)
+                val evaluationTarget = targetsByMemberId.getValue(it.id)
+                when (it.status) {
+                    MemberStatus.ACTIVE -> EvaluationTargetResponse(evaluationTarget, it)
+                    else -> EvaluationTargetResponse(evaluationTarget, it.id)
                 }
             }
     }

--- a/src/main/kotlin/apply/ui/admin/administrator/AdministratorsView.kt
+++ b/src/main/kotlin/apply/ui/admin/administrator/AdministratorsView.kt
@@ -16,6 +16,7 @@ import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.createDeleteButtonWithDialog
 import support.views.createPrimaryButton
@@ -23,19 +24,17 @@ import support.views.createPrimarySmallButton
 import support.views.toDisplayName
 
 @Route(value = "admin/administrators", layout = BaseLayout::class)
-class AdministratorsView(private val administratorService: AdministratorService) : VerticalLayout() {
+class AdministratorsView(
+    private val administratorService: AdministratorService,
+) : VerticalLayout() {
     init {
-        add(createTitle(), createButton(), createGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("관리자")).apply {
-            setSizeFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title(H1("관리자"))
 
-    private fun createButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("생성") {
                 AdministratorFormDialog(administratorService, NEW_VALUE.toDisplayName()) {
@@ -43,7 +42,7 @@ class AdministratorsView(private val administratorService: AdministratorService)
                 }
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }

--- a/src/main/kotlin/apply/ui/admin/cheater/CheatersView.kt
+++ b/src/main/kotlin/apply/ui/admin/cheater/CheatersView.kt
@@ -7,7 +7,6 @@ import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
@@ -15,6 +14,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer
 import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
 import support.views.NO_NAME
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.addSortableDateTimeColumn
 import support.views.createDeleteButtonWithDialog
@@ -23,20 +23,16 @@ import support.views.createPrimaryButton
 @Route(value = "admin/cheaters", layout = BaseLayout::class)
 class CheatersView(
     private val memberService: MemberService,
-    private val cheaterService: CheaterService
+    private val cheaterService: CheaterService,
 ) : VerticalLayout() {
     init {
-        add(createTitle(), createAddCheater(), createCheaterGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("부정행위자")).apply {
-            setSizeFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title("부정행위자")
 
-    private fun createAddCheater(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("추가") {
                 CheaterFormDialog(memberService, cheaterService) {
@@ -44,12 +40,12 @@ class CheatersView(
                 }
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }
 
-    private fun createCheaterGrid(): Grid<CheaterResponse> {
+    private fun createGrid(): Grid<CheaterResponse> {
         return Grid<CheaterResponse>(10).apply {
             addSortableColumn("이름") { it.name ?: NO_NAME }
             addSortableColumn("이메일") { it.email }

--- a/src/main/kotlin/apply/ui/admin/cheater/CheatersView.kt
+++ b/src/main/kotlin/apply/ui/admin/cheater/CheatersView.kt
@@ -45,7 +45,7 @@ class CheatersView(
         }
     }
 
-    private fun createGrid(): Grid<CheaterResponse> {
+    private fun createGrid(): Component {
         return Grid<CheaterResponse>(10).apply {
             addSortableColumn("이름") { it.name ?: NO_NAME }
             addSortableColumn("이메일") { it.email }

--- a/src/main/kotlin/apply/ui/admin/evaluation/EvaluationsView.kt
+++ b/src/main/kotlin/apply/ui/admin/evaluation/EvaluationsView.kt
@@ -6,7 +6,6 @@ import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
@@ -15,31 +14,30 @@ import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.createDeleteButtonWithDialog
 import support.views.createPrimaryButton
 import support.views.createPrimarySmallButton
 
 @Route(value = "admin/evaluations", layout = BaseLayout::class)
-class EvaluationsView(private val evaluationService: EvaluationService) : VerticalLayout() {
+class EvaluationsView(
+    private val evaluationService: EvaluationService,
+) : VerticalLayout() {
     init {
-        add(createTitle(), createButton(), createGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("평가 관리")).apply {
-            setSizeFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title("평가 관리")
 
-    private fun createButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("생성") {
                 UI.getCurrent().navigate(EvaluationsFormView::class.java, NEW_VALUE)
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }

--- a/src/main/kotlin/apply/ui/admin/invitation/InvitationsView.kt
+++ b/src/main/kotlin/apply/ui/admin/invitation/InvitationsView.kt
@@ -6,13 +6,13 @@ import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.data.renderer.ComponentRenderer
 import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.addSortableDateTimeColumn
 import support.views.createErrorSmallButton
@@ -26,17 +26,12 @@ class InvitationsView(
 ) : VerticalLayout() {
     init {
         setSizeFull()
-        add(createTitle(), createAcceptAllButton(), createGrid())
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("초대 관리")).apply {
-            setWidthFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title("초대 관리")
 
-    private fun createAcceptAllButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("조건부 수락") {
                 InviteAcceptanceDialog(invitationService).open()

--- a/src/main/kotlin/apply/ui/admin/mail/MailsView.kt
+++ b/src/main/kotlin/apply/ui/admin/mail/MailsView.kt
@@ -6,7 +6,6 @@ import apply.ui.admin.BaseLayout
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
@@ -15,6 +14,7 @@ import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.addSortableDateTimeColumn
 import support.views.createPrimaryButton
@@ -22,26 +22,22 @@ import support.views.createPrimarySmallButton
 
 @Route(value = "admin/mails", layout = BaseLayout::class)
 class MailsView(
-    private val mailHistoryService: MailHistoryService
+    private val mailHistoryService: MailHistoryService,
 ) : VerticalLayout() {
     init {
-        add(createTitle(), createButton(), createGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("메일 관리")).apply {
-            setSizeFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title("메일 관리")
 
-    private fun createButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("메일 보내기") {
                 UI.getCurrent().navigate(MailsFormView::class.java, NEW_VALUE)
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }

--- a/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
+++ b/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
@@ -35,20 +35,19 @@ class MissionsView(
 
     override fun setParameter(event: BeforeEvent, @WildcardParameter parameter: Long) {
         recruitmentId = parameter
-        add(createTitle(), createButton(), createGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return Title("${recruitmentService.getById(recruitmentId).title} 과제 관리")
-    }
+    private fun createTitle(): Component = Title("${recruitmentService.getById(recruitmentId).title} 과제 관리")
 
-    private fun createButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("생성") {
                 UI.getCurrent().navigate(MissionsFormView::class.java, "$recruitmentId/$NEW_VALUE")
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }

--- a/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentsView.kt
+++ b/src/main/kotlin/apply/ui/admin/recruitment/RecruitmentsView.kt
@@ -8,7 +8,6 @@ import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
@@ -17,6 +16,7 @@ import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.addSortableDateTimeColumn
 import support.views.createDeleteButtonWithDialog
@@ -24,25 +24,23 @@ import support.views.createPrimaryButton
 import support.views.createPrimarySmallButton
 
 @Route(value = "admin/recruitments", layout = BaseLayout::class)
-class RecruitmentsView(private val recruitmentService: RecruitmentService) : VerticalLayout() {
+class RecruitmentsView(
+    private val recruitmentService: RecruitmentService,
+) : VerticalLayout() {
     init {
-        add(createTitle(), createButton(), createGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("모집 관리")).apply {
-            setSizeFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title("모집 관리")
 
-    private fun createButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("생성") {
                 UI.getCurrent().navigate(RecruitmentsFormView::class.java, NEW_VALUE)
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }
@@ -93,10 +91,6 @@ class RecruitmentsView(private val recruitmentService: RecruitmentService) : Ver
     }
 
     private fun Boolean.toText(): String {
-        return if (this) {
-            "비공개"
-        } else {
-            "공개"
-        }
+        return if (this) "비공개" else "공개"
     }
 }

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.dialog.Dialog
 import com.vaadin.flow.component.grid.Grid
 import com.vaadin.flow.component.html.Div
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.html.H4
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
@@ -39,6 +38,7 @@ import com.vaadin.flow.router.BeforeEvent
 import com.vaadin.flow.router.HasUrlParameter
 import com.vaadin.flow.router.Route
 import com.vaadin.flow.router.WildcardParameter
+import support.views.Title
 import support.views.WITHDRAWN_NAME
 import support.views.addSortableColumn
 import support.views.addSortableDateColumn
@@ -65,7 +65,7 @@ class SelectionView(
     private val judgmentAllService: JudgmentAllService,
     private val myMissionService: MyMissionService,
     private val excelService: ExcelService,
-    private val evaluationTargetCsvService: EvaluationTargetCsvService
+    private val evaluationTargetCsvService: EvaluationTargetCsvService,
 ) : VerticalLayout(), HasUrlParameter<Long> {
     private var recruitmentId: Long = 0L
     private var evaluations: List<EvaluationSelectData> =
@@ -76,25 +76,21 @@ class SelectionView(
 
     override fun setParameter(event: BeforeEvent, @WildcardParameter parameter: Long) {
         this.recruitmentId = parameter
+        setSizeFull()
         add(createTitle(), createContent())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1(recruitmentService.getById(recruitmentId).title)).apply {
-            setWidthFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title(recruitmentService.getById(recruitmentId).title)
 
     private fun createContent(keyword: String = ""): Component {
         val tabsToGrids: Map<Tab, Component> = mapTabAndGrid(keyword)
         val (tabs, grids) = createTabComponents(tabsToGrids)
-        val menu = HorizontalLayout(
+        val toolbar = HorizontalLayout(
             createSearchBox {
                 removeAll()
                 add(
                     createTitle(),
-                    createContent(keyword = it)
+                    createContent(keyword = it),
                 )
                 selectedTabIndex = tabs.selectedIndex
             },
@@ -102,13 +98,16 @@ class SelectionView(
             HorizontalLayout(
                 createLoadButton(tabs),
                 createResultDownloadButton(),
-                createJudgeAllButton(tabs)
-            )
+                createJudgeAllButton(tabs),
+            ),
         ).apply {
             setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.BETWEEN
         }
-        return VerticalLayout(menu, grids, evaluationFileButtons).apply { setWidthFull() }
+        return VerticalLayout(toolbar, *grids.toTypedArray(), evaluationFileButtons).apply {
+            setSizeFull()
+            isPadding = false
+        }
     }
 
     private fun createEvaluationFileButtons(): HorizontalLayout {
@@ -192,23 +191,20 @@ class SelectionView(
         }
     }
 
-    private fun createTabComponents(tabsToGrids: Map<Tab, Component>): Pair<Tabs, Div> {
+    private fun createTabComponents(tabsToGrids: Map<Tab, Component>): Pair<Tabs, Collection<Component>> {
         val tabs = Tabs().apply {
             add(*(tabsToGrids.keys).toTypedArray())
             addSelectedChangeListener {
                 evaluationFileButtons.isVisible = !isTotalApplicantTab(it.selectedTab)
-                tabsToGrids.forEach { (tab, grid) ->
-                    grid.isVisible = (tab == selectedTab)
-                }
+                tabsToGrids.forEach { (tab, grid) -> grid.isVisible = (tab == selectedTab) }
             }
             setWidthFull()
             tabsToGrids.forEach { (tab, grid) -> grid.isVisible = (tab == selectedTab) }
             selectedIndex = selectedTabIndex
             tabs = this
         }
-
-        val grids = Div(*tabsToGrids.values.toTypedArray()).apply { setWidthFull() }
-
+        val grids = tabsToGrids.values
+        // val grids = Div(*tabsToGrids.values.toTypedArray()).apply { setSizeFull() }
         return tabs to grids
     }
 

--- a/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
+++ b/src/main/kotlin/apply/ui/admin/selections/SelectionView.kt
@@ -203,9 +203,7 @@ class SelectionView(
             selectedIndex = selectedTabIndex
             tabs = this
         }
-        val grids = tabsToGrids.values
-        // val grids = Div(*tabsToGrids.values.toTypedArray()).apply { setSizeFull() }
-        return tabs to grids
+        return tabs to tabsToGrids.values
     }
 
     private fun createLoadButton(tabs: Tabs): Button {

--- a/src/main/kotlin/apply/ui/admin/term/TermsView.kt
+++ b/src/main/kotlin/apply/ui/admin/term/TermsView.kt
@@ -8,7 +8,6 @@ import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.H1
 import com.vaadin.flow.component.orderedlayout.FlexComponent
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
@@ -17,6 +16,7 @@ import com.vaadin.flow.data.renderer.Renderer
 import com.vaadin.flow.router.Route
 import support.views.EDIT_VALUE
 import support.views.NEW_VALUE
+import support.views.Title
 import support.views.addSortableColumn
 import support.views.createDeleteButtonWithDialog
 import support.views.createPrimaryButton
@@ -24,19 +24,17 @@ import support.views.createPrimarySmallButton
 import support.views.toDisplayName
 
 @Route(value = "admin/terms", layout = BaseLayout::class)
-class TermsView(private val termService: TermService) : VerticalLayout() {
+class TermsView(
+    private val termService: TermService,
+) : VerticalLayout() {
     init {
-        add(createTitle(), createButton(), createGrid())
+        setSizeFull()
+        add(createTitle(), createToolbar(), createGrid())
     }
 
-    private fun createTitle(): Component {
-        return HorizontalLayout(H1("기수 관리")).apply {
-            setSizeFull()
-            justifyContentMode = FlexComponent.JustifyContentMode.CENTER
-        }
-    }
+    private fun createTitle(): Component = Title("기수 관리")
 
-    private fun createButton(): Component {
+    private fun createToolbar(): Component {
         return HorizontalLayout(
             createPrimaryButton("생성") {
                 TermFormDialog(termService, NEW_VALUE.toDisplayName()) {
@@ -44,7 +42,7 @@ class TermsView(private val termService: TermService) : VerticalLayout() {
                 }
             }
         ).apply {
-            setSizeFull()
+            setWidthFull()
             justifyContentMode = FlexComponent.JustifyContentMode.END
         }
     }

--- a/src/main/kotlin/support/views/Components.kt
+++ b/src/main/kotlin/support/views/Components.kt
@@ -125,7 +125,7 @@ fun createTabs(components: List<Component>): Component {
 class Title(val value: H1) : HorizontalLayout(), HasText {
     init {
         add(value)
-        setSizeFull()
+        setWidthFull()
         justifyContentMode = FlexComponent.JustifyContentMode.CENTER
     }
 

--- a/src/test/kotlin/apply/MemberFixtures.kt
+++ b/src/test/kotlin/apply/MemberFixtures.kt
@@ -43,6 +43,15 @@ fun createMember(
     )
 }
 
+fun createWithdrawnMember(
+    information: MemberInformation? = null,
+    password: Password = PASSWORD,
+    authorizationRequirement: AuthorizationRequirement = AuthorizationRequirement {},
+    id: Long = 0L,
+): Member {
+    return Member(information, password, authorizationRequirement, MemberStatus.WITHDRAWN, id)
+}
+
 fun createMemberInformation(
     email: String = EMAIL,
     name: String = NAME,

--- a/src/test/kotlin/apply/application/EvaluationTargetIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetIntegrationTest.kt
@@ -333,7 +333,7 @@ class EvaluationTargetIntegrationTest(
         When("해당 평가에서 특정 키워드로 평가 대상자를 조회하면") {
             val actual = evaluationTargetService.findAllByEvaluationIdAndKeyword(evaluation.id, keyword)
 
-            Then("키워드와 일치하는 평가 대상자만 반환한다") {
+            Then("키워드와 일치하는 탈퇴하지 않은 평가 대상자만 조회한다") {
                 actual shouldHaveSize 1
                 actual[0].email shouldContain keyword
             }

--- a/src/test/kotlin/apply/application/EvaluationTargetIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/EvaluationTargetIntegrationTest.kt
@@ -10,6 +10,7 @@ import apply.createEvaluationAnswer
 import apply.createEvaluationItem
 import apply.createEvaluationTarget
 import apply.createMember
+import apply.createWithdrawnMember
 import apply.domain.applicationform.ApplicationForm
 import apply.domain.applicationform.ApplicationFormRepository
 import apply.domain.cheater.Cheater
@@ -32,7 +33,10 @@ import apply.domain.member.MemberRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.springframework.transaction.annotation.Transactional
 import support.test.IntegrationTest
 import java.time.LocalDateTime
@@ -47,7 +51,7 @@ class EvaluationTargetIntegrationTest(
     private val evaluationItemRepository: EvaluationItemRepository,
     private val applicationFormRepository: ApplicationFormRepository,
     private val memberRepository: MemberRepository,
-    private val cheaterRepository: CheaterRepository
+    private val cheaterRepository: CheaterRepository,
 ) : BehaviorSpec({
     extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
 
@@ -63,7 +67,7 @@ class EvaluationTargetIntegrationTest(
         memberId: Long,
         recruitmentId: Long,
         submitted: Boolean,
-        submittedDateTime: LocalDateTime
+        submittedDateTime: LocalDateTime,
     ): ApplicationForm {
         return applicationFormRepository.save(
             createApplicationForm(memberId, recruitmentId, submitted = submitted, submittedDateTime = submittedDateTime)
@@ -74,7 +78,7 @@ class EvaluationTargetIntegrationTest(
         recruitmentId: Long = 1L,
         beforeEvaluationId: Long = 0L,
         title: String = EVALUATION_TITLE1,
-        description: String = EVALUATION_DESCRIPTION
+        description: String = EVALUATION_DESCRIPTION,
     ): Evaluation {
         return evaluationRepository.save(createEvaluation(title, description, recruitmentId, beforeEvaluationId))
     }
@@ -88,7 +92,7 @@ class EvaluationTargetIntegrationTest(
         memberId: Long,
         evaluationStatus: EvaluationStatus,
         note: String = EVALUATION_TARGET_NOTE,
-        evaluationAnswers: List<EvaluationAnswer> = emptyList()
+        evaluationAnswers: List<EvaluationAnswer> = emptyList(),
     ): EvaluationTarget {
         return evaluationTargetRepository.save(
             createEvaluationTarget(evaluationId, memberId, evaluationStatus, note, EvaluationAnswers(evaluationAnswers))
@@ -110,6 +114,12 @@ class EvaluationTargetIntegrationTest(
     fun saveCheaterApplicant(recruitmentId: Long, email: String): Member {
         val member = saveApplicant(recruitmentId, email)
         saveCheater(member.email)
+        return member
+    }
+
+    fun saveWithdrawnApplicant(recruitmentId: Long): Member {
+        val member = memberRepository.save(createWithdrawnMember())
+        saveApplicationForm(member.id, recruitmentId, true, now())
         return member
     }
 
@@ -289,6 +299,43 @@ class EvaluationTargetIntegrationTest(
                 actual.evaluationStatus shouldBe PASS
                 actual.evaluationAnswers.first(1L).score shouldBe 5
                 actual.note shouldBe "특이 사항(수정)"
+            }
+        }
+    }
+
+    Given("특정 평가의 평가 대상자가 탈퇴한 회원인 경우") {
+        val recruitmentId = 1L
+        val member = saveWithdrawnApplicant(recruitmentId)
+        val evaluation = saveEvaluation(recruitmentId)
+        saveEvaluationTarget(evaluation.id, member.id, PASS)
+
+        When("해당 평가에서 키워드 없이 평가 대상자를 조회하면") {
+            val actual = evaluationTargetService.findAllByEvaluationIdAndKeyword(evaluation.id)
+
+            Then("평가 대상자는 조회되지만 회원 정보는 확인할 수 없다") {
+                actual shouldHaveSize 1
+                actual[0].name.shouldBeNull()
+                actual[0].email.shouldBeNull()
+                actual[0].evaluationStatus shouldBe PASS
+            }
+        }
+    }
+
+    Given("특정 평가의 평가 대상자에 회원과 탈퇴한 회원이 혼재한 경우") {
+        val recruitmentId = 1L
+        val keyword = "chaechae"
+        val member1 = saveApplicant(recruitmentId, "$keyword@email.com")
+        val member2 = saveWithdrawnApplicant(recruitmentId)
+        val evaluation = saveEvaluation(recruitmentId)
+        saveEvaluationTarget(evaluation.id, member1.id, PASS)
+        saveEvaluationTarget(evaluation.id, member2.id, PASS)
+
+        When("해당 평가에서 특정 키워드로 평가 대상자를 조회하면") {
+            val actual = evaluationTargetService.findAllByEvaluationIdAndKeyword(evaluation.id, keyword)
+
+            Then("키워드와 일치하는 평가 대상자만 반환한다") {
+                actual shouldHaveSize 1
+                actual[0].email shouldContain keyword
             }
         }
     }

--- a/src/test/kotlin/apply/ui/api/EvaluationTargetRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/EvaluationTargetRestControllerTest.kt
@@ -133,7 +133,7 @@ class EvaluationTargetRestControllerTest : RestControllerTest() {
     }
 
     @Test
-    fun `평가지를 기준으로 평가대상자들의 상태를 업데이트한다`() {
+    fun `평가지를 기준으로 평가 대상자들의 상태를 업데이트한다`() {
         val contentStream = Path("src/test/resources/another_evaluation.csv").inputStream()
         val file = MockMultipartFile("evaluation", "evaluation.csv", "text/csv", contentStream)
 


### PR DESCRIPTION
Resolves #618 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 관리 화면의 그리드 높이가 화면 전체를 차지하지 않아 사용성이 떨어졌습니다.

# 어떻게 해결했나요?

- 각 페이지에 `setSizeFull()`을 추가하고, `Title`과 `createToolbar()`를 사용하여 레이아웃을 일관되게 하였습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 모니터 해상도나 화면 크기에 따라 관리 화면의 레이아웃이 깨지거나 사용성이 저하되지 않는지 확인해 주세요.

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
