### PR TITLE
feat(member): change to only allow members 14 years of age or older to sign up

### DIFF
--- a/frontend/src/components/form/BirthField/BirthField.module.css
+++ b/frontend/src/components/form/BirthField/BirthField.module.css
@@ -26,7 +26,7 @@
 }
 
 .rule-field {
-  margin: 0 0.5rem;
+  margin: 0.2rem 0.5rem 0;
   height: 0.75rem;
   font-size: 0.75rem;
   color: var(--red);

--- a/frontend/src/components/form/BirthField/BirthField.tsx
+++ b/frontend/src/components/form/BirthField/BirthField.tsx
@@ -11,6 +11,7 @@ registerLocale("ko", ko);
 
 type BirthFieldProps = Omit<ReactDatePickerProps, "value"> & {
   value?: Date | null;
+  errorMessage?: string;
 };
 
 const BirthField = ({
@@ -19,6 +20,7 @@ const BirthField = ({
   required = false,
   className,
   name,
+  errorMessage,
   ...props
 }: BirthFieldProps) => {
   return (
@@ -43,6 +45,7 @@ const BirthField = ({
           autoComplete="off"
           {...props}
         />
+        {errorMessage && <p className={styles["rule-field"]}>{errorMessage}</p>}
       </div>
     </div>
   );

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -15,6 +15,7 @@ export const ERROR_MESSAGE = {
     GITHUB_USERNAME:
       "GitHub 사용자 이름 정책에 따라 영문, 숫자, 하이픈 조합을 사용하여 최대 39자까지 가능합니다.",
     BIRTHDAY: "유효하지 않은 날짜입니다. 정확한 날짜를 입력해 주세요.",
+    BIRTHDAY_IS_NOT_OVER_14: "만 14세 이상만 회원가입이 가능합니다.",
   },
   API: {
     ALREADY_REGISTER: "이미 지원한 이력이 있습니다.",

--- a/frontend/src/hooks/useSignUpForm.js
+++ b/frontend/src/hooks/useSignUpForm.js
@@ -6,6 +6,7 @@ import { isValidGithubUsername } from "../utils/validation/githubUsername";
 import { isValidName } from "../utils/validation/name";
 import { isValidPassword } from "../utils/validation/password";
 import { isValidPhoneNumber } from "../utils/validation/phoneNumber";
+import { isAtLeast14YearsOld } from "../utils/validation/birthday";
 
 export const SIGN_UP_FORM_NAME = {
   IS_TERM_AGREED: "isTermAgreed",
@@ -37,6 +38,7 @@ const initialErrorMessage = {
   [SIGN_UP_FORM_NAME.PASSWORD]: "",
   [SIGN_UP_FORM_NAME.CONFIRM_PASSWORD]: "",
   [SIGN_UP_FORM_NAME.NAME]: "",
+  [SIGN_UP_FORM_NAME.BIRTHDAY]: "",
   [SIGN_UP_FORM_NAME.PHONE_NUMBER]: "",
   [SIGN_UP_FORM_NAME.GITHUB_USERNAME]: "",
 };
@@ -112,6 +114,11 @@ const useSignUpForm = () => {
   };
 
   const handleChangeBirthday = (date) => {
+    const errorMessage = isAtLeast14YearsOld(date)
+      ? ""
+      : ERROR_MESSAGE.VALIDATION.BIRTHDAY_IS_NOT_OVER_14;
+
+    updateErrorMessage(SIGN_UP_FORM_NAME.BIRTHDAY, errorMessage);
     updateRequiredForm(SIGN_UP_FORM_NAME.BIRTHDAY, date);
   };
 

--- a/frontend/src/pages/SignUp/SignUp.js
+++ b/frontend/src/pages/SignUp/SignUp.js
@@ -129,6 +129,7 @@ const SignUp = () => {
           name={SIGN_UP_FORM_NAME.BIRTHDAY}
           value={form[SIGN_UP_FORM_NAME.BIRTHDAY]}
           onChange={handleChanges[SIGN_UP_FORM_NAME.BIRTHDAY]}
+          errorMessage={errorMessage[SIGN_UP_FORM_NAME.BIRTHDAY]}
           required
         />
         <MessageTextInput

--- a/frontend/src/utils/validation/__tests__/birthday.test.ts
+++ b/frontend/src/utils/validation/__tests__/birthday.test.ts
@@ -1,0 +1,40 @@
+// birthday.test.ts
+import { isAtLeast14YearsOld } from "../birthday";
+
+describe("isAtLeast14YearsOld 함수 테스트", () => {
+  test("기준일로부터 생년월일이 만 14년을 초과한 경우, 만 14세 이상이어야 한다.", () => {
+    // given
+    const birthDate = "2009-05-27";
+    const givenDate = "2024-05-27";
+
+    // when
+    const result = isAtLeast14YearsOld(birthDate, givenDate);
+
+    // then
+    expect(result).toBe(true);
+  });
+
+  test("기준일로부터 생년월일이 정확히 만 14년인 경우, 만 14세 이상이어야 한다.", () => {
+    // given
+    const birthDate = "2010-05-27";
+    const givenDate = "2024-05-27";
+
+    // when
+    const result = isAtLeast14YearsOld(birthDate, givenDate);
+
+    // then
+    expect(result).toBe(true);
+  });
+
+  test("기준일로부터 생년월일이 만 14년이 되지 않은 경우, 만 14세 미만이어야 한다.", () => {
+    // given
+    const birthDate = "2010-05-28";
+    const givenDate = "2024-05-27";
+
+    // when
+    const result = isAtLeast14YearsOld(birthDate, givenDate);
+
+    // then
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/utils/validation/birthday.ts
+++ b/frontend/src/utils/validation/birthday.ts
@@ -1,0 +1,15 @@
+export function isAtLeast14YearsOld(birthDate: string, givenDate: string): boolean {
+  const TEENAGER_AGE = 14;
+
+  const given = givenDate ? new Date(givenDate) : new Date();
+  const birth = new Date(birthDate);
+
+  const age = given.getFullYear() - birth.getFullYear();
+  const monthDifference = given.getMonth() - birth.getMonth();
+  const dayDifference = given.getDate() - birth.getDate();
+
+  return (
+    age > TEENAGER_AGE ||
+    (age === TEENAGER_AGE && (monthDifference > 0 || (monthDifference === 0 && dayDifference >= 0)))
+  );
+}

--- a/src/main/kotlin/apply/application/MemberAuthenticationService.kt
+++ b/src/main/kotlin/apply/application/MemberAuthenticationService.kt
@@ -4,7 +4,9 @@ import apply.domain.authenticationcode.AuthenticationCode
 import apply.domain.authenticationcode.AuthenticationCodeRepository
 import apply.domain.authenticationcode.getLastByEmail
 import apply.domain.member.Member
+import apply.domain.member.MemberInformation
 import apply.domain.member.MemberRepository
+import apply.domain.member.MinimumAgeRequirement
 import apply.domain.member.UnidentifiedMemberException
 import apply.domain.member.existsByEmail
 import apply.domain.member.findByEmail
@@ -25,15 +27,22 @@ class MemberAuthenticationService(
         authenticationCodeRepository.getLastByEmail(request.email).validate(request.authenticationCode)
         val member = memberRepository.save(
             Member(
-                email = request.email,
-                password = request.password,
-                name = request.name,
-                birthday = request.birthday,
-                phoneNumber = request.phoneNumber,
-                githubUsername = request.githubUsername,
+                request.toMemberInformation(),
+                request.password,
+                MinimumAgeRequirement()
             )
         )
         return jwtTokenProvider.createToken(member.email)
+    }
+
+    private fun RegisterMemberRequest.toMemberInformation(): MemberInformation {
+        return MemberInformation(
+            email = email,
+            name = name,
+            birthday = birthday,
+            phoneNumber = phoneNumber,
+            githubUsername = githubUsername,
+        )
     }
 
     fun generateTokenByLogin(request: AuthenticateMemberRequest): String {

--- a/src/main/kotlin/apply/config/DatabaseInitializer.kt
+++ b/src/main/kotlin/apply/config/DatabaseInitializer.kt
@@ -25,6 +25,7 @@ import apply.domain.judgmentitem.ProgrammingLanguage
 import apply.domain.mail.MailHistory
 import apply.domain.mail.MailHistoryRepository
 import apply.domain.member.Member
+import apply.domain.member.MemberInformation
 import apply.domain.member.MemberRepository
 import apply.domain.member.Password
 import apply.domain.mission.Mission
@@ -254,36 +255,48 @@ class DatabaseInitializer(
     private fun populateMembers() {
         val members = listOf(
             Member(
-                name = "홍길동",
-                email = "a@email.com",
-                phoneNumber = "010-0000-0000",
-                githubUsername = "jaeyeonling",
-                birthday = createLocalDate(2020, 4, 17),
-                password = Password("password"),
+                MemberInformation(
+                    name = "홍길동",
+                    email = "a@email.com",
+                    phoneNumber = "010-0000-0000",
+                    githubUsername = "jaeyeonling",
+                    birthday = createLocalDate(2000, 4, 17),
+                ),
+                Password("password"),
+                {}
             ),
             Member(
-                name = "홍길동2",
-                email = "b@email.com",
-                phoneNumber = "010-0000-0000",
-                githubUsername = "jaeyeonling",
-                birthday = createLocalDate(2020, 5, 5),
+                MemberInformation(
+                    name = "홍길동2",
+                    email = "b@email.com",
+                    phoneNumber = "010-0000-0000",
+                    githubUsername = "jaeyeonling",
+                    birthday = createLocalDate(2000, 5, 5),
+                ),
                 password = Password("password"),
+                {}
             ),
             Member(
-                name = "홍길동3",
-                email = "c@email.com",
-                phoneNumber = "010-0000-0000",
-                githubUsername = "jaeyeonling",
-                birthday = createLocalDate(2020, 1, 1),
-                password = Password("password"),
+                MemberInformation(
+                    name = "홍길동3",
+                    email = "c@email.com",
+                    phoneNumber = "010-0000-0000",
+                    githubUsername = "jaeyeonling",
+                    birthday = createLocalDate(2000, 1, 1),
+                ),
+                Password("password"),
+                {}
             ),
             Member(
-                name = "홍길동4",
-                email = "d@email.com",
-                phoneNumber = "010-0000-0000",
-                githubUsername = "jaeyeonling",
-                birthday = createLocalDate(2020, 1, 1),
-                password = Password("password"),
+                MemberInformation(
+                    name = "홍길동4",
+                    email = "d@email.com",
+                    phoneNumber = "010-0000-0000",
+                    githubUsername = "jaeyeonling",
+                    birthday = createLocalDate(2000, 1, 1),
+                ),
+                Password("password"),
+                {}
             )
         )
         memberRepository.saveAll(members)

--- a/src/main/kotlin/apply/domain/member/AuthorizationRequirement.kt
+++ b/src/main/kotlin/apply/domain/member/AuthorizationRequirement.kt
@@ -1,5 +1,5 @@
 package apply.domain.member
 
 fun interface AuthorizationRequirement {
-    fun meets(information: MemberInformation): Boolean
+    fun require(information: MemberInformation)
 }

--- a/src/main/kotlin/apply/domain/member/AuthorizationRequirement.kt
+++ b/src/main/kotlin/apply/domain/member/AuthorizationRequirement.kt
@@ -1,0 +1,5 @@
+package apply.domain.member
+
+fun interface AuthorizationRequirement {
+    fun meets(information: MemberInformation): Boolean
+}

--- a/src/main/kotlin/apply/domain/member/Member.kt
+++ b/src/main/kotlin/apply/domain/member/Member.kt
@@ -2,6 +2,7 @@ package apply.domain.member
 
 import support.domain.BaseRootEntity
 import java.time.LocalDate
+import java.time.Period
 import javax.persistence.AttributeOverride
 import javax.persistence.Column
 import javax.persistence.Embedded
@@ -36,6 +37,11 @@ class Member(
 
     val githubUsername: String
         get() = information.githubUsername
+
+    init {
+        val age = Period.between(birthday, LocalDate.now()).years
+        require(age >= 14) { "만 14세 미만은 회원 가입할 수 없습니다." }
+    }
 
     constructor(
         email: String,

--- a/src/main/kotlin/apply/domain/member/Member.kt
+++ b/src/main/kotlin/apply/domain/member/Member.kt
@@ -2,7 +2,6 @@ package apply.domain.member
 
 import support.domain.BaseRootEntity
 import java.time.LocalDate
-import java.time.Period
 import javax.persistence.AttributeOverride
 import javax.persistence.Column
 import javax.persistence.Embedded
@@ -21,6 +20,7 @@ class Member(
     @AttributeOverride(name = "value", column = Column(name = "password", nullable = false))
     @Embedded
     var password: Password,
+    authorizationRequirement: AuthorizationRequirement,
     id: Long = 0L,
 ) : BaseRootEntity<Member>(id) {
     val email: String
@@ -39,29 +39,8 @@ class Member(
         get() = information.githubUsername
 
     init {
-        val age = Period.between(birthday, LocalDate.now()).years
-        require(age >= 14) { "만 14세 미만은 회원 가입할 수 없습니다." }
+        authorizationRequirement.require(information)
     }
-
-    constructor(
-        email: String,
-        password: Password,
-        name: String,
-        birthday: LocalDate,
-        phoneNumber: String,
-        githubUsername: String,
-        id: Long = 0L,
-    ) : this(
-        MemberInformation(
-            email = email,
-            name = name,
-            birthday = birthday,
-            phoneNumber = phoneNumber,
-            githubUsername = githubUsername
-        ),
-        password,
-        id,
-    )
 
     fun authenticate(password: Password) {
         identify(this.password == password) { "사용자 정보가 일치하지 않습니다." }

--- a/src/main/kotlin/apply/domain/member/MinimumAgeRequirement.kt
+++ b/src/main/kotlin/apply/domain/member/MinimumAgeRequirement.kt
@@ -1,0 +1,18 @@
+package apply.domain.member
+
+import java.time.LocalDate
+import java.time.Period
+
+class MinimumAgeRequirement(
+    private val age: Int = DEFAULT_MINIMUM_AGE,
+    private val baseDate: LocalDate = LocalDate.now(),
+) : AuthorizationRequirement {
+    override fun meets(information: MemberInformation): Boolean {
+        val age = Period.between(information.birthday, baseDate).years
+        return age >= DEFAULT_MINIMUM_AGE
+    }
+
+    companion object {
+        private const val DEFAULT_MINIMUM_AGE: Int = 14
+    }
+}

--- a/src/main/kotlin/apply/domain/member/MinimumAgeRequirement.kt
+++ b/src/main/kotlin/apply/domain/member/MinimumAgeRequirement.kt
@@ -7,9 +7,9 @@ class MinimumAgeRequirement(
     private val age: Int = DEFAULT_MINIMUM_AGE,
     private val baseDate: LocalDate = LocalDate.now(),
 ) : AuthorizationRequirement {
-    override fun meets(information: MemberInformation): Boolean {
+    override fun require(information: MemberInformation) {
         val age = Period.between(information.birthday, baseDate).years
-        return age >= DEFAULT_MINIMUM_AGE
+        require(age >= this.age) { "만 ${this.age}세 미만은 회원 가입할 수 없습니다." }
     }
 
     companion object {

--- a/src/test/kotlin/apply/MemberFixtures.kt
+++ b/src/test/kotlin/apply/MemberFixtures.kt
@@ -3,6 +3,7 @@ package apply
 import apply.application.AuthenticateMemberRequest
 import apply.application.RegisterMemberRequest
 import apply.domain.member.Member
+import apply.domain.member.MemberInformation
 import apply.domain.member.Password
 import support.createLocalDate
 import java.time.LocalDate
@@ -30,6 +31,16 @@ fun createMember(
     id: Long = 0L,
 ): Member {
     return Member(email, password, name, birthday, phoneNumber, githubUsername, id)
+}
+
+fun createMemberInformation(
+    email: String = EMAIL,
+    name: String = NAME,
+    birthday: LocalDate = BIRTHDAY,
+    phoneNumber: String = PHONE_NUMBER,
+    githubUsername: String = GITHUB_USERNAME,
+): MemberInformation {
+    return MemberInformation(email, name, birthday, phoneNumber, githubUsername)
 }
 
 fun createRegisterMemberRequest(

--- a/src/test/kotlin/apply/MemberFixtures.kt
+++ b/src/test/kotlin/apply/MemberFixtures.kt
@@ -2,6 +2,7 @@ package apply
 
 import apply.application.AuthenticateMemberRequest
 import apply.application.RegisterMemberRequest
+import apply.domain.member.AuthorizationRequirement
 import apply.domain.member.Member
 import apply.domain.member.MemberInformation
 import apply.domain.member.Password
@@ -28,9 +29,15 @@ fun createMember(
     birthday: LocalDate = BIRTHDAY,
     phoneNumber: String = PHONE_NUMBER,
     githubUsername: String = GITHUB_USERNAME,
+    authorizationRequirement: AuthorizationRequirement = AuthorizationRequirement {},
     id: Long = 0L,
 ): Member {
-    return Member(email, password, name, birthday, phoneNumber, githubUsername, id)
+    return Member(
+        createMemberInformation(email, name, birthday, phoneNumber, githubUsername),
+        password,
+        authorizationRequirement,
+        id
+    )
 }
 
 fun createMemberInformation(

--- a/src/test/kotlin/apply/domain/member/MemberTest.kt
+++ b/src/test/kotlin/apply/domain/member/MemberTest.kt
@@ -7,8 +7,14 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.time.LocalDate
 
 class MemberTest : StringSpec({
+    "만 14세 미만은 회원 가입할 수 없다" {
+        val birthday = LocalDate.now().plusYears(13L)
+        shouldThrow<IllegalArgumentException> { createMember(birthday = birthday) }
+    }
+
     "회원의 비밀번호와 일치하는지 확인한다" {
         val member = createMember()
         shouldNotThrowAny { member.authenticate(PASSWORD) }

--- a/src/test/kotlin/apply/domain/member/MemberTest.kt
+++ b/src/test/kotlin/apply/domain/member/MemberTest.kt
@@ -11,8 +11,11 @@ import java.time.LocalDate
 
 class MemberTest : StringSpec({
     "만 14세 미만은 회원 가입할 수 없다" {
-        val birthday = LocalDate.now().plusYears(13L)
-        shouldThrow<IllegalArgumentException> { createMember(birthday = birthday) }
+        val now = LocalDate.now()
+        val requirement = MinimumAgeRequirement(age = 14, baseDate = now)
+        shouldThrow<IllegalArgumentException> {
+            createMember(birthday = now, authorizationRequirement = requirement)
+        }
     }
 
     "회원의 비밀번호와 일치하는지 확인한다" {

--- a/src/test/kotlin/apply/domain/member/MinimumAgeRequirementTest.kt
+++ b/src/test/kotlin/apply/domain/member/MinimumAgeRequirementTest.kt
@@ -1,0 +1,29 @@
+package apply.domain.member
+
+import apply.createMemberInformation
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import java.time.LocalDate
+
+class MinimumAgeRequirementTest : StringSpec({
+    val requirement = MinimumAgeRequirement(14, LocalDate.of(2024, 5, 30))
+
+    "만 14세 이상은 최소 연령 요건을 충족한다" {
+        val information = createMemberInformation(birthday = LocalDate.of(2010, 5, 1))
+        val actual = requirement.meets(information)
+        actual.shouldBeTrue()
+    }
+
+    "만 14세 미만은 최소 연령 요건을 충족하지 않는다" {
+        val information = createMemberInformation(birthday = LocalDate.of(2010, 5, 31))
+        val actual = requirement.meets(information)
+        actual.shouldBeFalse()
+    }
+
+    "기준일이 생일과 같으면 만 나이가 늘어난다" {
+        val information = createMemberInformation(birthday = LocalDate.of(2010, 5, 30))
+        val actual = requirement.meets(information)
+        actual.shouldBeTrue()
+    }
+})

--- a/src/test/kotlin/apply/domain/member/MinimumAgeRequirementTest.kt
+++ b/src/test/kotlin/apply/domain/member/MinimumAgeRequirementTest.kt
@@ -1,29 +1,26 @@
 package apply.domain.member
 
 import apply.createMemberInformation
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.booleans.shouldBeTrue
 import java.time.LocalDate
 
 class MinimumAgeRequirementTest : StringSpec({
-    val requirement = MinimumAgeRequirement(14, LocalDate.of(2024, 5, 30))
+    val requirement = MinimumAgeRequirement(age = 14, baseDate = LocalDate.of(2024, 5, 30))
 
     "만 14세 이상은 최소 연령 요건을 충족한다" {
         val information = createMemberInformation(birthday = LocalDate.of(2010, 5, 1))
-        val actual = requirement.meets(information)
-        actual.shouldBeTrue()
+        shouldNotThrowAny { requirement.require(information) }
     }
 
     "만 14세 미만은 최소 연령 요건을 충족하지 않는다" {
         val information = createMemberInformation(birthday = LocalDate.of(2010, 5, 31))
-        val actual = requirement.meets(information)
-        actual.shouldBeFalse()
+        shouldThrow<IllegalArgumentException> { requirement.require(information) }
     }
 
     "기준일이 생일과 같으면 만 나이가 늘어난다" {
         val information = createMemberInformation(birthday = LocalDate.of(2010, 5, 30))
-        val actual = requirement.meets(information)
-        actual.shouldBeTrue()
+        shouldNotThrowAny { requirement.require(information) }
     }
 })


### PR DESCRIPTION
Resolves #742 
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 개인정보 보호법에 따라 만 14세 미만 아동의 가입을 금지하고자 합니다.

# 어떻게 해결했나요?

- 클라이언트에서 서버에 이르기까지 모든 곳에 만 나이 유효성 검사 로직을 넣었습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 최소 가입 연령, 최대 가입 연령 등 다양한 가입 조건을 충족할 수 있도록 모델링하고 구현하였습니다.

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
