### PR TITLE
fix(apply): improve multiline display and add reset confirmation

### DIFF
--- a/frontend/src/hooks/useApplicationRegisterForm.js
+++ b/frontend/src/hooks/useApplicationRegisterForm.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import * as Api from "../api";
 import { FORM } from "../constants/form";
-import { ERROR_MESSAGE } from "../constants/messages";
+import { CONFIRM_MESSAGE, ERROR_MESSAGE } from "../constants/messages";
 import { PATH, PARAM } from "../constants/path";
 import { formatDateTime } from "../utils/format/date";
 import { isValidUrl } from "../utils/validation/url";
@@ -122,6 +122,8 @@ const useApplicationRegisterForm = ({
   }, [status]);
 
   const reset = () => {
+    if (!window.confirm(CONFIRM_MESSAGE.RESET_APPLICATION)) return;
+
     setRequiredForm(requiredFormInitialValue);
     setForm(formInitialValue);
     setErrorMessage(errorMessageInitialValue);

--- a/frontend/src/hooks/useApplicationRegisterForm.js
+++ b/frontend/src/hooks/useApplicationRegisterForm.js
@@ -122,7 +122,9 @@ const useApplicationRegisterForm = ({
   }, [status]);
 
   const reset = () => {
-    if (!window.confirm(CONFIRM_MESSAGE.RESET_APPLICATION)) return;
+    if (!window.confirm(CONFIRM_MESSAGE.RESET_APPLICATION)) {
+      return;
+    }
 
     setRequiredForm(requiredFormInitialValue);
     setForm(formInitialValue);

--- a/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
+++ b/frontend/src/pages/ApplicationRegister/ApplicationRegister.js
@@ -138,7 +138,7 @@ const ApplicationRegister = () => {
       <Container title="지원서 작성" titleAlign={TITLE_ALIGN.LEFT}>
         <h3 className={styles["recruitment-title"]}>{currentRecruitment.title}</h3>
         <Form onSubmit={handleSubmit}>
-          {status === PARAM.APPLICATION_FORM_STATUS.EDIT && (
+          {modifiedDateTime && (
             <p className={styles["autosave-indicator"]}>
               {`임시 저장되었습니다. (${modifiedDateTime})`}
             </p>

--- a/frontend/src/pages/MissionView/MissionView.module.css
+++ b/frontend/src/pages/MissionView/MissionView.module.css
@@ -17,3 +17,7 @@
 .mission-viewer-body li {
   list-style: disc;
 }
+
+.mission-viewer-body pre code {
+  tab-size: 10;
+}


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10, resolves #123
-->

# 해결하려는 문제가 무엇인가요?

- 치명적이지는 않지만, UI/UX 측면에서 개선이 필요한 부분들을 다듬었습니다.
- 언어 설정에서 외국어를 선택한 후 임시 저장된 지원서를 클릭하면 임시 저장 시간이 표시되지 않는 문제를 해결하였습니다.

# 어떻게 해결했나요?

- 지원 항목에 줄 바꿈이 포함된 경우, 클라이언트 화면에서도 줄 바꿈이 그대로 적용되도록 수정하였습니다.
- 지원서 작성 시 초기화 버튼을 눌렀을 때, 실제 초기화 여부를 한 번 더 확인하도록 수정하였습니다. (상수 메시지는 이미 존재했으나, 어느 시점에 기능이 제거된 것으로 보입니다)
- 과제 내 코드 블록의 탭 사이즈를 8에서 10으로 변경하여 Mac과 Windows 환경에서 동일하게 보이도록 조정하였습니다.
- Google Translate 사용 시, 임시 저장 시간이 번역 과정에서 사라지는 문제를 해결하기 위해 화면 렌더링 구조를 조정하였습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 로컬 환경에서 해당 기능들이 정상적으로 동작하는지 확인해 주세요.

## 참고 자료

- `https://github.com/highlightjs/highlight.js/issues/508`
- [리액트에서 구글 번역기가 번역하면서, DOM 트리를 변경해 렌더링이 되지 않는 현상](https://dongwooklee96.github.io/post/2021/03/30/리액트에서-구글-번역기가-번역하면서-dom-트리를-변경해-렌더링이-되지-않는-현상.html)

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
