### PR TITLE
feat(mail): support bilingual emails in korean and english

### DIFF
--- a/src/main/kotlin/apply/application/mail/MailService.kt
+++ b/src/main/kotlin/apply/application/mail/MailService.kt
@@ -82,7 +82,7 @@ class MailService(
         }
         mailSender.send(
             email,
-            "메일 인증 코드를 발송해 드립니다.",
+            "Email verification code issued / 메일 인증 코드를 발송해 드립니다.",
             templateEngine.process("mail/email-authentication.html", context)
         )
     }

--- a/src/main/kotlin/apply/application/mail/MailService.kt
+++ b/src/main/kotlin/apply/application/mail/MailService.kt
@@ -65,7 +65,7 @@ class MailService(
         }
         mailSender.send(
             member.email,
-            "${member.name}님, 지원이 완료되었습니다.",
+            "Your application has been submitted / ${member.name}님, 지원이 완료되었습니다.",
             templateEngine.process("mail/submission-complete", context)
         )
     }

--- a/src/main/kotlin/apply/application/mail/MailService.kt
+++ b/src/main/kotlin/apply/application/mail/MailService.kt
@@ -44,7 +44,7 @@ class MailService(
         }
         mailSender.send(
             event.email,
-            "Temporary password issued / ${event.name}님, 임시 비밀번호를 발송해 드립니다.",
+            "Temporary password issued / 임시 비밀번호를 발송해 드립니다.",
             templateEngine.process("mail/password-reset", context)
         )
     }
@@ -65,7 +65,7 @@ class MailService(
         }
         mailSender.send(
             member.email,
-            "Your application has been submitted / ${member.name}님, 지원이 완료되었습니다.",
+            "Your application has been submitted / 지원이 완료되었습니다.",
             templateEngine.process("mail/submission-complete", context)
         )
     }

--- a/src/main/kotlin/apply/application/mail/MailService.kt
+++ b/src/main/kotlin/apply/application/mail/MailService.kt
@@ -44,7 +44,7 @@ class MailService(
         }
         mailSender.send(
             event.email,
-            "${event.name}님, 임시 비밀번호를 발송해 드립니다.",
+            "Temporary password issued / ${event.name}님, 임시 비밀번호를 발송해 드립니다.",
             templateEngine.process("mail/password-reset", context)
         )
     }

--- a/src/main/kotlin/apply/application/mail/MailService.kt
+++ b/src/main/kotlin/apply/application/mail/MailService.kt
@@ -44,7 +44,7 @@ class MailService(
         }
         mailSender.send(
             event.email,
-            "Temporary password issued / 임시 비밀번호를 발송해 드립니다.",
+            "Your temporary password / 임시 비밀번호 발급 안내",
             templateEngine.process("mail/password-reset", context)
         )
     }
@@ -65,7 +65,7 @@ class MailService(
         }
         mailSender.send(
             member.email,
-            "Your application has been submitted / 지원이 완료되었습니다.",
+            "Application received / 지원 접수 완료 안내",
             templateEngine.process("mail/submission-complete", context)
         )
     }
@@ -82,7 +82,7 @@ class MailService(
         }
         mailSender.send(
             email,
-            "Email verification code issued / 메일 인증 코드를 발송해 드립니다.",
+            "Email verification code / 이메일 인증 코드 안내",
             templateEngine.process("mail/email-authentication.html", context)
         )
     }

--- a/src/main/resources/templates/mail/common.html
+++ b/src/main/resources/templates/mail/common.html
@@ -143,7 +143,10 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
+                      Copyright
+                      <span th:text="${#temporals.year(#temporals.createNow())}"
+                        >2025</span
+                      >. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/common.html
+++ b/src/main/resources/templates/mail/common.html
@@ -143,7 +143,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright 2021. 우아한테크코스. All rights reserved.
+                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/email-authentication.html
+++ b/src/main/resources/templates/mail/email-authentication.html
@@ -68,7 +68,8 @@
                         padding-top: 48px;
                       "
                     >
-                      이메일 인증 코드
+                      Email Verification Code<br />
+                      <span style="margin-top: 8px; display: block;">이메일 인증 코드</span>
                     </td>
                   </tr>
                   <tr>
@@ -110,9 +111,13 @@
                         text-align: center;
                       "
                     >
