### PR TITLE
fix(support): correct typo in equals method

### DIFF
--- a/src/main/kotlin/support/domain/BaseEntities.kt
+++ b/src/main/kotlin/support/domain/BaseEntities.kt
@@ -38,7 +38,7 @@ abstract class BaseRootEntity<T : AbstractAggregateRoot<T>>(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as BaseEntity
+        other as BaseRootEntity<*>
 
         if (id != other.id) return false
 

--- a/src/main/kotlin/support/domain/BaseEntities.kt
+++ b/src/main/kotlin/support/domain/BaseEntities.kt
@@ -18,9 +18,7 @@ abstract class BaseEntity(
 
         other as BaseEntity
 
-        if (id != other.id) return false
-
-        return true
+        return id == other.id
     }
 
     override fun hashCode(): Int {
@@ -40,9 +38,7 @@ abstract class BaseRootEntity<T : AbstractAggregateRoot<T>>(
 
         other as BaseRootEntity<*>
 
-        if (id != other.id) return false
-
-        return true
+        return id == other.id
     }
 
     override fun hashCode(): Int {


### PR DESCRIPTION
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?
- BaseRootEntity를 상속받은 클래스끼리 equals로 비교하려 했을 때 ClassCastException이 발생합니다.

# 어떻게 해결했나요?
- BaseRootEntity 클래스 내부 equals method의 BaseEntity를 BaseRootEntity<*>로 변경했습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- BaseRootEntity 추상 클래스를 상속받는 다른 클래스에 대한 동작이 정상적으로 이루어질지 의견 부탁드립니다.



---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
