### PR TITLE
feat(mission): add submission method to mission

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("com.ninja-squad:springmockk:3.1.2")
+    testImplementation("io.mockk:mockk:1.13.12")
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
 }

--- a/src/main/kotlin/apply/application/MissionDtos.kt
+++ b/src/main/kotlin/apply/application/MissionDtos.kt
@@ -6,6 +6,7 @@ import apply.domain.judgmentitem.JudgmentItem
 import apply.domain.judgmentitem.ProgrammingLanguage
 import apply.domain.mission.Mission
 import apply.domain.mission.MissionStatus
+import apply.domain.mission.SubmissionMethod
 import java.time.LocalDateTime
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -27,14 +28,17 @@ data class MissionData(
 
     @field:NotBlank
     var description: String = "",
-    var judgmentItemData: JudgmentItemData = JudgmentItemData(),
 
     @field:NotNull
     var submittable: Boolean = false,
 
     @field:NotNull
     var hidden: Boolean = true,
-    var id: Long = 0L
+
+    @field:NotNull
+    var submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+    var judgmentItemData: JudgmentItemData = JudgmentItemData(),
+    var id: Long = 0L,
 ) {
     constructor(mission: Mission, evaluation: Evaluation, judgmentItemData: JudgmentItemData) : this(
         mission.title,
@@ -42,9 +46,10 @@ data class MissionData(
         mission.period.startDateTime,
         mission.period.endDateTime,
         mission.description,
-        judgmentItemData,
         mission.submittable,
         mission.hidden,
+        mission.submissionMethod,
+        judgmentItemData,
         mission.id
     )
 }
@@ -59,7 +64,7 @@ data class MissionAndEvaluationResponse(
     val status: MissionStatus,
     val hidden: Boolean,
     val startDateTime: LocalDateTime,
-    val endDateTime: LocalDateTime
+    val endDateTime: LocalDateTime,
 ) {
     constructor(mission: Mission, evaluation: Evaluation) : this(
         mission.id,
@@ -82,7 +87,7 @@ data class MissionResponse(
     val submittable: Boolean,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
-    val status: MissionStatus
+    val status: MissionStatus,
 ) {
     constructor(mission: Mission) : this(
         mission.id,
@@ -104,13 +109,13 @@ data class MyMissionAndJudgementResponse(
     val endDateTime: LocalDateTime,
     val status: MissionStatus,
     val testable: Boolean,
-    val judgment: LastJudgmentResponse?
+    val judgment: LastJudgmentResponse?,
 ) {
     constructor(
         mission: Mission,
         submitted: Boolean,
         testable: Boolean,
-        judgment: LastJudgmentResponse? = null
+        judgment: LastJudgmentResponse? = null,
     ) : this(
         mission.id,
         mission.title,
@@ -150,7 +155,7 @@ data class JudgmentItemData(
     var id: Long = 0L,
     var testName: String = "",
     var evaluationItemSelectData: EvaluationItemSelectData = EvaluationItemSelectData(),
-    var programmingLanguage: ProgrammingLanguage = ProgrammingLanguage.NONE
+    var programmingLanguage: ProgrammingLanguage = ProgrammingLanguage.NONE,
 ) {
     constructor(judgmentItem: JudgmentItem, evaluationItemSelectData: EvaluationItemSelectData) : this(
         judgmentItem.id,
@@ -162,7 +167,7 @@ data class JudgmentItemData(
 
 data class EvaluationItemSelectData(
     var title: String = "",
-    var id: Long = 0L
+    var id: Long = 0L,
 ) {
     constructor(evaluationItem: EvaluationItem) : this(evaluationItem.title, evaluationItem.id)
 }

--- a/src/main/kotlin/apply/application/MissionDtos.kt
+++ b/src/main/kotlin/apply/application/MissionDtos.kt
@@ -57,24 +57,24 @@ data class MissionData(
 data class MissionAndEvaluationResponse(
     val id: Long,
     val title: String,
-    val description: String,
-    val evaluationTitle: String,
     val evaluationId: Long,
+    val evaluationTitle: String,
     val submittable: Boolean,
     val status: MissionStatus,
     val hidden: Boolean,
+    val submissionMethod: SubmissionMethod,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
 ) {
     constructor(mission: Mission, evaluation: Evaluation) : this(
         mission.id,
         mission.title,
-        mission.description,
-        evaluation.title,
         evaluation.id,
+        evaluation.title,
         mission.submittable,
         mission.status,
         mission.hidden,
+        mission.submissionMethod,
         mission.period.startDateTime,
         mission.period.endDateTime
     )

--- a/src/main/kotlin/apply/application/MissionDtos.kt
+++ b/src/main/kotlin/apply/application/MissionDtos.kt
@@ -83,31 +83,34 @@ data class MissionAndEvaluationResponse(
 data class MissionResponse(
     val id: Long,
     val title: String,
-    val description: String,
-    val submittable: Boolean,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
-    val status: MissionStatus,
+    val description: String,
+    val submittable: Boolean,
+    val hidden: Boolean,
+    val submissionMethod: SubmissionMethod,
 ) {
     constructor(mission: Mission) : this(
         mission.id,
         mission.title,
-        mission.description,
-        mission.submittable,
         mission.period.startDateTime,
         mission.period.endDateTime,
-        mission.status
+        mission.description,
+        mission.submittable,
+        mission.hidden,
+        mission.submissionMethod
     )
 }
 
 data class MyMissionAndJudgementResponse(
     val id: Long,
     val title: String,
-    val submittable: Boolean,
-    val submitted: Boolean,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
+    val submittable: Boolean,
+    val submissionMethod: SubmissionMethod,
     val status: MissionStatus,
+    val submitted: Boolean,
     val testable: Boolean,
     val judgment: LastJudgmentResponse?,
 ) {
@@ -119,11 +122,12 @@ data class MyMissionAndJudgementResponse(
     ) : this(
         mission.id,
         mission.title,
-        mission.submittable,
-        submitted,
         mission.period.startDateTime,
         mission.period.endDateTime,
+        mission.submittable,
+        mission.submissionMethod,
         mission.status,
+        submitted,
         testable,
         judgment
     )
@@ -132,20 +136,22 @@ data class MyMissionAndJudgementResponse(
 data class MyMissionResponse(
     val id: Long,
     val title: String,
-    val description: String,
-    val submittable: Boolean,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime,
+    val description: String,
+    val submittable: Boolean,
+    val submissionMethod: SubmissionMethod,
     val status: MissionStatus,
     val submitted: Boolean,
 ) {
     constructor(mission: Mission, description: String, submitted: Boolean) : this(
         mission.id,
         mission.title,
-        description,
-        mission.submittable,
         mission.period.startDateTime,
         mission.period.endDateTime,
+        description,
+        mission.submittable,
+        mission.submissionMethod,
         mission.status,
         submitted
     )

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -1,5 +1,6 @@
 package apply.application
 
+import apply.domain.evaluation.Evaluation
 import apply.domain.evaluation.EvaluationRepository
 import apply.domain.evaluation.getOrThrow
 import apply.domain.evaluationitem.EvaluationItemRepository
@@ -43,22 +44,13 @@ class MissionService(
     }
 
     private fun validate(request: MissionData) {
-        val evaluationId = request.evaluation.id
-        require(evaluationRepository.existsById(evaluationId)) { "평가가 존재하지 않습니다. id: $evaluationId" }
-        if (isNew(request)) {
-            check(!missionRepository.existsByEvaluationId(evaluationId)) {
-                "이미 과제가 등록된 평가입니다. evaluationId: $evaluationId"
-            }
-        } else {
-            val mission = missionRepository.getOrThrow(request.id)
-            check(mission.evaluationId == evaluationId) {
-                "과제의 평가는 수정할 수 없습니다."
-            }
-        }
+        val evaluation = evaluationRepository.getOrThrow(request.evaluation.id)
+        val mission = missionRepository.findByIdOrNull(request.id)
+        mission?.validateSameEvaluation(evaluation.id) ?: evaluation.validateNoMission()
     }
 
-    private fun isNew(request: MissionData): Boolean {
-        return request.id == 0L || !missionRepository.existsById(request.id)
+    private fun Evaluation.validateNoMission() {
+        require(!missionRepository.existsByEvaluationId(id)) { "이미 과제가 등록된 평가입니다. evaluationId: $id" }
     }
 
     private fun JudgmentItem.update(request: MissionData) {

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -26,10 +26,10 @@ class MissionService(
         val mission = missionRepository.save(
             Mission(
                 request.title,
-                request.description,
                 request.evaluation.id,
                 request.startDateTime,
                 request.endDateTime,
+                request.description,
                 request.submittable,
                 request.hidden,
                 request.submissionMethod,

--- a/src/main/kotlin/apply/application/MissionService.kt
+++ b/src/main/kotlin/apply/application/MissionService.kt
@@ -19,7 +19,7 @@ class MissionService(
     private val missionRepository: MissionRepository,
     private val evaluationRepository: EvaluationRepository,
     private val evaluationItemRepository: EvaluationItemRepository,
-    private val judgmentItemRepository: JudgmentItemRepository
+    private val judgmentItemRepository: JudgmentItemRepository,
 ) {
     fun save(request: MissionData): MissionResponse {
         validate(request)
@@ -32,6 +32,7 @@ class MissionService(
                 request.endDateTime,
                 request.submittable,
                 request.hidden,
+                request.submissionMethod,
                 request.id
             )
         )

--- a/src/main/kotlin/apply/config/DatabaseInitializer.kt
+++ b/src/main/kotlin/apply/config/DatabaseInitializer.kt
@@ -30,6 +30,7 @@ import apply.domain.member.MemberRepository
 import apply.domain.member.Password
 import apply.domain.mission.Mission
 import apply.domain.mission.MissionRepository
+import apply.domain.mission.SubmissionMethod
 import apply.domain.recruitment.Recruitment
 import apply.domain.recruitment.RecruitmentRepository
 import apply.domain.recruitmentitem.RecruitmentItem
@@ -412,6 +413,9 @@ class DatabaseInitializer(
         val missions = listOf(
             Mission(
                 title = "1주 차 프리코스 - 숫자 야구 게임",
+                evaluationId = 2L,
+                startDateTime = createLocalDateTime(2020, 11, 24, 15),
+                endDateTime = createLocalDateTime(2120, 12, 1, 0),
                 description = """
                     |# 미션 - 숫자 야구 게임
                     |
@@ -463,14 +467,15 @@ class DatabaseInitializer(
                     |}
                     |```
                 """.trimMargin(),
-                evaluationId = 2L,
-                startDateTime = createLocalDateTime(2020, 11, 24, 15),
-                endDateTime = createLocalDateTime(2120, 12, 1, 0),
                 submittable = true,
-                hidden = false
+                hidden = false,
+                submissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST
             ),
             Mission(
                 title = "2주 차 프리코스 - 자동차 경주 게임",
+                evaluationId = 3L,
+                startDateTime = createLocalDateTime(2020, 12, 1, 15),
+                endDateTime = createLocalDateTime(2120, 12, 8, 0),
                 description = """
                     |# 미션 - 자동차 경주 게임
                     |
@@ -480,11 +485,9 @@ class DatabaseInitializer(
                     |- 세 개의 요구 사항을 만족하기 위해 노력한다. 특히 기능을 구현하기 전에 기능 목록을 만들고, 기능 단위로 커밋 하는 방식으로 진행한다.
                     |- 기능 요구 사항에 기재되지 않은 내용은 스스로 판단하여 구현한다.
                 """.trimMargin(),
-                evaluationId = 3L,
-                startDateTime = createLocalDateTime(2020, 12, 1, 15),
-                endDateTime = createLocalDateTime(2120, 12, 8, 0),
                 submittable = true,
-                hidden = false
+                hidden = false,
+                submissionMethod = SubmissionMethod.PRIVATE_REPOSITORY
             )
         )
         missionRepository.saveAll(missions)

--- a/src/main/kotlin/apply/domain/mission/Mission.kt
+++ b/src/main/kotlin/apply/domain/mission/Mission.kt
@@ -7,6 +7,8 @@ import java.time.LocalDateTime
 import javax.persistence.Column
 import javax.persistence.Embedded
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.Lob
 
 @SQLDelete(sql = "update mission set deleted = true where id = ?")
@@ -31,7 +33,11 @@ class Mission(
 
     @Column(nullable = false)
     var hidden: Boolean = true,
-    id: Long = 0L
+
+    @Column(nullable = false, columnDefinition = "varchar(255) default 'PUBLIC_PULL_REQUEST'")
+    @Enumerated(EnumType.STRING)
+    val submissionMethod: SubmissionMethod,
+    id: Long = 0L,
 ) : BaseEntity(id) {
     @Column(nullable = false)
     private var deleted: Boolean = false
@@ -53,6 +59,16 @@ class Mission(
         endDateTime: LocalDateTime,
         submittable: Boolean = false,
         hidden: Boolean = true,
-        id: Long = 0L
-    ) : this(title, description, evaluationId, MissionPeriod(startDateTime, endDateTime), submittable, hidden, id)
+        submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+        id: Long = 0L,
+    ) : this(
+        title,
+        description,
+        evaluationId,
+        MissionPeriod(startDateTime, endDateTime),
+        submittable,
+        hidden,
+        submissionMethod,
+        id
+    )
 }

--- a/src/main/kotlin/apply/domain/mission/Mission.kt
+++ b/src/main/kotlin/apply/domain/mission/Mission.kt
@@ -71,4 +71,8 @@ class Mission(
         submissionMethod,
         id
     )
+
+    fun validateSameEvaluation(evaluationId: Long) {
+        require(this.evaluationId == evaluationId) { "과제의 평가는 수정할 수 없습니다." }
+    }
 }

--- a/src/main/kotlin/apply/domain/mission/Mission.kt
+++ b/src/main/kotlin/apply/domain/mission/Mission.kt
@@ -19,14 +19,14 @@ class Mission(
     val title: String,
 
     @Column(nullable = false)
-    @Lob
-    val description: String,
-
-    @Column(nullable = false)
     val evaluationId: Long,
 
     @Embedded
     var period: MissionPeriod,
+
+    @Column(nullable = false)
+    @Lob
+    val description: String,
 
     @Column(nullable = false)
     var submittable: Boolean = false,
@@ -53,19 +53,19 @@ class Mission(
 
     constructor(
         title: String,
-        description: String,
         evaluationId: Long,
         startDateTime: LocalDateTime,
         endDateTime: LocalDateTime,
-        submittable: Boolean = false,
-        hidden: Boolean = true,
-        submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+        description: String,
+        submittable: Boolean,
+        hidden: Boolean,
+        submissionMethod: SubmissionMethod,
         id: Long = 0L,
     ) : this(
         title,
-        description,
         evaluationId,
         MissionPeriod(startDateTime, endDateTime),
+        description,
         submittable,
         hidden,
         submissionMethod,

--- a/src/main/kotlin/apply/domain/mission/SubmissionMethod.kt
+++ b/src/main/kotlin/apply/domain/mission/SubmissionMethod.kt
@@ -1,0 +1,6 @@
+package apply.domain.mission
+
+enum class SubmissionMethod(val label: String) {
+    PUBLIC_PULL_REQUEST("공개 풀 리퀘스트"),
+    PRIVATE_REPOSITORY("비공개 저장소");
+}

--- a/src/main/kotlin/apply/ui/admin/mission/MissionForm.kt
+++ b/src/main/kotlin/apply/ui/admin/mission/MissionForm.kt
@@ -79,6 +79,7 @@ class MissionForm() : BindingIdentityFormLayout<MissionData>(MissionData::class)
     override fun fill(data: MissionData) {
         fillDefault(data)
         evaluation.isReadOnly = true
+        submissionMethod.isReadOnly = true // https://github.com/vaadin/flow-components/issues/1058
         if (data.judgmentItemData != JudgmentItemData()) {
             addJudgmentItemForm()
             judgmentItemForm.fill(data.judgmentItemData)

--- a/src/main/kotlin/apply/ui/admin/mission/MissionForm.kt
+++ b/src/main/kotlin/apply/ui/admin/mission/MissionForm.kt
@@ -4,6 +4,8 @@ import apply.application.EvaluationItemSelectData
 import apply.application.EvaluationSelectData
 import apply.application.JudgmentItemData
 import apply.application.MissionData
+import apply.domain.mission.SubmissionMethod
+import apply.domain.mission.SubmissionMethod.PUBLIC_PULL_REQUEST
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.datetimepicker.DateTimePicker
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup
@@ -15,23 +17,26 @@ import support.views.createBooleanRadioButtonGroup
 import support.views.createErrorSmallButton
 import support.views.createItemSelect
 import support.views.createPrimarySmallButton
+import support.views.createRadioButtonGroup
 
 class MissionForm() : BindingIdentityFormLayout<MissionData>(MissionData::class) {
     private val title: TextField = TextField("과제명")
-    private val description: TextArea = TextArea("설명")
     private val evaluation: Select<EvaluationSelectData> = createItemSelect<EvaluationSelectData>("평가").apply {
         setItemLabelGenerator(EvaluationSelectData::title)
         isEmptySelectionAllowed = false
     }
     private val startDateTime: DateTimePicker = DateTimePicker("시작 일시")
     private val endDateTime: DateTimePicker = DateTimePicker("종료 일시")
+    private val description: TextArea = TextArea("설명")
     private val submittable: RadioButtonGroup<Boolean> = createBooleanRadioButtonGroup("제출 여부", "제출 시작", "제출 중지", false)
     private val hidden: RadioButtonGroup<Boolean> = createBooleanRadioButtonGroup("공개 여부", "비공개", "공개", true)
+    private val submissionMethod: RadioButtonGroup<SubmissionMethod> =
+        createRadioButtonGroup("제출 방식", PUBLIC_PULL_REQUEST, SubmissionMethod::label)
     private val addButton: Button = createAddButton()
     private val judgmentItemForm: JudgmentItemForm = JudgmentItemForm()
 
     init {
-        add(title, evaluation, startDateTime, endDateTime, description, submittable, hidden)
+        add(title, evaluation, startDateTime, endDateTime, description, submittable, hidden, submissionMethod)
         setResponsiveSteps(ResponsiveStep("0", 1))
         addFormItem(addButton, "자동 채점 항목")
         drawRequired()

--- a/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
+++ b/src/main/kotlin/apply/ui/admin/mission/MissionsView.kt
@@ -60,6 +60,7 @@ class MissionsView(
             addSortableColumn("평가명", MissionAndEvaluationResponse::evaluationTitle)
             addSortableColumn("상태") { it.status.toText() }
             addSortableColumn("공개 여부") { it.hidden.toText() }
+            addSortableColumn("제출 방식") { it.submissionMethod.label }
             addSortableDateTimeColumn("시작일시", MissionAndEvaluationResponse::startDateTime)
             addSortableDateTimeColumn("종료일시", MissionAndEvaluationResponse::endDateTime)
             addColumn(createButtonRenderer()).apply { isAutoWidth = true }
@@ -100,10 +101,6 @@ class MissionsView(
     }
 
     private fun Boolean.toText(): String {
-        return if (this) {
-            "비공개"
-        } else {
-            "공개"
-        }
+        return if (this) "비공개" else "공개"
     }
 }

--- a/src/main/kotlin/support/views/Components.kt
+++ b/src/main/kotlin/support/views/Components.kt
@@ -34,13 +34,26 @@ fun createBooleanRadioButtonGroup(
     labelText: String,
     trueText: String = true.toString(),
     falseText: String = false.toString(),
-    defaultValue: Boolean = false
+    defaultValue: Boolean = false,
 ): RadioButtonGroup<Boolean> {
     return RadioButtonGroup<Boolean>().apply {
         setItems(true, false)
         label = labelText
         value = defaultValue
         setRenderer(createTextRenderer(trueText, falseText))
+    }
+}
+
+inline fun <reified T : Enum<T>> createRadioButtonGroup(
+    labelText: String,
+    defaultValue: T,
+    crossinline renderer: (T) -> String,
+): RadioButtonGroup<T> {
+    return RadioButtonGroup<T>().apply {
+        setItems(*enumValues<T>())
+        label = labelText
+        value = defaultValue
+        setRenderer(ComponentRenderer { text -> Text(renderer(text)) })
     }
 }
 
@@ -57,7 +70,7 @@ private fun createTextRenderer(trueText: String, falseText: String): ComponentRe
 private fun createBox(
     icon: VaadinIcon,
     labelText: String = "",
-    eventListener: (name: String) -> Unit
+    eventListener: (name: String) -> Unit,
 ): HorizontalLayout {
     val textField = TextField().apply {
         label = labelText

--- a/src/main/resources/db/migration/V3_1__Add_mission_submission_method.sql
+++ b/src/main/resources/db/migration/V3_1__Add_mission_submission_method.sql
@@ -1,0 +1,2 @@
+alter table mission
+    add submission_method varchar(255) not null default 'PUBLIC_PULL_REQUEST' after start_date_time;

--- a/src/test/kotlin/apply/MissionFixtures.kt
+++ b/src/test/kotlin/apply/MissionFixtures.kt
@@ -30,10 +30,10 @@ private val END_DATE_TIME: LocalDateTime = LocalDateTime.now().plusDays(7L)
 
 fun createMission(
     title: String = MISSION_TITLE,
-    description: String = MISSION_DESCRIPTION,
     evaluationId: Long = 1L,
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
+    description: String = MISSION_DESCRIPTION,
     submittable: Boolean = true,
     hidden: Boolean = false,
     submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
@@ -41,10 +41,10 @@ fun createMission(
 ): Mission {
     return Mission(
         title,
-        description,
         evaluationId,
         startDateTime,
         endDateTime,
+        description,
         submittable,
         hidden,
         submissionMethod,

--- a/src/test/kotlin/apply/MissionFixtures.kt
+++ b/src/test/kotlin/apply/MissionFixtures.kt
@@ -9,6 +9,7 @@ import apply.application.MyMissionAndJudgementResponse
 import apply.application.MyMissionResponse
 import apply.domain.mission.Mission
 import apply.domain.mission.MissionStatus
+import apply.domain.mission.SubmissionMethod
 import support.flattenByMargin
 import java.time.LocalDateTime
 
@@ -35,9 +36,20 @@ fun createMission(
     endDateTime: LocalDateTime = END_DATE_TIME,
     submittable: Boolean = true,
     hidden: Boolean = false,
-    id: Long = 0L
+    submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+    id: Long = 0L,
 ): Mission {
-    return Mission(title, description, evaluationId, startDateTime, endDateTime, submittable, hidden, id)
+    return Mission(
+        title,
+        description,
+        evaluationId,
+        startDateTime,
+        endDateTime,
+        submittable,
+        hidden,
+        submissionMethod,
+        id
+    )
 }
 
 fun createMissionData(
@@ -46,10 +58,11 @@ fun createMissionData(
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
     description: String = MISSION_DESCRIPTION,
-    judgmentItemData: JudgmentItemData = JudgmentItemData(),
     submittable: Boolean = true,
     hidden: Boolean = true,
-    id: Long = 0L
+    submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+    judgmentItemData: JudgmentItemData = JudgmentItemData(),
+    id: Long = 0L,
 ): MissionData {
     return MissionData(
         title,
@@ -57,9 +70,10 @@ fun createMissionData(
         startDateTime,
         endDateTime,
         description,
-        judgmentItemData,
         submittable,
         hidden,
+        submissionMethod,
+        judgmentItemData,
         id
     )
 }
@@ -71,7 +85,7 @@ fun createMissionResponse(
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
     missionStatus: MissionStatus = MissionStatus.SUBMITTING,
-    id: Long = 0L
+    id: Long = 0L,
 ): MissionResponse {
     return MissionResponse(
         id,
@@ -93,7 +107,7 @@ fun createMyMissionAndJudgementResponse(
     missionStatus: MissionStatus = MissionStatus.SUBMITTING,
     testable: Boolean = true,
     judgment: LastJudgmentResponse? = createLastJudgmentResponse(),
-    id: Long = 0L
+    id: Long = 0L,
 ): MyMissionAndJudgementResponse {
     return MyMissionAndJudgementResponse(
         id,

--- a/src/test/kotlin/apply/MissionFixtures.kt
+++ b/src/test/kotlin/apply/MissionFixtures.kt
@@ -107,9 +107,9 @@ fun createMyMissionAndJudgementResponse(
     submittable: Boolean = true,
     submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
     status: MissionStatus = MissionStatus.SUBMITTING,
-    submitted: Boolean = true,
-    testable: Boolean = true,
-    judgment: LastJudgmentResponse? = createLastJudgmentResponse(),
+    submitted: Boolean = false,
+    testable: Boolean = false,
+    judgment: LastJudgmentResponse? = null,
     id: Long = 0L,
 ): MyMissionAndJudgementResponse {
     return MyMissionAndJudgementResponse(

--- a/src/test/kotlin/apply/MissionFixtures.kt
+++ b/src/test/kotlin/apply/MissionFixtures.kt
@@ -80,31 +80,34 @@ fun createMissionData(
 
 fun createMissionResponse(
     title: String = MISSION_TITLE,
-    description: String = MISSION_DESCRIPTION,
-    submittable: Boolean = true,
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
-    missionStatus: MissionStatus = MissionStatus.SUBMITTING,
+    description: String = MISSION_DESCRIPTION,
+    submittable: Boolean = true,
+    hidden: Boolean = false,
+    submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
     id: Long = 0L,
 ): MissionResponse {
     return MissionResponse(
         id,
         title,
-        description,
-        submittable,
         startDateTime,
         endDateTime,
-        missionStatus
+        description,
+        submittable,
+        hidden,
+        submissionMethod
     )
 }
 
 fun createMyMissionAndJudgementResponse(
     title: String = MISSION_TITLE,
-    submittable: Boolean = true,
-    submitted: Boolean = true,
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
-    missionStatus: MissionStatus = MissionStatus.SUBMITTING,
+    submittable: Boolean = true,
+    submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+    status: MissionStatus = MissionStatus.SUBMITTING,
+    submitted: Boolean = true,
     testable: Boolean = true,
     judgment: LastJudgmentResponse? = createLastJudgmentResponse(),
     id: Long = 0L,
@@ -112,11 +115,12 @@ fun createMyMissionAndJudgementResponse(
     return MyMissionAndJudgementResponse(
         id,
         title,
-        submittable,
-        submitted,
         startDateTime,
         endDateTime,
-        missionStatus,
+        submittable,
+        submissionMethod,
+        status,
+        submitted,
         testable,
         judgment
     )
@@ -124,22 +128,24 @@ fun createMyMissionAndJudgementResponse(
 
 fun createMyMissionResponse(
     title: String = MISSION_TITLE,
-    description: String = FORMATTED_MISSION_DESCRIPTION,
-    submittable: Boolean = true,
     startDateTime: LocalDateTime = START_DATE_TIME,
     endDateTime: LocalDateTime = END_DATE_TIME,
-    missionStatus: MissionStatus = MissionStatus.SUBMITTING,
+    description: String = FORMATTED_MISSION_DESCRIPTION,
+    submittable: Boolean = true,
+    submissionMethod: SubmissionMethod = SubmissionMethod.PUBLIC_PULL_REQUEST,
+    status: MissionStatus = MissionStatus.SUBMITTING,
     submitted: Boolean = true,
     id: Long = 0L,
 ): MyMissionResponse {
     return MyMissionResponse(
         id,
         title,
-        description,
-        submittable,
         startDateTime,
         endDateTime,
-        missionStatus,
-        submitted,
+        description,
+        submittable,
+        submissionMethod,
+        status,
+        submitted
     )
 }

--- a/src/test/kotlin/apply/application/MissionServiceTest.kt
+++ b/src/test/kotlin/apply/application/MissionServiceTest.kt
@@ -5,6 +5,7 @@ import apply.createMission
 import apply.createMissionData
 import apply.createMissionResponse
 import apply.domain.evaluation.EvaluationRepository
+import apply.domain.evaluation.getOrThrow
 import apply.domain.evaluationitem.EvaluationItemRepository
 import apply.domain.judgmentitem.JudgmentItemRepository
 import apply.domain.mission.MissionRepository
@@ -35,13 +36,16 @@ class MissionServiceTest : BehaviorSpec({
     )
 
     Given("과제가 없는 평가가 있는 경우") {
-        every { evaluationRepository.existsById(any()) } returns true
+        val evaluation = createEvaluation()
+
+        every { evaluationRepository.getOrThrow(any()) } returns evaluation
+        every { missionRepository.findByIdOrNull(any()) } returns null
         every { missionRepository.existsByEvaluationId(any()) } returns false
-        every { missionRepository.save(any()) } returns createMission()
+        every { missionRepository.save(any()) } returns createMission(evaluationId = evaluation.id)
         every { judgmentItemRepository.findByMissionId(any()) } returns null
 
         When("해당 평가에 대한 과제를 생성하면") {
-            val actual = missionService.save(createMissionData())
+            val actual = missionService.save(createMissionData(evaluation = EvaluationSelectData(evaluation)))
 
             Then("과제가 생성된다") {
                 actual shouldBe createMissionResponse()
@@ -50,11 +54,11 @@ class MissionServiceTest : BehaviorSpec({
     }
 
     Given("평가가 존재하지 않는 경우") {
-        every { evaluationRepository.existsById(any()) } returns false
+        every { evaluationRepository.getOrThrow(any()) } throws NoSuchElementException()
 
         When("해당 평가에 대한 과제를 생성하면") {
             Then("예외가 발생한다") {
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<NoSuchElementException> {
                     missionService.save(createMissionData())
                 }
             }
@@ -62,13 +66,16 @@ class MissionServiceTest : BehaviorSpec({
     }
 
     Given("평가에 대한 과제가 이미 있는 경우") {
-        every { evaluationRepository.existsById(any()) } returns true
+        val evaluation = createEvaluation()
+
+        every { evaluationRepository.getOrThrow(any()) } returns evaluation
+        every { missionRepository.findByIdOrNull(any()) } returns null
         every { missionRepository.existsByEvaluationId(any()) } returns true
 
         When("해당 평가에 대한 과제를 생성하면") {
             Then("예외가 발생한다") {
-                shouldThrow<IllegalStateException> {
-                    missionService.save(createMissionData())
+                shouldThrow<IllegalArgumentException> {
+                    missionService.save(createMissionData(evaluation = EvaluationSelectData(evaluation)))
                 }
             }
         }

--- a/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
+++ b/src/test/kotlin/apply/ui/api/MissionRestControllerTest.kt
@@ -10,7 +10,9 @@ import apply.createMissionData
 import apply.createMissionResponse
 import apply.createMyMissionAndJudgementResponse
 import apply.createMyMissionResponse
-import apply.domain.judgment.JudgmentStatus
+import apply.domain.judgment.JudgmentStatus.SUCCEEDED
+import apply.domain.mission.SubmissionMethod.PRIVATE_REPOSITORY
+import apply.domain.mission.SubmissionMethod.PUBLIC_PULL_REQUEST
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.Runs
 import io.mockk.every
@@ -77,20 +79,31 @@ class MissionRestControllerTest : RestControllerTest() {
     @Test
     fun `나의 과제 목록을 조회한다`() {
         val responses = listOf(
-            createMyMissionAndJudgementResponse(id = 1L, submitted = false, testable = false, judgment = null),
-            createMyMissionAndJudgementResponse(id = 2L, submitted = false, testable = true, judgment = null),
-            createMyMissionAndJudgementResponse(id = 3L, submitted = true, testable = true, judgment = null),
+            createMyMissionAndJudgementResponse(id = 1L, submissionMethod = PUBLIC_PULL_REQUEST),
+            createMyMissionAndJudgementResponse(id = 2L, submissionMethod = PRIVATE_REPOSITORY),
+            createMyMissionAndJudgementResponse(
+                id = 3L,
+                submitted = false,
+                testable = true,
+                judgment = null
+            ),
             createMyMissionAndJudgementResponse(
                 id = 4L,
                 submitted = true,
                 testable = true,
-                judgment = createLastJudgmentResponse()
+                judgment = null
             ),
             createMyMissionAndJudgementResponse(
                 id = 5L,
                 submitted = true,
                 testable = true,
-                judgment = createLastJudgmentResponse(passCount = 9, totalCount = 10, status = JudgmentStatus.SUCCEEDED)
+                judgment = createLastJudgmentResponse()
+            ),
+            createMyMissionAndJudgementResponse(
+                id = 6L,
+                submitted = true,
+                testable = true,
+                judgment = createLastJudgmentResponse(passCount = 9, totalCount = 10, status = SUCCEEDED)
             )
         )
         every { missionQueryService.findAllByMemberIdAndRecruitmentId(any(), any()) } returns responses


### PR DESCRIPTION
Resolves #721 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 과제를 생성할 때 과제 제출물을 제출하는 방식을 결정할 수 있어야 합니다.

# 어떻게 해결했나요?

- 제출 방식에는 공개 풀 리퀘스트 방식과 비공개 저장소 방식이 있습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 과제 생성 화면의 입력 순서와 일치하도록 클래스의 매개 변수 순서를 조정했습니다.
- 과제 조회 그리드에서 열의 순서를 변경했습니다. UI가 괜찮은지 확인해 주세요.
- 라디오 버튼 그룹에 버그가 있습니다. 읽기 전용이지만 비활성화되어 있으며, 향후 Vaadin 버전이 업그레이드되면 이 문제는 해결될 것으로 보입니다. (14.10.0)

## 참고 자료

- `https://github.com/vaadin/flow-components/issues/1058`
- https://github.com/woowacourse/service-apply/issues/721#issuecomment-2358663532

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