-                      이메일 인증 코드가 발급되었습니다.
-                      <br />
-                      해당 문자를 인증 코드 입력창에 입력해 주세요.
+                      Here is your email verification code.<br />
+                      Please enter the verification code to verify your email.
+                      <br /><br />
+                      <span style="display: block; margin-top: 24px; color: #666666;">
+                        이메일 인증 코드가 발급되었습니다.<br />
+                        해당 문자를 인증 코드 입력창에 입력해 주세요.
+                      </span>
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/email-authentication.html
+++ b/src/main/resources/templates/mail/email-authentication.html
@@ -69,7 +69,9 @@
                       "
                     >
                       Email Verification Code<br />
-                      <span style="margin-top: 8px; display: block;">이메일 인증 코드</span>
+                      <span style="margin-top: 8px; display: block"
+                        >이메일 인증 코드</span
+                      >
                     </td>
                   </tr>
                   <tr>
@@ -114,7 +116,9 @@
                       Here is your email verification code.<br />
                       Please enter the verification code to verify your email.
                       <br /><br />
-                      <span style="display: block; margin-top: 24px; color: #666666;">
+                      <span
+                        style="display: block; margin-top: 24px; color: #666666"
+                      >
                         이메일 인증 코드가 발급되었습니다.<br />
                         해당 문자를 인증 코드 입력창에 입력해 주세요.
                       </span>
@@ -197,7 +201,10 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
+                      Copyright
+                      <span th:text="${#temporals.year(#temporals.createNow())}"
+                        >2025</span
+                      >. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/email-authentication.html
+++ b/src/main/resources/templates/mail/email-authentication.html
@@ -197,7 +197,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright 2021. 우아한테크코스. All rights reserved.
+                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/email-authentication.html
+++ b/src/main/resources/templates/mail/email-authentication.html
@@ -114,13 +114,13 @@
                       "
                     >
                       Here is your email verification code.<br />
-                      Please enter the verification code to verify your email.
+                      Please enter this code to verify your email address.
                       <br /><br />
                       <span
                         style="display: block; margin-top: 24px; color: #666666"
                       >
                         이메일 인증 코드가 발급되었습니다.<br />
-                        해당 문자를 인증 코드 입력창에 입력해 주세요.
+                        인증 코드를 입력하여 이메일 인증을 완료해 주세요.
                       </span>
                     </td>
                   </tr>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -69,7 +69,9 @@
                       "
                     >
                       Temporary Password Issued<br />
-                      <span style="margin-top: 8px; display: block;">임시 비밀번호 발급</span>
+                      <span style="margin-top: 8px; display: block"
+                        >임시 비밀번호 발급</span
+                      >
                     </td>
                   </tr>
                   <tr>
@@ -113,10 +115,14 @@
                       A temporary password has been issued for your account.<br />
                       Please log in and reset your password to a new one.
                       <br /><br />
-                      <span style="display: block; margin-top: 24px; color: #666666;">
-                        안녕하세요. <span th:text="${name}"></span>님.<br /><br />
+                      <span
+                        style="display: block; margin-top: 24px; color: #666666"
+                      >
+                        안녕하세요.
+                        <span th:text="${name}"></span>님.<br /><br />
                         임시 비밀번호가 발급되었습니다.<br />
-                        로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정해 주세요.
+                        로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정해
+                        주세요.
                       </span>
                     </td>
                   </tr>
@@ -151,8 +157,18 @@
                                 text-decoration: none;
                               "
                             >
-                              <span style="font-size: 15px; display: block;">Go to Login Page</span>
-                              <span style="font-size: 13px; display: block; margin-top: 2px; opacity: 0.9;">로그인 페이지로 이동</span>
+                              <span style="font-size: 15px; display: block"
+                                >Go to Login Page</span
+                              >
+                              <span
+                                style="
+                                  font-size: 13px;
+                                  display: block;
+                                  margin-top: 2px;
+                                  opacity: 0.9;
+                                "
+                                >로그인 페이지로 이동</span
+                              >
                             </a>
                           </td>
                         </tr>
@@ -236,7 +252,10 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
+                      Copyright
+                      <span th:text="${#temporals.year(#temporals.createNow())}"
+                        >2025</span
+                      >. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -119,7 +119,7 @@
                       <span
                         style="display: block; margin-top: 24px; color: #666666"
                       >
