### PR TITLE
feat(application): change the first temporary save to require a save button

### DIFF
--- a/frontend/src/constants/errorCodes.ts
+++ b/frontend/src/constants/errorCodes.ts
@@ -1,0 +1,6 @@
+export const ERROR_CODE = {
+  LOAD_APPLICATION_FORM: {
+    NOT_FOUND: 404,
+    ALREADY_APPLIED: 400,
+  },
+} as const;

--- a/frontend/src/hooks/useApplicationRegisterForm.js
+++ b/frontend/src/hooks/useApplicationRegisterForm.js
@@ -1,14 +1,12 @@
 import { useEffect, useState } from "react";
-import { generatePath, useNavigate, useLocation } from "react-router";
+import { useNavigate } from "react-router";
 import * as Api from "../api";
 import { FORM } from "../constants/form";
 import { ERROR_MESSAGE } from "../constants/messages";
 import { PATH, PARAM } from "../constants/path";
 import { formatDateTime } from "../utils/format/date";
-import { generateQuery } from "../utils/route/query";
 import { isValidURL } from "../utils/validation/url";
 import useTokenContext from "./useTokenContext";
-import { ERROR_CODE } from "../constants/errorCodes";
 
 export const APPLICATION_REGISTER_FORM_NAME = {
   ANSWERS: "answers",
@@ -43,7 +41,6 @@ const useApplicationRegisterForm = ({
 
   const [modifiedDateTime, setModifiedDateTime] = useState("");
   const navigate = useNavigate();
-  const location = useLocation();
   const { token } = useTokenContext();
 
   const isAnswersEmpty =
@@ -105,14 +102,10 @@ const useApplicationRegisterForm = ({
         data: { answers, referenceUrl, modifiedDateTime },
       } = application;
 
-      setRequiredForm({ answers: answers?.map((answer) => answer.contents) });
+      setRequiredForm({ answers: answers.map((answer) => answer.contents) });
       setForm({ referenceUrl });
       setModifiedDateTime(formatDateTime(new Date(modifiedDateTime)));
     } catch (error) {
-      if (error?.response?.status === ERROR_CODE.LOAD_APPLICATION_FORM.NOT_FOUND) {
-        return;
-      }
-
       handleLoadFormError();
     }
   };

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -2,7 +2,6 @@ import { useState, useMemo } from "react";
 import useRecruitmentContext from "./useRecruitmentContext";
 import { RECRUITS_TAB, PROGRAM_TAB } from "../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
-import { RECRUITMENT_STATUS } from "../constants/recruitment";
 
 type ProgramTabStatus = typeof PROGRAM_TAB[keyof typeof PROGRAM_TAB];
 
@@ -32,11 +31,6 @@ const filterRecruitmentsByProgramLabel: (
 ) => Recruitment[] = (recruitments, programLabel) =>
   recruitments.filter((recruitmentItem) => matchProgram(recruitmentItem.title, programLabel));
 
-const isRecruitable = (recruitment: Recruitment) =>
-  recruitment?.recruitable &&
-  recruitment?.status !== RECRUITMENT_STATUS.ENDED &&
-  Date.now() <= new Date(recruitment.endDateTime).getTime();
-
 const useRecruitList: () => {
   programTabStatus: ProgramTabStatus;
   setProgramTabStatus: React.Dispatch<React.SetStateAction<ProgramTabStatus>>;
@@ -58,7 +52,7 @@ const useRecruitList: () => {
     return filterRecruitmentsByProgramLabel(sortedRecruitments, programTabStatus.label);
   }, [recruitment, programTabStatus]);
 
-  return { programTabStatus, setProgramTabStatus, filteredRecruitments, isRecruitable };
+  return { programTabStatus, setProgramTabStatus, filteredRecruitments };
 };
 
 export default useRecruitList;

--- a/frontend/src/hooks/useRecruitList.ts
+++ b/frontend/src/hooks/useRecruitList.ts
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import useRecruitmentContext from "./useRecruitmentContext";
 import { RECRUITS_TAB, PROGRAM_TAB } from "../constants/tab";
 import { Recruitment } from "../../types/domains/recruitments";
+import { RECRUITMENT_STATUS } from "../constants/recruitment";
 
 type ProgramTabStatus = typeof PROGRAM_TAB[keyof typeof PROGRAM_TAB];
 
@@ -31,6 +32,11 @@ const filterRecruitmentsByProgramLabel: (
 ) => Recruitment[] = (recruitments, programLabel) =>
   recruitments.filter((recruitmentItem) => matchProgram(recruitmentItem.title, programLabel));
 
+const isRecruitable = (recruitment: Recruitment) =>
+  recruitment?.recruitable &&
+  recruitment?.status !== RECRUITMENT_STATUS.ENDED &&
+  Date.now() <= new Date(recruitment.endDateTime).getTime();
+
 const useRecruitList: () => {
   programTabStatus: ProgramTabStatus;
   setProgramTabStatus: React.Dispatch<React.SetStateAction<ProgramTabStatus>>;
@@ -52,7 +58,7 @@ const useRecruitList: () => {
     return filterRecruitmentsByProgramLabel(sortedRecruitments, programTabStatus.label);
   }, [recruitment, programTabStatus]);
 
-  return { programTabStatus, setProgramTabStatus, filteredRecruitments };
+  return { programTabStatus, setProgramTabStatus, filteredRecruitments, isRecruitable };
 };
 
 export default useRecruitList;

