### PR TITLE
test(apply): fix broken tests due to updated hook return types

### DIFF
--- a/frontend/src/components/MyApplicationItem/MyMissionItem/__tests__/MyMissionItem.test.tsx
+++ b/frontend/src/components/MyApplicationItem/MyMissionItem/__tests__/MyMissionItem.test.tsx
@@ -10,9 +10,9 @@ import { PARAM, PATH } from "../../../../constants/path";
 import { Mission } from "../../../../../types/domains/recruitments";
 import { BUTTON_LABEL } from "../../../../constants/recruitment";
 
-jest.mock("../useMission");
-jest.mock("../useRefresh");
-jest.mock("../useMissionJudgment");
+jest.mock("../../../../hooks/useMission");
+jest.mock("../../../../hooks/useRefresh");
+jest.mock("../../../../hooks/useMissionJudgment");
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -27,15 +27,10 @@ describe("MyMissionItem 컴포넌트 테스트", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useMission as jest.Mock).mockReturnValue({
-      getter: {
-        missionItem: MISSION_ITEM,
-        applyButtonLabel: BUTTON_LABEL.SUBMIT,
-        formattedStartDateTime: "2023-01-01 00:00",
-        formattedEndDateTime: "2023-01-31 23:59",
-      },
-      setter: {
-        setMissionItem: jest.fn(),
-      },
+      missionItem: MISSION_ITEM,
+      applyButtonLabel: BUTTON_LABEL.SUBMIT,
+      formattedStartDateTime: "2023-01-01 00:00",
+      formattedEndDateTime: "2023-01-31 23:59",
     });
     (useRefresh as jest.Mock).mockReturnValue({ requestRefresh: jest.fn() });
     (useMissionJudgment as jest.Mock).mockReturnValue({
@@ -58,15 +53,11 @@ describe("MyMissionItem 컴포넌트 테스트", () => {
 
     it("미션 상태가 제출 중이 아닐 때 과제 제출 버튼이 비활성화되어야 한다", () => {
       (useMission as jest.Mock).mockReturnValue({
-        getter: {
-          missionItem: { ...MISSION_ITEM, status: "NOT_SUBMITTING" },
-          applyButtonLabel: BUTTON_LABEL.SUBMIT,
-          formattedStartDateTime: "2023-01-01 00:00",
-          formattedEndDateTime: "2023-01-31 23:59",
-        },
-        setter: {
-          setMissionItem: jest.fn(),
-        },
+        missionItem: { ...MISSION_ITEM, status: "NOT_SUBMITTING" },
+        applyButtonLabel: BUTTON_LABEL.SUBMIT,
+        formattedStartDateTime: "2023-01-01 00:00",
+        formattedEndDateTime: "2023-01-31 23:59",
+        setMissionItem: jest.fn(),
       });
 
       render(
@@ -105,15 +96,11 @@ describe("MyMissionItem 컴포넌트 테스트", () => {
     it("미션 과제 제출물 미제출 시, 'new' 상태로 과제 제출 페이지로 이동해야 한다", () => {
       const mockMission: Mission = { ...MISSION_ITEM, submitted: false, status: "SUBMITTING" };
       (useMission as jest.Mock).mockReturnValue({
-        getter: {
-          missionItem: mockMission,
-          applyButtonLabel: BUTTON_LABEL.SUBMIT,
-          formattedStartDateTime: "2023-01-01 00:00",
-          formattedEndDateTime: "2023-01-31 23:59",
-        },
-        setter: {
-          setMissionItem: jest.fn(),
-        },
+        missionItem: mockMission,
+        applyButtonLabel: BUTTON_LABEL.SUBMIT,
+        formattedStartDateTime: "2023-01-01 00:00",
+        formattedEndDateTime: "2023-01-31 23:59",
+        setMissionItem: jest.fn(),
       });
 
       render(<MyMissionItem recruitmentId={RECRUITMENT_ID} mission={mockMission} />);
@@ -138,15 +125,11 @@ describe("MyMissionItem 컴포넌트 테스트", () => {
     it("미션 과제 제출물 제출 시, 'edit' 상태로 과제 제출 페이지로 이동해야 한다", () => {
       const mockMission: Mission = { ...MISSION_ITEM, submitted: true, status: "SUBMITTING" };
       (useMission as jest.Mock).mockReturnValue({
-        getter: {
-          missionItem: mockMission,
-          applyButtonLabel: BUTTON_LABEL.EDIT,
-          formattedStartDateTime: "2023-01-01 00:00",
-          formattedEndDateTime: "2023-01-31 23:59",
-        },
-        setter: {
-          setMissionItem: jest.fn(),
-        },
+        missionItem: mockMission,
+        applyButtonLabel: BUTTON_LABEL.EDIT,
+        formattedStartDateTime: "2023-01-01 00:00",
+        formattedEndDateTime: "2023-01-31 23:59",
+        setMissionItem: jest.fn(),
       });
 
       render(

--- a/frontend/src/components/MyApplicationItem/MyMissionItem/__tests__/testMissionMockUtils.ts
+++ b/frontend/src/components/MyApplicationItem/MyMissionItem/__tests__/testMissionMockUtils.ts
@@ -15,6 +15,7 @@ export function createMockMission(overrides: Partial<Mission> = {}): Mission {
     status: MISSION_STATUS.SUBMITTING,
     testable: true,
     judgment: null,
+    submissionMethod: "PUBLIC_PULL_REQUEST",
   };
 
   return {
@@ -33,6 +34,7 @@ export function createMockJudgment(overrides: Partial<Judgment> = {}): Judgment 
     message: "",
     startedDateTime: "2023-06-01T12:00:00" as ISO8601DateString,
     commitUrl: "https://github.com/test/commit",
+    url: "https://github.com/test",
   };
 
   return {

--- a/frontend/src/components/MyApplicationItem/MyMissionItem/__tests__/useMission.test.ts
+++ b/frontend/src/components/MyApplicationItem/MyMissionItem/__tests__/useMission.test.ts
@@ -27,7 +27,7 @@ describe("useMission 훅 테스트", () => {
         useMission({ mission: mockMission, recruitmentId: mockRecruitmentId })
       );
 
-      expect(result.current.getter).toEqual(
+      expect(result.current).toEqual(
         expect.objectContaining({
           missionItem: expect.objectContaining({ ...mockMission }),
           applyButtonLabel: BUTTON_LABEL.SUBMIT,
@@ -50,7 +50,7 @@ describe("useMission 훅 테스트", () => {
       const updatedMission = { ...mockMission, title: "Updated Mission" };
       rerender({ mission: updatedMission });
 
-      expect(result.current.getter.missionItem).toEqual(updatedMission);
+      expect(result.current.missionItem).toEqual(updatedMission);
     });
   });
 });


### PR DESCRIPTION

<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 전체 테스트를 실행했을 때 실패하는 테스트가 있습니다. 

# 어떻게 해결했나요?

- `useMission` 훅에서 리턴하는 값의 형식이 변경된 부분을 테스트에서의 mock 데이터 형식에도 반영합니다. 
- `Mission`, `Judgment` 타입에 필수값으로 지정된 프로퍼티들을 테스트 데이터에도 지정해줍니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 우선 테스트가 깨지는 부분만 해결하였습니다. 
- 모킹 방식 자체에서 개선할 부분이 있다면 별도로 개선해보면 좋을 것 같습니다 :)

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