-                        안녕하세요.
+                        안녕하세요,
                         <span th:text="${name}"></span>님.<br /><br />
                         계정에 대한 임시 비밀번호가 발급되었습니다.<br />
                         해당 비밀번호로 로그인한 뒤, 반드시 새로운 비밀번호로

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -113,16 +113,17 @@
                     >
                       Hello <span th:text="${name}"></span>,<br /><br />
                       A temporary password has been issued for your account.<br />
-                      Please log in and reset your password to a new one.
+                      Please log in with this temporary password and set a new
+                      password immediately.
                       <br /><br />
                       <span
                         style="display: block; margin-top: 24px; color: #666666"
                       >
                         안녕하세요.
                         <span th:text="${name}"></span>님.<br /><br />
-                        임시 비밀번호가 발급되었습니다.<br />
-                        로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정해
-                        주세요.
+                        계정에 대한 임시 비밀번호가 발급되었습니다.<br />
+                        해당 비밀번호로 로그인한 뒤, 반드시 새로운 비밀번호로
+                        변경해 주세요.
                       </span>
                     </td>
                   </tr>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -68,7 +68,8 @@
                         padding-top: 48px;
                       "
                     >
-                      임시 비밀번호 발급
+                      Temporary Password Issued<br />
+                      <span style="margin-top: 8px; display: block;">임시 비밀번호 발급</span>
                     </td>
                   </tr>
                   <tr>
@@ -108,11 +109,15 @@
                         text-align: center;
                       "
                     >
-                      안녕하세요. <span th:text="${name}"></span>님.
+                      Hello <span th:text="${name}"></span>,<br /><br />
+                      A temporary password has been issued for your account.<br />
+                      Please log in and reset your password to a new one.
                       <br /><br />
-                      임시 비밀번호가 발급되었습니다. <br />
-                      로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정해
-                      주세요.
+                      <span style="display: block; margin-top: 24px; color: #666666;">
+                        안녕하세요. <span th:text="${name}"></span>님.<br /><br />
+                        임시 비밀번호가 발급되었습니다.<br />
+                        로그인 후 임시 비밀번호를 새로운 비밀번호로 재설정해 주세요.
+                      </span>
                     </td>
                   </tr>
                   <tr>
@@ -139,17 +144,15 @@
                                 background-color: #333333;
                                 color: #ffffff;
                                 display: block;
-                                padding-top: 6px;
-                                padding-bottom: 6px;
-                                padding-left: 26px;
-                                padding-right: 26px;
+                                padding: 8px 24px;
                                 text-align: center;
                                 border-radius: 4px;
                                 cursor: pointer;
                                 text-decoration: none;
                               "
                             >
-                              로그인 페이지로 이동
+                              <span style="font-size: 15px; display: block;">Go to Login Page</span>
+                              <span style="font-size: 13px; display: block; margin-top: 2px; opacity: 0.9;">로그인 페이지로 이동</span>
                             </a>
                           </td>
                         </tr>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -236,7 +236,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright 2021. 우아한테크코스. All rights reserved.
+                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/submission-complete.html
+++ b/src/main/resources/templates/mail/submission-complete.html
@@ -68,7 +68,8 @@
                         padding-top: 48px;
                       "
                     >
-                      지원 완료
+                      Application Received<br/>
+                      <span style="margin-top: 8px; display: block;">지원 완료</span>
                     </td>
                   </tr>
                   <tr style="color: #333333; padding: 0; font-size: 16px">
@@ -84,12 +85,17 @@
                         text-align: center;
                       "
                     >
-                      안녕하세요. <span th:text="${name}"></span>님.
+                      Hello <span th:text="${name}"></span>,<br /><br />
+                      Your application for the <strong><span th:text="${recruit}"></span></strong> has been successfully submitted.<br />
+                      We will keep you updated on the next steps via this email. Please stay tuned for further updates.<br /><br />
+                      Thank you for your application. We appreciate it!
                       <br /><br />
-                      우아한테크코스 <span th:text="${recruit}"></span> 지원이
-                      완료되었습니다.<br />추후 진행 사항은 해당 이메일을 통해
-                      안내됩니다. <br /><br />
-                      감사합니다.
+                      <span style="display: block; margin-top: 24px; color: #666666;">
+                        안녕하세요. <span th:text="${name}"></span>님.<br /><br />
+                        우아한테크코스 <span th:text="${recruit}"></span> 지원이 완료되었습니다.<br />
+                        추후 진행 사항은 해당 이메일을 통해 안내됩니다.<br /><br />
+                        감사합니다.
+                      </span>
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/submission-complete.html
+++ b/src/main/resources/templates/mail/submission-complete.html
@@ -88,22 +88,24 @@
                       "
                     >
                       Hello <span th:text="${name}"></span>,<br /><br />