--- a/frontend/src/hooks/useRecruitmentItem.js
+++ b/frontend/src/hooks/useRecruitmentItem.js
@@ -13,7 +13,7 @@ const useRecruitmentItem = (recruitmentId) => {
 
       setRecruitmentItems(data);
     } catch (error) {
-      alert("지원서를 불러오는데 실패했습니다.");
+      alert("지원서를 불러오는 데 실패했습니다.");
       navigate(PATH.HOME, { replace: true });
     }
   };

--- a/frontend/src/mock/dummy.ts
+++ b/frontend/src/mock/dummy.ts
@@ -48,11 +48,11 @@ export const recruitmentDummy = [
   },
   {
     id: 5,
-    title: "우아한테크캠프 Pro 5기",
+    title: "우아한테크캠프 Pro 6기",
     recruitable: true,
     hidden: false,
     startDateTime: "2020-10-25T15:00:00" as ISO8601DateString,
-    endDateTime: "2021-11-30T10:00:00" as ISO8601DateString,
+    endDateTime: "2025-11-30T10:00:00" as ISO8601DateString,
     status: RECRUITMENT_STATUS.RECRUITING,
   },
 ];

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -77,6 +77,10 @@ const ApplicationRegister = () => {
 
   const save = async ({ referenceUrl, answers }) => {
     try {
+      if (status === PARAM.APPLICATION_FORM_STATUS.NEW) {
+        await Api.createForm({ token, recruitmentId });
+      }
+
       await Api.updateForm({
         token,
         data: {
@@ -97,6 +101,10 @@ const ApplicationRegister = () => {
 
   const tempSave = async ({ referenceUrl, answers }) => {
     try {
+      if (status === PARAM.APPLICATION_FORM_STATUS.NEW) {
+        await Api.createForm({ token, recruitmentId });
+      }
+
       await Api.updateForm({
         token,
         data: {

--- a/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
+++ b/frontend/src/pages/AssignmentSubmit/AssignmentSubmit.js
@@ -53,7 +53,7 @@ const AssignmentSubmit = () => {
         await postAssignment(payload);
       }
 
-      if (status === PARAM.APPLICATION_FORM_STATUS.EDIT) {
+      if (status === PARAM.ASSIGNMENT_STATUS.EDIT) {
         await patchAssignment(payload);
       }
 

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -5,40 +5,69 @@ import TabItem from "../../components/@common/TabItem/TabItem";
 import RecruitmentItem from "../../components/RecruitmentItem/RecruitmentItem";
 import { generateQuery } from "../../utils/route/query";
 import { PATH, PARAM } from "../../constants/path";
+import { ERROR_MESSAGE } from "../../constants/messages";
+import { ERROR_CODE } from "../../constants/errorCodes";
 import { PROGRAM_TAB, PROGRAM_TAB_LIST } from "../../constants/tab";
 import styles from "./Recruits.module.css";
+import * as Api from "../../api";
 
 const Recruits = () => {
   const { token } = useTokenContext();
   const navigate = useNavigate();
 
-  const { programTabStatus, setProgramTabStatus, filteredRecruitments } = useRecruitList();
+  const { programTabStatus, setProgramTabStatus, filteredRecruitments, isRecruitable } =
+    useRecruitList();
 
-  const goToNewApplicationFormPage = (recruitment) => {
-    if (!token) {
-      navigate(
-        { pathname: PATH.LOGIN },
-        {
-          state: {
-            currentRecruitment: recruitment,
-          },
-        }
-      );
-      return;
+  const goToNewApplicationFormPage = async (recruitment) => {
+    try {
+      if (!isRecruitable(recruitment)) {
+        alert("지원 불가능한 모집입니다.");
+        return;
+      }
+      const { data } = await Api.fetchForm({ token, recruitmentId: recruitment.id });
+
+      navigateToApplication({
+        recruitment,
+        status: PARAM.APPLICATION_FORM_STATUS.EDIT,
+        state: { application: data },
+      });
+    } catch (error) {
+      handleFetchingError({ error, recruitment });
     }
+  };
+
+  const navigateToApplication = ({ recruitment, status, state }) => {
     navigate(
       {
         pathname: generatePath(PATH.APPLICATION_FORM, {
-          status: PARAM.APPLICATION_FORM_STATUS.NEW,
+          status,
         }),
         search: generateQuery({ recruitmentId: recruitment.id }),
       },
-      {
-        state: {
-          currentRecruitment: recruitment,
-        },
-      }
+      { state: { currentRecruitment: recruitment, ...state } }
     );
+  };
+
+  const handleFetchingError = ({ error, recruitment }) => {
+    const {
+      response: {
+        status,
+        data: { message = null },
+      },
+    } = error;
+
+    if (status === ERROR_CODE.LOAD_APPLICATION_FORM.NOT_FOUND) {
+      navigateToApplication({ recruitment, status: PARAM.APPLICATION_FORM_STATUS.NEW });
+      return;
+    }
+
+    if (status === ERROR_CODE.LOAD_APPLICATION_FORM.ALREADY_APPLIED && message) {
+      alert(message);
+      return;
+    }
+
+    alert(ERROR_MESSAGE.API.LOAD_APPLICATION_FORM);
+    navigate(PATH.HOME, { replace: true });
   };
 
   return (

--- a/frontend/src/pages/Recruits/Recruits.js
+++ b/frontend/src/pages/Recruits/Recruits.js
@@ -15,15 +15,10 @@ const Recruits = () => {
   const { token } = useTokenContext();
   const navigate = useNavigate();
 
-  const { programTabStatus, setProgramTabStatus, filteredRecruitments, isRecruitable } =
-    useRecruitList();
+  const { programTabStatus, setProgramTabStatus, filteredRecruitments } = useRecruitList();
 
-  const goToNewApplicationFormPage = async (recruitment) => {
+  const goToApplicationFormPage = async (recruitment) => {
     try {
-      if (!isRecruitable(recruitment)) {
-        alert("지원 불가능한 모집입니다.");
-        return;
-      }
       const { data } = await Api.fetchForm({ token, recruitmentId: recruitment.id });
 
       navigateToApplication({
@@ -52,7 +47,7 @@ const Recruits = () => {
     const {
       response: {
         status,
-        data: { message = null },
+        data: { message },
       },
     } = error;
 
@@ -61,13 +56,12 @@ const Recruits = () => {
       return;
     }
 
-    if (status === ERROR_CODE.LOAD_APPLICATION_FORM.ALREADY_APPLIED && message) {
+    if (status === ERROR_CODE.LOAD_APPLICATION_FORM.ALREADY_APPLIED) {
       alert(message);
       return;
     }
 
     alert(ERROR_MESSAGE.API.LOAD_APPLICATION_FORM);
-    navigate(PATH.HOME, { replace: true });
   };
 
   return (
@@ -105,7 +99,7 @@ const Recruits = () => {
                 <RecruitmentItem
                   key={recruitment.id}
                   recruitment={recruitment}
-                  onClickButton={() => goToNewApplicationFormPage(recruitment)}
+                  onClickButton={() => goToApplicationFormPage(recruitment)}
                   role="listitem"
                 />
               ))

--- a/src/docs/asciidoc/application-form.adoc
+++ b/src/docs/asciidoc/application-form.adoc
@@ -16,13 +16,15 @@ operation::application-form-me-get[snippets='http-request,http-response']
 
 operation::application-form-get[snippets='http-request,http-response']
 
-=== 최종 지원서 조회
+=== 지원서 조회 실패
+
+==== 최종 지원서 조회
 
 이미 제출한 지원서를 조회하는 경우
 
 operation::application-form-get-bad-request[snippets='http-response']
 
-=== 존재하지 않는 지원서 조회
+==== 존재하지 않는 지원서 조회
 
 해당 모집에 대한 지원서가 존재하지 않는 경우
 

--- a/src/docs/asciidoc/application-form.adoc
+++ b/src/docs/asciidoc/application-form.adoc
@@ -15,3 +15,9 @@ operation::application-form-me-get[snippets='http-request,http-response']
 == 지원서 조회
 
 operation::application-form-get[snippets='http-request,http-response']
+
+=== 지원서 조회 실패
+
+해당 모집에 대한 지원서가 존재하지 않는 경우
+
+operation::application-form-get-not-found[snippets='http-response']

--- a/src/docs/asciidoc/application-form.adoc
+++ b/src/docs/asciidoc/application-form.adoc
@@ -16,7 +16,13 @@ operation::application-form-me-get[snippets='http-request,http-response']
 
 operation::application-form-get[snippets='http-request,http-response']
 
-=== 지원서 조회 실패
+=== 최종 지원서 조회
+
+이미 제출한 지원서를 조회하는 경우
+
+operation::application-form-get-bad-request[snippets='http-response']
+
+=== 존재하지 않는 지원서 조회
 
 해당 모집에 대한 지원서가 존재하지 않는 경우
 

--- a/src/main/kotlin/apply/application/ApplicationFormService.kt
+++ b/src/main/kotlin/apply/application/ApplicationFormService.kt
@@ -59,7 +59,7 @@ class ApplicationFormService(
 
     private fun findByRecruitmentIdAndUserId(recruitmentId: Long, userId: Long): ApplicationForm =
         applicationFormRepository.findByRecruitmentIdAndUserId(recruitmentId, userId)
-            ?: throw IllegalArgumentException("해당하는 지원서가 없습니다.")
+            ?: throw NoSuchElementException("해당하는 지원서가 없습니다.")
 
     private fun findApplicableRecruitment(recruitmentId: Long): Recruitment {
         val recruitment = recruitmentRepository.getOrThrow(recruitmentId)

--- a/src/main/kotlin/apply/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/apply/ui/api/ExceptionHandler.kt
@@ -71,8 +71,8 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
             .body(ApiResponse.error(exception.message))
     }
 
-    @ExceptionHandler(EntityNotFoundException::class)
-    fun handleNotFoundException(exception: EntityNotFoundException): ResponseEntity<ApiResponse<Unit>> {
+    @ExceptionHandler(NoSuchElementException::class, EntityNotFoundException::class)
+    fun handleNotFoundException(exception: RuntimeException): ResponseEntity<ApiResponse<Unit>> {
         logger.error("message", exception)
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(ApiResponse.error(exception.message))

--- a/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
+++ b/src/test/kotlin/apply/application/ApplicationFormServiceTest.kt
@@ -66,7 +66,7 @@ class ApplicationFormServiceTest : BehaviorSpec({
 
         When("특정 회원이 해당 모집에 대한 지원서를 수정하면") {
             Then("예외가 발생한다") {
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<NoSuchElementException> {
                     applicationFormService.update(userId, UpdateApplicationFormRequest(recruitment.id))
                 }
             }
@@ -169,7 +169,7 @@ class ApplicationFormServiceTest : BehaviorSpec({
 
         When("지원서를 조회하면") {
             Then("예외가 발생한다") {
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<NoSuchElementException> {
                     applicationFormService.getApplicationForm(1L, 1L)
                 }
             }

--- a/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
@@ -93,6 +93,22 @@ class ApplicationFormRestControllerTest : RestControllerTest() {
     }
 
     @Test
+    fun `최종 지원서를 조회하는 경우 400으로 응답한다`() {
+        every {
+            applicationFormService.getApplicationForm(any(), any())
+        } throws IllegalStateException("이미 제출한 지원서는 열람할 수 없습니다.")
+
+        mockMvc.get("/api/application-forms") {
+            bearer("valid_token")
+            param("recruitmentId", "1")
+        }.andExpect {
+            status { isBadRequest }
+        }.andDo {
+            handle(document("application-form-get-bad-request"))
+        }
+    }
+
+    @Test
     fun `특정 모집에 대한 특정 회원의 지원서가 없는 경우 404로 응답한다`() {
         every {
             applicationFormService.getApplicationForm(any(), any())

--- a/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
@@ -93,6 +93,22 @@ class ApplicationFormRestControllerTest : RestControllerTest() {
     }
 
     @Test
+    fun `특정 모집에 대한 특정 회원의 지원서가 없는 경우 404로 응답한다`() {
+        every {
+            applicationFormService.getApplicationForm(any(), any())
+        } throws NoSuchElementException("해당하는 지원서가 없습니다.")
+
+        mockMvc.get("/api/application-forms") {
+            bearer("valid_token")
+            param("recruitmentId", "1")
+        }.andExpect {
+            status { isNotFound }
+        }.andDo {
+            handle(document("application-form-get-not-found"))
+        }
+    }
+
+    @Test
     fun `특정 모집 id와 지원자에 대한 키워드(이름 or 이메일)로 지원서 정보들을 조회한다`() {
         val keyword = "아마찌"
         val responses = listOf(ApplicantAndFormResponse(createUser(name = keyword), false, createApplicationForm()))

--- a/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/ApplicationFormRestControllerTest.kt
@@ -102,7 +102,7 @@ class ApplicationFormRestControllerTest : RestControllerTest() {
             bearer("valid_token")
             param("recruitmentId", "1")
         }.andExpect {
-            status { isBadRequest }
+            status { isBadRequest() }
         }.andDo {
             handle(document("application-form-get-bad-request"))
         }
@@ -118,7 +118,7 @@ class ApplicationFormRestControllerTest : RestControllerTest() {
             bearer("valid_token")
             param("recruitmentId", "1")
         }.andExpect {
-            status { isNotFound }
+            status { isNotFound() }
         }.andDo {
             handle(document("application-form-get-not-found"))
         }


### PR DESCRIPTION
Resolves #477 

# 해결하려는 문제가 무엇인가요?

- / 또는 /recruit 페이지의 모집 항목을 최초로 클릭하여 진입하더라도 "임시 저장되었습니다" 문구가 뜨고 실제로 지원서가 서버에서 생성됩니다.

# 어떻게 해결했나요?

- 사용자가 직접 '임시 저장 버튼'을 최초로 누르면, 지원서 생성 요청 API를 호출하고 생성 완료된 지원서 id 값을 반환 받으면 지원서 수정 API를 요청하여 사용자가 작성한 항목을 서버에 저장합니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 아래의 흐름에 따라 기능이 정상 동작하는지 검토 부탁드립니다.
   1. [x] 목록 -> 처음 작성 진입
   2. [x] 목록 -> 처음 작성 -> 임시저장
   3. [x] 목록 -> 처음 작성 -> 제출 -> 목록
   4. [x] 목록 -> 임시 저장 -> 작성 페이지
   5. [x] 내 지원서 -> 작성 페이지
   6. [x] 내 지원서 -> 작성 페이지 -> 제출 -> 이후 진입 불가
   7. [x] 목록(최종제출) -> 진입 불가
- 리팩터링할 요소가 많이 남아있지만, 별도의 이슈로 진행하기 위해서 작업하지 않았습니다. 혹시라도 이 이슈에서 리팩터링하거나 다른 이슈에서 추가적으로 리팩터링하면 좋을 것 같은 요소가 있으시다면 검토 부탁드려요!

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