-                      Your application for the
-                      <strong><span th:text="${recruit}"></span></strong> has
-                      been successfully submitted.<br />
-                      We will keep you updated on the next steps via this email.
-                      Please stay tuned for further updates.<br /><br />
-                      Thank you for your application. We appreciate it!
+                      Thank you for applying to
+                      <strong><span th:text="${recruit}"></span></strong>.<br />
+                      We have successfully received your application.<br /><br />
+                      We will review your application and notify you of the next
+                      steps by email.<br />
+                      Thank you again for your interest.
                       <br /><br />
                       <span
                         style="display: block; margin-top: 24px; color: #666666"
                       >
-                        안녕하세요.
+                        안녕하세요,
                         <span th:text="${name}"></span>님.<br /><br />
-                        <span th:text="${recruit}"></span> 지원이
-                        완료되었습니다.<br />
-                        추후 진행 사항은 해당 이메일을 통해 안내됩니다.<br /><br />
-                        감사합니다.
+                        <strong><span th:text="${recruit}"></span></strong>에
+                        지원해 주셔서 감사합니다.<br />
+                        지원서가 정상적으로 접수되었습니다.<br /><br />
+                        지원서 검토 후 이후 진행 절차를 이메일로 안내해 드릴
+                        예정입니다.<br />
+                        관심을 가져 주셔서 다시 한번 감사합니다.
                       </span>
                     </td>
                   </tr>

--- a/src/main/resources/templates/mail/submission-complete.html
+++ b/src/main/resources/templates/mail/submission-complete.html
@@ -92,7 +92,7 @@
                       <br /><br />
                       <span style="display: block; margin-top: 24px; color: #666666;">
                         안녕하세요. <span th:text="${name}"></span>님.<br /><br />
-                        우아한테크코스 <span th:text="${recruit}"></span> 지원이 완료되었습니다.<br />
+                        <span th:text="${recruit}"></span> 지원이 완료되었습니다.<br />
                         추후 진행 사항은 해당 이메일을 통해 안내됩니다.<br /><br />
                         감사합니다.
                       </span>
@@ -175,7 +175,7 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright 2021. 우아한테크코스. All rights reserved.
+                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/main/resources/templates/mail/submission-complete.html
+++ b/src/main/resources/templates/mail/submission-complete.html
@@ -68,8 +68,10 @@
                         padding-top: 48px;
                       "
                     >
-                      Application Received<br/>
-                      <span style="margin-top: 8px; display: block;">지원 완료</span>
+                      Application Received<br />
+                      <span style="margin-top: 8px; display: block"
+                        >지원 완료</span
+                      >
                     </td>
                   </tr>
                   <tr style="color: #333333; padding: 0; font-size: 16px">
@@ -86,13 +88,20 @@
                       "
                     >
                       Hello <span th:text="${name}"></span>,<br /><br />
-                      Your application for the <strong><span th:text="${recruit}"></span></strong> has been successfully submitted.<br />
-                      We will keep you updated on the next steps via this email. Please stay tuned for further updates.<br /><br />
+                      Your application for the
+                      <strong><span th:text="${recruit}"></span></strong> has
+                      been successfully submitted.<br />
+                      We will keep you updated on the next steps via this email.
+                      Please stay tuned for further updates.<br /><br />
                       Thank you for your application. We appreciate it!
                       <br /><br />
-                      <span style="display: block; margin-top: 24px; color: #666666;">
-                        안녕하세요. <span th:text="${name}"></span>님.<br /><br />
-                        <span th:text="${recruit}"></span> 지원이 완료되었습니다.<br />
+                      <span
+                        style="display: block; margin-top: 24px; color: #666666"
+                      >
+                        안녕하세요.
+                        <span th:text="${name}"></span>님.<br /><br />
+                        <span th:text="${recruit}"></span> 지원이
+                        완료되었습니다.<br />
                         추후 진행 사항은 해당 이메일을 통해 안내됩니다.<br /><br />
                         감사합니다.
                       </span>
@@ -175,7 +184,10 @@
                       id="copyright"
                       style="padding: 0; color: #666666; font-size: 12px"
                     >
-                      Copyright <span th:text="${#temporals.year(#temporals.createNow())}">2025</span>. 테크코스. All rights reserved.
+                      Copyright
+                      <span th:text="${#temporals.year(#temporals.createNow())}"
+                        >2025</span
+                      >. 테크코스. All rights reserved.
                     </td>
                   </tr>
                 </table>

--- a/src/test/kotlin/apply/application/mail/MailServiceIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/mail/MailServiceIntegrationTest.kt
@@ -55,7 +55,7 @@ class MailServiceIntegrationTest(
 
             Then("이메일 본문이 생성된다") {
                 actual shouldContain "Hello <span>홍길동</span>,"
-                actual shouldContain "안녕하세요. <span>홍길동</span>님."
+                actual shouldContain "안녕하세요, <span>홍길동</span>님."
                 actual shouldContain "Copyright <span>${LocalDate.now().year}</span>."
             }
         }

--- a/src/test/kotlin/apply/application/mail/MailServiceIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/mail/MailServiceIntegrationTest.kt
@@ -5,12 +5,16 @@ import apply.createMailData
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.string.shouldContain
 import org.springframework.context.annotation.Import
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring5.ISpringTemplateEngine
 import support.test.IntegrationTest
+import java.time.LocalDate
 
 @Import(TestMailConfiguration::class)
 @IntegrationTest
 class MailServiceIntegrationTest(
-    private val mailService: MailService
+    private val mailService: MailService,
+    private val templateEngine: ISpringTemplateEngine,
 ) : BehaviorSpec({
     Given("마크다운으로 본문을 작성한 이메일이 있는 경우") {
         val body = """
@@ -28,6 +32,28 @@ class MailServiceIntegrationTest(
                     |<p>안녕하세요. 우아한테크코스입니다.<br />
                     |오늘은 미션 안내와 더불어 2주 차부터 시작되는 커뮤니티에 대한 가이드도 함께 공유드리니 <strong>반드시 이메일 내용을 꼼꼼하게 정독</strong>해 주세요.</p>
                 """.trimMargin()
+            }
+        }
+    }
+
+    Given("이메일 템플릿이 있는 경우") {
+        val context = Context().apply {
+            setVariables(
+                mapOf(
+                    "name" to "홍길동",
+                    "recruit" to "우아한테크코스 웹 백엔드 8기",
+                    "url" to "https://apply.techcourse.co.kr",
+                )
+            )
+        }
+
+        When("템플릿 엔진으로 이메일을 렌더링하면") {
+            val actual = templateEngine.process("mail/submission-complete", context)
+
+            Then("이메일 본문이 생성된다") {
+                actual shouldContain "Hello <span>홍길동</span>,"
+                actual shouldContain "안녕하세요. <span>홍길동</span>님."
+                actual shouldContain "Copyright <span>${LocalDate.now().year}</span>."
             }
         }
     }

--- a/src/test/kotlin/apply/application/mail/MailServiceIntegrationTest.kt
+++ b/src/test/kotlin/apply/application/mail/MailServiceIntegrationTest.kt
@@ -49,6 +49,9 @@ class MailServiceIntegrationTest(
 
         When("템플릿 엔진으로 이메일을 렌더링하면") {
             val actual = templateEngine.process("mail/submission-complete", context)
+                .replace("\\s+".toRegex(), " ")
+                .replace("<(\\w+)\\s+>".toRegex(), "<$1>")
+                .replace("</(\\w+)\\s+>".toRegex(), "</$1>")
 
             Then("이메일 본문이 생성된다") {
                 actual shouldContain "Hello <span>홍길동</span>,"


### PR DESCRIPTION
Resolves #776 

# 해결하려는 문제가 무엇인가요?

- 자동 전송되는 이메일을 글로벌 사용자도 이해할 수 있도록 개선하였습니다.

# 어떻게 해결했나요?

- 메일 템플릿에 영어/한글을 함께 표기하도록 수정하였습니다.
   - 지원 화면 > 가입하기 > 이메일 인증
   - 지원 화면 > 로그인 > 비밀번호 찾기
   - 지원 화면 > 지원서 최종 제출
   - 관리 화면 > 메일 관리 > 메일 보내기

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 실제 수신 화면에서 내용을 이해하는 데 불편함이 없는지 확인해 주세요.
- 영어 문장과 표현 중 자연스럽지 않은 부분은 없는지 확인해 주세요.

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
